### PR TITLE
feat: add Secrets Store CSI Driver CRDs

### DIFF
--- a/secrets-store.csi.x-k8s.io/secretproviderclass_v1.json
+++ b/secrets-store.csi.x-k8s.io/secretproviderclass_v1.json
@@ -1,0 +1,110 @@
+{
+  "description": "SecretProviderClass is the Schema for the secretproviderclasses API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "SecretProviderClassSpec defines the desired state of SecretProviderClass",
+      "properties": {
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Configuration for specific provider",
+          "type": "object"
+        },
+        "provider": {
+          "description": "Configuration for provider name",
+          "type": "string"
+        },
+        "secretObjects": {
+          "items": {
+            "description": "SecretObject defines the desired state of synced K8s secret objects",
+            "properties": {
+              "annotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "annotations of k8s secret object",
+                "type": "object"
+              },
+              "data": {
+                "items": {
+                  "description": "SecretObjectData defines the desired state of synced K8s secret object data",
+                  "properties": {
+                    "key": {
+                      "description": "data field to populate",
+                      "type": "string"
+                    },
+                    "objectName": {
+                      "description": "name of the object to sync",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "labels of K8s secret object",
+                "type": "object"
+              },
+              "secretName": {
+                "description": "name of the K8s secret object",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of K8s secret object",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "SecretProviderClassStatus defines the observed state of SecretProviderClass",
+      "properties": {
+        "byPod": {
+          "items": {
+            "description": "ByPodStatus defines the state of SecretProviderClass as seen by an individual controller",
+            "properties": {
+              "id": {
+                "description": "id of the pod that wrote the status",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "namespace of the pod that wrote the status",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/secrets-store.csi.x-k8s.io/secretproviderclass_v1alpha1.json
+++ b/secrets-store.csi.x-k8s.io/secretproviderclass_v1alpha1.json
@@ -1,0 +1,110 @@
+{
+  "description": "SecretProviderClass is the Schema for the secretproviderclasses API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "SecretProviderClassSpec defines the desired state of SecretProviderClass",
+      "properties": {
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Configuration for specific provider",
+          "type": "object"
+        },
+        "provider": {
+          "description": "Configuration for provider name",
+          "type": "string"
+        },
+        "secretObjects": {
+          "items": {
+            "description": "SecretObject defines the desired state of synced K8s secret objects",
+            "properties": {
+              "annotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "annotations of k8s secret object",
+                "type": "object"
+              },
+              "data": {
+                "items": {
+                  "description": "SecretObjectData defines the desired state of synced K8s secret object data",
+                  "properties": {
+                    "key": {
+                      "description": "data field to populate",
+                      "type": "string"
+                    },
+                    "objectName": {
+                      "description": "name of the object to sync",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "labels of K8s secret object",
+                "type": "object"
+              },
+              "secretName": {
+                "description": "name of the K8s secret object",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of K8s secret object",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "SecretProviderClassStatus defines the observed state of SecretProviderClass",
+      "properties": {
+        "byPod": {
+          "items": {
+            "description": "ByPodStatus defines the state of SecretProviderClass as seen by an individual controller",
+            "properties": {
+              "id": {
+                "description": "id of the pod that wrote the status",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "namespace of the pod that wrote the status",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/secrets-store.csi.x-k8s.io/secretproviderclasspodstatus_v1.json
+++ b/secrets-store.csi.x-k8s.io/secretproviderclasspodstatus_v1.json
@@ -1,0 +1,52 @@
+{
+  "description": "SecretProviderClassPodStatus is the Schema for the secretproviderclassespodstatus API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "status": {
+      "description": "SecretProviderClassPodStatusStatus defines the observed state of SecretProviderClassPodStatus",
+      "properties": {
+        "mounted": {
+          "type": "boolean"
+        },
+        "objects": {
+          "items": {
+            "description": "SecretProviderClassObject defines the object fetched from external secrets store",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "podName": {
+          "type": "string"
+        },
+        "secretProviderClassName": {
+          "type": "string"
+        },
+        "targetPath": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/secrets-store.csi.x-k8s.io/secretproviderclasspodstatus_v1alpha1.json
+++ b/secrets-store.csi.x-k8s.io/secretproviderclasspodstatus_v1alpha1.json
@@ -1,0 +1,52 @@
+{
+  "description": "SecretProviderClassPodStatus is the Schema for the secretproviderclassespodstatus API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "status": {
+      "description": "SecretProviderClassPodStatusStatus defines the observed state of SecretProviderClassPodStatus",
+      "properties": {
+        "mounted": {
+          "type": "boolean"
+        },
+        "objects": {
+          "items": {
+            "description": "SecretProviderClassObject defines the object fetched from external secrets store",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "podName": {
+          "type": "string"
+        },
+        "secretProviderClassName": {
+          "type": "string"
+        },
+        "targetPath": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Add [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/) CRDs schemes.
Reference in kubernetes-sigs repo: https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/config/crd/bases

Sorry but it is my first PR there and I'm not secure if needed update index.yaml file with k8s-sigs repo info.