### PR TITLE
add alternative permissionlist naming

### DIFF
--- a/rabbitmq.com/permissionlist_v1beta1.json
+++ b/rabbitmq.com/permissionlist_v1beta1.json
@@ -1,0 +1,128 @@
+{
+  "description": "Permission is the Schema for the permissions API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PermissionSpec defines the desired state of Permission",
+      "properties": {
+        "permissions": {
+          "description": "Permissions to grant to the user in the specific vhost; required property. See RabbitMQ doc for more information: https://www.rabbitmq.com/access-control.html#user-management",
+          "properties": {
+            "configure": {
+              "type": "string"
+            },
+            "read": {
+              "type": "string"
+            },
+            "write": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "rabbitmqClusterReference": {
+          "description": "Reference to the RabbitmqCluster that both the provided user and vhost are. Required property.",
+          "properties": {
+            "name": {
+              "description": "The name of the RabbitMQ cluster to reference.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "The namespace of the RabbitMQ cluster to reference. Defaults to the namespace of the requested resource if omitted.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "user": {
+          "description": "Name of an existing user; must provide user or userReference, else create/update will fail; cannot be updated",
+          "type": "string"
+        },
+        "userReference": {
+          "description": "Reference to an existing user.rabbitmq.com object; must provide user or userReference, else create/update will fail; cannot be updated",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "vhost": {
+          "description": "Name of an existing vhost; required property; cannot be updated",
+          "type": "string"
+        }
+      },
+      "required": [
+        "permissions",
+        "rabbitmqClusterReference",
+        "vhost"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "PermissionStatus defines the observed state of Permission",
+      "properties": {
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "description": "The last time this Condition status changed.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "Full text reason for current status of the condition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "One word, camel-case reason for current status of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "True, False, or Unknown",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type indicates the scope of the custom resource status addressed by the condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent successful generation observed for this Permission. It corresponds to the Permission's generation, which is updated on mutation by the API Server.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Apparently this CRD may (also) need to be called permissionlist rather than (just) permission