### PR TITLE
update argocd applicationset schema

### DIFF
--- a/argoproj.io/applicationset_v1alpha1.json
+++ b/argoproj.io/applicationset_v1alpha1.json
@@ -384,10 +384,40 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
                               },
                               "repoURL": {
                                 "type": "string"
@@ -402,6 +432,261 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "syncPolicy": {
                             "properties": {
                               "automated": {
@@ -414,6 +699,24 @@
                                   },
                                   "selfHeal": {
                                     "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -458,8 +761,7 @@
                         },
                         "required": [
                           "destination",
-                          "project",
-                          "source"
+                          "project"
                         ],
                         "type": "object",
                         "additionalProperties": false
@@ -845,10 +1147,40 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
                               },
                               "repoURL": {
                                 "type": "string"
@@ -863,6 +1195,261 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "syncPolicy": {
                             "properties": {
                               "automated": {
@@ -875,6 +1462,24 @@
                                   },
                                   "selfHeal": {
                                     "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -919,8 +1524,7 @@
                         },
                         "required": [
                           "destination",
-                          "project",
-                          "source"
+                          "project"
                         ],
                         "type": "object",
                         "additionalProperties": false
@@ -977,6 +1581,9 @@
                       "additionalProperties": false
                     },
                     "type": "array"
+                  },
+                  "pathParamPrefix": {
+                    "type": "string"
                   },
                   "repoURL": {
                     "type": "string"
@@ -1309,10 +1916,40 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
                               },
                               "repoURL": {
                                 "type": "string"
@@ -1327,6 +1964,261 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "syncPolicy": {
                             "properties": {
                               "automated": {
@@ -1339,6 +2231,24 @@
                                   },
                                   "selfHeal": {
                                     "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1383,8 +2293,7 @@
                         },
                         "required": [
                           "destination",
-                          "project",
-                          "source"
+                          "project"
                         ],
                         "type": "object",
                         "additionalProperties": false
@@ -1399,6 +2308,7 @@
                   }
                 },
                 "required": [
+                  "pathParamPrefix",
                   "repoURL",
                   "revision"
                 ],
@@ -1734,10 +2644,40 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
                               },
                               "repoURL": {
                                 "type": "string"
@@ -1752,6 +2692,261 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "syncPolicy": {
                             "properties": {
                               "automated": {
@@ -1764,6 +2959,24 @@
                                   },
                                   "selfHeal": {
                                     "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1808,8 +3021,7 @@
                         },
                         "required": [
                           "destination",
-                          "project",
-                          "source"
+                          "project"
                         ],
                         "type": "object",
                         "additionalProperties": false
@@ -2204,10 +3416,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -2222,6 +3464,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -2234,6 +3731,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -2278,8 +3793,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -2665,10 +4179,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -2683,6 +4227,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -2695,6 +4494,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -2739,8 +4556,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -2797,6 +4613,9 @@
                                 "additionalProperties": false
                               },
                               "type": "array"
+                            },
+                            "pathParamPrefix": {
+                              "type": "string"
                             },
                             "repoURL": {
                               "type": "string"
@@ -3129,10 +4948,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -3147,6 +4996,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -3159,6 +5263,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -3203,8 +5325,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -3219,6 +5340,7 @@
                             }
                           },
                           "required": [
+                            "pathParamPrefix",
                             "repoURL",
                             "revision"
                           ],
@@ -3554,10 +5676,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -3572,6 +5724,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -3584,6 +5991,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -3628,8 +6053,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -3762,6 +6186,9 @@
                                 "api": {
                                   "type": "string"
                                 },
+                                "appSecretName": {
+                                  "type": "string"
+                                },
                                 "labels": {
                                   "items": {
                                     "type": "string"
@@ -3794,6 +6221,46 @@
                               "required": [
                                 "owner",
                                 "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "gitlab": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "project": {
+                                  "type": "string"
+                                },
+                                "pullRequestState": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "project"
                               ],
                               "type": "object",
                               "additionalProperties": false
@@ -4123,10 +6590,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -4141,6 +6638,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -4153,6 +6905,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -4197,8 +6967,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -4217,6 +6986,45 @@
                         },
                         "scmProvider": {
                           "properties": {
+                            "azureDevOps": {
+                              "properties": {
+                                "accessTokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "organization": {
+                                  "type": "string"
+                                },
+                                "teamProject": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "accessTokenRef",
+                                "organization",
+                                "teamProject"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "bitbucket": {
                               "properties": {
                                 "allBranches": {
@@ -4313,6 +7121,12 @@
                                   "labelMatch": {
                                     "type": "string"
                                   },
+                                  "pathsDoNotExist": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "pathsExist": {
                                     "items": {
                                       "type": "string"
@@ -4372,6 +7186,9 @@
                                   "type": "boolean"
                                 },
                                 "api": {
+                                  "type": "string"
+                                },
+                                "appSecretName": {
                                   "type": "string"
                                 },
                                 "organization": {
@@ -4762,10 +7579,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -4780,6 +7627,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -4792,6 +7894,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -4836,8 +7956,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -4849,6 +7968,43 @@
                               ],
                               "type": "object",
                               "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "selector": {
+                          "properties": {
+                            "matchExpressions": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
                             }
                           },
                           "type": "object",
@@ -5181,10 +8337,40 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
                               },
                               "repoURL": {
                                 "type": "string"
@@ -5199,6 +8385,261 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "syncPolicy": {
                             "properties": {
                               "automated": {
@@ -5211,6 +8652,24 @@
                                   },
                                   "selfHeal": {
                                     "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -5255,8 +8714,7 @@
                         },
                         "required": [
                           "destination",
-                          "project",
-                          "source"
+                          "project"
                         ],
                         "type": "object",
                         "additionalProperties": false
@@ -5651,10 +9109,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -5669,6 +9157,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -5681,6 +9424,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -5725,8 +9486,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -6112,10 +9872,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -6130,6 +9920,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -6142,6 +10187,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -6186,8 +10249,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -6244,6 +10306,9 @@
                                 "additionalProperties": false
                               },
                               "type": "array"
+                            },
+                            "pathParamPrefix": {
+                              "type": "string"
                             },
                             "repoURL": {
                               "type": "string"
@@ -6576,10 +10641,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -6594,6 +10689,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -6606,6 +10956,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -6650,8 +11018,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -6666,6 +11033,7 @@
                             }
                           },
                           "required": [
+                            "pathParamPrefix",
                             "repoURL",
                             "revision"
                           ],
@@ -7001,10 +11369,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -7019,6 +11417,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -7031,6 +11684,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -7075,8 +11746,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -7209,6 +11879,9 @@
                                 "api": {
                                   "type": "string"
                                 },
+                                "appSecretName": {
+                                  "type": "string"
+                                },
                                 "labels": {
                                   "items": {
                                     "type": "string"
@@ -7241,6 +11914,46 @@
                               "required": [
                                 "owner",
                                 "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "gitlab": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "project": {
+                                  "type": "string"
+                                },
+                                "pullRequestState": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "project"
                               ],
                               "type": "object",
                               "additionalProperties": false
@@ -7570,10 +12283,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -7588,6 +12331,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -7600,6 +12598,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -7644,8 +12660,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -7664,6 +12679,45 @@
                         },
                         "scmProvider": {
                           "properties": {
+                            "azureDevOps": {
+                              "properties": {
+                                "accessTokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "api": {
+                                  "type": "string"
+                                },
+                                "organization": {
+                                  "type": "string"
+                                },
+                                "teamProject": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "accessTokenRef",
+                                "organization",
+                                "teamProject"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "bitbucket": {
                               "properties": {
                                 "allBranches": {
@@ -7760,6 +12814,12 @@
                                   "labelMatch": {
                                     "type": "string"
                                   },
+                                  "pathsDoNotExist": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "pathsExist": {
                                     "items": {
                                       "type": "string"
@@ -7819,6 +12879,9 @@
                                   "type": "boolean"
                                 },
                                 "api": {
+                                  "type": "string"
+                                },
+                                "appSecretName": {
                                   "type": "string"
                                 },
                                 "organization": {
@@ -8209,10 +13272,40 @@
                                             },
                                             "name": {
                                               "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             }
                                           },
                                           "type": "object",
                                           "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
                                         },
                                         "repoURL": {
                                           "type": "string"
@@ -8227,6 +13320,261 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "syncPolicy": {
                                       "properties": {
                                         "automated": {
@@ -8239,6 +13587,24 @@
                                             },
                                             "selfHeal": {
                                               "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
                                             }
                                           },
                                           "type": "object",
@@ -8283,8 +13649,7 @@
                                   },
                                   "required": [
                                     "destination",
-                                    "project",
-                                    "source"
+                                    "project"
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
@@ -8296,6 +13661,43 @@
                               ],
                               "type": "object",
                               "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "selector": {
+                          "properties": {
+                            "matchExpressions": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
                             }
                           },
                           "type": "object",
@@ -8634,10 +14036,40 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
                               },
                               "repoURL": {
                                 "type": "string"
@@ -8652,6 +14084,261 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "syncPolicy": {
                             "properties": {
                               "automated": {
@@ -8664,6 +14351,24 @@
                                   },
                                   "selfHeal": {
                                     "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -8708,8 +14413,7 @@
                         },
                         "required": [
                           "destination",
-                          "project",
-                          "source"
+                          "project"
                         ],
                         "type": "object",
                         "additionalProperties": false
@@ -8837,6 +14541,9 @@
                       "api": {
                         "type": "string"
                       },
+                      "appSecretName": {
+                        "type": "string"
+                      },
                       "labels": {
                         "items": {
                           "type": "string"
@@ -8869,6 +14576,46 @@
                     "required": [
                       "owner",
                       "repo"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitlab": {
+                    "properties": {
+                      "api": {
+                        "type": "string"
+                      },
+                      "labels": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "project": {
+                        "type": "string"
+                      },
+                      "pullRequestState": {
+                        "type": "string"
+                      },
+                      "tokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "project"
                     ],
                     "type": "object",
                     "additionalProperties": false
@@ -9198,10 +14945,40 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
                               },
                               "repoURL": {
                                 "type": "string"
@@ -9216,6 +14993,261 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "syncPolicy": {
                             "properties": {
                               "automated": {
@@ -9228,6 +15260,24 @@
                                   },
                                   "selfHeal": {
                                     "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -9272,8 +15322,7 @@
                         },
                         "required": [
                           "destination",
-                          "project",
-                          "source"
+                          "project"
                         ],
                         "type": "object",
                         "additionalProperties": false
@@ -9292,6 +15341,45 @@
               },
               "scmProvider": {
                 "properties": {
+                  "azureDevOps": {
+                    "properties": {
+                      "accessTokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "allBranches": {
+                        "type": "boolean"
+                      },
+                      "api": {
+                        "type": "string"
+                      },
+                      "organization": {
+                        "type": "string"
+                      },
+                      "teamProject": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "accessTokenRef",
+                      "organization",
+                      "teamProject"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "bitbucket": {
                     "properties": {
                       "allBranches": {
@@ -9388,6 +15476,12 @@
                         "labelMatch": {
                           "type": "string"
                         },
+                        "pathsDoNotExist": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "pathsExist": {
                           "items": {
                             "type": "string"
@@ -9447,6 +15541,9 @@
                         "type": "boolean"
                       },
                       "api": {
+                        "type": "string"
+                      },
+                      "appSecretName": {
                         "type": "string"
                       },
                       "organization": {
@@ -9837,10 +15934,40 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
                               },
                               "repoURL": {
                                 "type": "string"
@@ -9855,6 +15982,261 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "syncPolicy": {
                             "properties": {
                               "automated": {
@@ -9867,6 +16249,24 @@
                                   },
                                   "selfHeal": {
                                     "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -9911,8 +16311,7 @@
                         },
                         "required": [
                           "destination",
-                          "project",
-                          "source"
+                          "project"
                         ],
                         "type": "object",
                         "additionalProperties": false
@@ -9928,12 +16327,108 @@
                 },
                 "type": "object",
                 "additionalProperties": false
+              },
+              "selector": {
+                "properties": {
+                  "matchExpressions": {
+                    "items": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "operator": {
+                          "type": "string"
+                        },
+                        "values": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
               }
             },
             "type": "object",
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "goTemplate": {
+          "type": "boolean"
+        },
+        "strategy": {
+          "properties": {
+            "rollingSync": {
+              "properties": {
+                "steps": {
+                  "items": {
+                    "properties": {
+                      "matchExpressions": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "maxUpdate": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "syncPolicy": {
           "properties": {
@@ -10265,10 +16760,40 @@
                         },
                         "name": {
                           "type": "string"
+                        },
+                        "parameters": {
+                          "items": {
+                            "properties": {
+                              "array": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "map": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "string": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "ref": {
+                      "type": "string"
                     },
                     "repoURL": {
                       "type": "string"
@@ -10283,6 +16808,261 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "sources": {
+                  "items": {
+                    "properties": {
+                      "chart": {
+                        "type": "string"
+                      },
+                      "directory": {
+                        "properties": {
+                          "exclude": {
+                            "type": "string"
+                          },
+                          "include": {
+                            "type": "string"
+                          },
+                          "jsonnet": {
+                            "properties": {
+                              "extVars": {
+                                "items": {
+                                  "properties": {
+                                    "code": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "libs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tlas": {
+                                "items": {
+                                  "properties": {
+                                    "code": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurse": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "helm": {
+                        "properties": {
+                          "fileParameters": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "ignoreMissingValueFiles": {
+                            "type": "boolean"
+                          },
+                          "parameters": {
+                            "items": {
+                              "properties": {
+                                "forceString": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "passCredentials": {
+                            "type": "boolean"
+                          },
+                          "releaseName": {
+                            "type": "string"
+                          },
+                          "skipCrds": {
+                            "type": "boolean"
+                          },
+                          "valueFiles": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "values": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "kustomize": {
+                        "properties": {
+                          "commonAnnotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "commonLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "forceCommonAnnotations": {
+                            "type": "boolean"
+                          },
+                          "forceCommonLabels": {
+                            "type": "boolean"
+                          },
+                          "images": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namePrefix": {
+                            "type": "string"
+                          },
+                          "nameSuffix": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "plugin": {
+                        "properties": {
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "parameters": {
+                            "items": {
+                              "properties": {
+                                "array": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "map": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "string": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ref": {
+                        "type": "string"
+                      },
+                      "repoURL": {
+                        "type": "string"
+                      },
+                      "targetRevision": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repoURL"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
                 "syncPolicy": {
                   "properties": {
                     "automated": {
@@ -10295,6 +17075,24 @@
                         },
                         "selfHeal": {
                           "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "managedNamespaceMetadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -10339,8 +17137,7 @@
               },
               "required": [
                 "destination",
-                "project",
-                "source"
+                "project"
               ],
               "type": "object",
               "additionalProperties": false
@@ -10363,6 +17160,33 @@
     },
     "status": {
       "properties": {
+        "applicationStatus": {
+          "items": {
+            "properties": {
+              "application": {
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "application",
+              "message",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
         "conditions": {
           "items": {
             "properties": {


### PR DESCRIPTION
Problem:
The current schema doesn't have some new attributes for example, `pathParamPrefix` for the git generator (mentioned [here](https://argo-cd.readthedocs.io/en/latest/operator-manual/applicationset/Generators-Git/)) which results in this error
```
stdin - ApplicationSet apps is invalid: For field spec.generators.0.git: Additional property pathParamPrefix is not allowed
```

Here are the steps I took to generate this file
1. Grab the CRD from my cluster with `kubectl get crds applicationsets.argoproj.io -o yaml > applicationset.yaml` (I'm using argocd 2.6-RC2 at the moment)
2. Download `openapi2jsonschema.py` to my local
3. Run `openapi2jsonschema.py applicationset.yaml` and then copy the json file to replace the old one

We have tested the new change by pointing the schema location to our fork, and it's working

Not sure about the ordering though....