### PR TITLE
feat: add datadogmetrics.datadoghq.com CRD

### DIFF
--- a/datadoghq.com/datadogmetric_v1alpha1.json
+++ b/datadoghq.com/datadogmetric_v1alpha1.json
@@ -1,0 +1,99 @@
+{
+  "description": "DatadogMetric allows autoscaling on arbitrary Datadog query",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DatadogMetricSpec defines the desired state of DatadogMetric",
+      "properties": {
+        "externalMetricName": {
+          "description": "ExternalMetricName is reserved for internal use",
+          "type": "string"
+        },
+        "maxAge": {
+          "description": "MaxAge provides the max age for the metric query (overrides the default setting `external_metrics_provider.max_age`)",
+          "type": "string"
+        },
+        "query": {
+          "description": "Query is the raw datadog query",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DatadogMetricStatus defines the observed state of DatadogMetric",
+      "properties": {
+        "autoscalerReferences": {
+          "description": "List of autoscalers currently using this DatadogMetric",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions Represents the latest available observations of a DatadogMetric's current state.",
+          "items": {
+            "description": "DatadogMetricCondition describes the state of a DatadogMetric at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "Last time the condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of DatadogMetric condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "currentValue": {
+          "description": "Value is the latest value of the metric",
+          "type": "string"
+        }
+      },
+      "required": [
+        "currentValue"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Add [DatadogMetrics CRD scheme](https://github.com/DataDog/helm-charts/blob/main/crds/datadoghq.com_datadogmetrics.yaml) of Datadog Monitoring.

I think this is the most used CRD to customize Datadog behaviors for example in HPAs. The other Datadog CRDs are defined by the official Datadog helm chart, and I don't think they are defined in application deployments.