### PR TITLE
feat: add GCP backendconfig CRDs

### DIFF
--- a/cloud.google.com/backendconfig_v1.json
+++ b/cloud.google.com/backendconfig_v1.json
@@ -1,0 +1,313 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BackendConfigSpec is the spec for a BackendConfig resource",
+      "properties": {
+        "cdn": {
+          "description": "CDNConfig contains configuration for CDN-enabled backends.",
+          "properties": {
+            "bypassCacheOnRequestHeaders": {
+              "items": {
+                "description": "BypassCacheOnRequestHeader contains configuration for how requests containing specific request headers bypass the cache, even if the content was previously cached.",
+                "properties": {
+                  "headerName": {
+                    "description": "The header field name to match on when bypassing cache. Values are case-insensitive.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "cacheMode": {
+              "type": "string"
+            },
+            "cachePolicy": {
+              "description": "CacheKeyPolicy contains configuration for how requests to a CDN-enabled backend are cached.",
+              "properties": {
+                "includeHost": {
+                  "description": "If true, requests to different hosts will be cached separately.",
+                  "type": "boolean"
+                },
+                "includeProtocol": {
+                  "description": "If true, http and https requests will be cached separately.",
+                  "type": "boolean"
+                },
+                "includeQueryString": {
+                  "description": "If true, query string parameters are included in the cache key according to QueryStringBlacklist and QueryStringWhitelist. If neither is set, the entire query string is included and if false the entire query string is excluded.",
+                  "type": "boolean"
+                },
+                "queryStringBlacklist": {
+                  "description": "Names of query strint parameters to exclude from cache keys. All other parameters are included. Either specify QueryStringBlacklist or QueryStringWhitelist, but not both.",
+                  "items": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "queryStringWhitelist": {
+                  "description": "Names of query string parameters to include in cache keys. All other parameters are excluded. Either specify QueryStringBlacklist or QueryStringWhitelist, but not both.",
+                  "items": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "clientTtl": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "defaultTtl": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "maxTtl": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "negativeCaching": {
+              "type": "boolean"
+            },
+            "negativeCachingPolicy": {
+              "items": {
+                "description": "NegativeCachingPolicy contains configuration for how negative caching is applied.",
+                "properties": {
+                  "code": {
+                    "description": "The HTTP status code to define a TTL against. Only HTTP status codes 300, 301, 308, 404, 405, 410, 421, 451 and 501 are can be specified as values, and you cannot specify a status code more than once.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "ttl": {
+                    "description": "The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "requestCoalescing": {
+              "type": "boolean"
+            },
+            "serveWhileStale": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "signedUrlCacheMaxAgeSec": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "signedUrlKeys": {
+              "items": {
+                "description": "SignedUrlKey represents a customer-supplied Signing Key used by Cloud CDN Signed URLs",
+                "properties": {
+                  "keyName": {
+                    "description": "KeyName: Name of the key. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
+                    "type": "string"
+                  },
+                  "keyValue": {
+                    "description": "KeyValue: 128-bit key value used for signing the URL. The key value must be a valid RFC 4648 Section 5 base64url encoded string.",
+                    "type": "string"
+                  },
+                  "secretName": {
+                    "description": "The name of a k8s secret which stores the 128-bit key value used for signing the URL. The key value must be a valid RFC 4648 Section 5 base64url encoded string",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "connectionDraining": {
+          "description": "ConnectionDrainingConfig contains configuration for connection draining. For now the draining timeout. May manage more settings in the future.",
+          "properties": {
+            "drainingTimeoutSec": {
+              "description": "Draining timeout in seconds.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customRequestHeaders": {
+          "description": "CustomRequestHeadersConfig contains configuration for custom request headers",
+          "properties": {
+            "headers": {
+              "items": {
+                "default": "",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "healthCheck": {
+          "description": "HealthCheckConfig contains configuration for the health check.",
+          "properties": {
+            "checkIntervalSec": {
+              "description": "CheckIntervalSec is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "healthyThreshold": {
+              "description": "HealthyThreshold is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "port": {
+              "description": "Port is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks. If Port is used, the controller updates portSpecification as well",
+              "format": "int64",
+              "type": "integer"
+            },
+            "requestPath": {
+              "description": "RequestPath is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "type": "string"
+            },
+            "timeoutSec": {
+              "description": "TimeoutSec is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": {
+              "description": "Type is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "type": "string"
+            },
+            "unhealthyThreshold": {
+              "description": "UnhealthyThreshold is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "iap": {
+          "description": "IAPConfig contains configuration for IAP-enabled backends.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "oauthclientCredentials": {
+              "description": "OAuthClientCredentials contains credentials for a single IAP-enabled backend.",
+              "properties": {
+                "clientID": {
+                  "description": "Direct reference to OAuth client id.",
+                  "type": "string"
+                },
+                "clientSecret": {
+                  "description": "Direct reference to OAuth client secret.",
+                  "type": "string"
+                },
+                "secretName": {
+                  "default": "",
+                  "description": "The name of a k8s secret which stores the OAuth client id & secret.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "enabled",
+            "oauthclientCredentials"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logging": {
+          "description": "LogConfig contains configuration for logging.",
+          "properties": {
+            "enable": {
+              "description": "This field denotes whether to enable logging for the load balancer traffic served by this backend service.",
+              "type": "boolean"
+            },
+            "sampleRate": {
+              "description": "This field can only be specified if logging is enabled for this backend service. The value of the field must be in [0, 1]. This configures the sampling rate of requests to the load balancer where 1.0 means all logged requests are reported and 0.0 means no logged requests are reported. The default value is 1.0.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "securityPolicy": {
+          "description": "SecurityPolicyConfig contains configuration for CloudArmor-enabled backends. If not specified, the controller will not reconcile the security policy configuration. In other words, users can make changes in GCE without the controller overwriting them.",
+          "properties": {
+            "name": {
+              "default": "",
+              "description": "Name of the security policy that should be associated. If set to empty, the existing security policy on the backend will be removed.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sessionAffinity": {
+          "description": "SessionAffinityConfig contains configuration for stickyness parameters.",
+          "properties": {
+            "affinityCookieTtlSec": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "affinityType": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "timeoutSec": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/cloud.google.com/backendconfig_v1beta1.json
+++ b/cloud.google.com/backendconfig_v1beta1.json
@@ -1,0 +1,211 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BackendConfigSpec is the spec for a BackendConfig resource",
+      "properties": {
+        "cdn": {
+          "description": "CDNConfig contains configuration for CDN-enabled backends.",
+          "properties": {
+            "cachePolicy": {
+              "description": "CacheKeyPolicy contains configuration for how requests to a CDN-enabled backend are cached.",
+              "properties": {
+                "includeHost": {
+                  "description": "If true, requests to different hosts will be cached separately.",
+                  "type": "boolean"
+                },
+                "includeProtocol": {
+                  "description": "If true, http and https requests will be cached separately.",
+                  "type": "boolean"
+                },
+                "includeQueryString": {
+                  "description": "If true, query string parameters are included in the cache key according to QueryStringBlacklist and QueryStringWhitelist. If neither is set, the entire query string is included and if false the entire query string is excluded.",
+                  "type": "boolean"
+                },
+                "queryStringBlacklist": {
+                  "description": "Names of query strint parameters to exclude from cache keys. All other parameters are included. Either specify QueryStringBlacklist or QueryStringWhitelist, but not both.",
+                  "items": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "queryStringWhitelist": {
+                  "description": "Names of query string parameters to include in cache keys. All other parameters are excluded. Either specify QueryStringBlacklist or QueryStringWhitelist, but not both.",
+                  "items": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "connectionDraining": {
+          "description": "ConnectionDrainingConfig contains configuration for connection draining. For now the draining timeout. May manage more settings in the future.",
+          "properties": {
+            "drainingTimeoutSec": {
+              "description": "Draining timeout in seconds.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customRequestHeaders": {
+          "description": "CustomRequestHeadersConfig contains configuration for custom request headers",
+          "properties": {
+            "headers": {
+              "items": {
+                "default": "",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "healthCheck": {
+          "description": "HealthCheckConfig contains configuration for the health check.",
+          "properties": {
+            "checkIntervalSec": {
+              "description": "CheckIntervalSec is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "healthyThreshold": {
+              "description": "HealthyThreshold is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "port": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "requestPath": {
+              "description": "RequestPath is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "type": "string"
+            },
+            "timeoutSec": {
+              "description": "TimeoutSec is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": {
+              "description": "Type is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "type": "string"
+            },
+            "unhealthyThreshold": {
+              "description": "UnhealthyThreshold is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "iap": {
+          "description": "IAPConfig contains configuration for IAP-enabled backends.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "oauthclientCredentials": {
+              "description": "OAuthClientCredentials contains credentials for a single IAP-enabled backend.",
+              "properties": {
+                "clientID": {
+                  "description": "Direct reference to OAuth client id.",
+                  "type": "string"
+                },
+                "clientSecret": {
+                  "description": "Direct reference to OAuth client secret.",
+                  "type": "string"
+                },
+                "secretName": {
+                  "default": "",
+                  "description": "The name of a k8s secret which stores the OAuth client id & secret.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "enabled",
+            "oauthclientCredentials"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "securityPolicy": {
+          "description": "SecurityPolicyConfig contains configuration for CloudArmor-enabled backends. If not specified, the controller will not reconcile the security policy configuration. In other words, users can make changes in GCE without the controller overwriting them.",
+          "properties": {
+            "name": {
+              "default": "",
+              "description": "Name of the security policy that should be associated. If set to empty, the existing security policy on the backend will be removed.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sessionAffinity": {
+          "description": "SessionAffinityConfig contains configuration for stickyness parameters.",
+          "properties": {
+            "affinityCookieTtlSec": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "affinityType": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "timeoutSec": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
These are under `cloud.google.com` instead of `networking.gke.io`