### PR TITLE
Add K3s cattle.io CRDs

### DIFF
--- a/helm.cattle.io/helmchart_v1.json
+++ b/helm.cattle.io/helmchart_v1.json
@@ -1,0 +1,11 @@
+{
+  "properties": {
+    "spec": {
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "status": {
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  },
+  "type": "object"
+}

--- a/helm.cattle.io/helmchartconfig_v1.json
+++ b/helm.cattle.io/helmchartconfig_v1.json
@@ -1,0 +1,11 @@
+{
+  "properties": {
+    "spec": {
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "status": {
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  },
+  "type": "object"
+}

--- a/k3s.cattle.io/addon_v1.json
+++ b/k3s.cattle.io/addon_v1.json
@@ -1,0 +1,11 @@
+{
+  "properties": {
+    "spec": {
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "status": {
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Add cattle.io CRD schemas that ship with Rancher K3s.

These schemas were created using `crd-extractor.sh` on a fresh K3s cluster (v1.26.1+k3s1) with servicelb and traefik disabled.

```
$ Utilities/crd-extractor.sh 
JSON schema written to addon_v1.json
JSON schema written to helmchartconfig_v1.json
JSON schema written to helmchart_v1.json
Successfully converted 3 CRDs to JSON schema
...
```