### PR TITLE
feat: update External Secrets Operator CRDs to v0.7.2

### DIFF
--- a/external-secrets.io/clusterexternalsecret_v1beta1.json
+++ b/external-secrets.io/clusterexternalsecret_v1beta1.json
@@ -28,7 +28,7 @@
                 "description": "ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.",
                 "properties": {
                   "remoteRef": {
-                    "description": "ExternalSecretDataRemoteRef defines Provider data location.",
+                    "description": "RemoteRef points to the remote secret and defines which secret (version/property/..) to fetch.",
                     "properties": {
                       "conversionStrategy": {
                         "default": "Default",
@@ -64,7 +64,58 @@
                     "additionalProperties": false
                   },
                   "secretKey": {
+                    "description": "SecretKey defines the key in which the controller stores the value. This is the key in the Kind=Secret",
                     "type": "string"
+                  },
+                  "sourceRef": {
+                    "description": "SourceRef allows you to override the source from which the value will pulled from.",
+                    "maxProperties": 1,
+                    "properties": {
+                      "generatorRef": {
+                        "description": "GeneratorRef points to a generator custom resource in",
+                        "properties": {
+                          "apiVersion": {
+                            "default": "generators.external-secrets.io/v1alpha1",
+                            "description": "Specify the apiVersion of the generator resource",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Specify the name of the generator resource",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storeRef": {
+                        "description": "SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the SecretStore resource",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
                 "required": [
@@ -81,7 +132,7 @@
               "items": {
                 "properties": {
                   "extract": {
-                    "description": "Used to extract multiple key/value pairs from one secret",
+                    "description": "Used to extract multiple key/value pairs from one secret Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.",
                     "properties": {
                       "conversionStrategy": {
                         "default": "Default",
@@ -117,7 +168,7 @@
                     "additionalProperties": false
                   },
                   "find": {
-                    "description": "Used to find secrets based on tags or regular expressions",
+                    "description": "Used to find secrets based on tags or regular expressions Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.",
                     "properties": {
                       "conversionStrategy": {
                         "default": "Default",
@@ -183,6 +234,56 @@
                       "additionalProperties": false
                     },
                     "type": "array"
+                  },
+                  "sourceRef": {
+                    "description": "SourceRef points to a store or generator which contains secret values ready to use. Use this in combination with Extract or Find pull values out of a specific SecretStore. When sourceRef points to a generator Extract or Find is not supported. The generator returns a static map of values",
+                    "maxProperties": 1,
+                    "properties": {
+                      "generatorRef": {
+                        "description": "GeneratorRef points to a generator custom resource in",
+                        "properties": {
+                          "apiVersion": {
+                            "default": "generators.external-secrets.io/v1alpha1",
+                            "description": "Specify the apiVersion of the generator resource",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Specify the name of the generator resource",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storeRef": {
+                        "description": "SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.",
+                        "properties": {
+                          "kind": {
+                            "description": "Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the SecretStore resource",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
                 "type": "object",
@@ -283,8 +384,6 @@
                     },
                     "templateFrom": {
                       "items": {
-                        "maxProperties": 1,
-                        "minProperties": 1,
                         "properties": {
                           "configMap": {
                             "properties": {
@@ -292,6 +391,10 @@
                                 "items": {
                                   "properties": {
                                     "key": {
+                                      "type": "string"
+                                    },
+                                    "templateAs": {
+                                      "default": "Values",
                                       "type": "string"
                                     }
                                   },
@@ -314,12 +417,19 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "literal": {
+                            "type": "string"
+                          },
                           "secret": {
                             "properties": {
                               "items": {
                                 "items": {
                                   "properties": {
                                     "key": {
+                                      "type": "string"
+                                    },
+                                    "templateAs": {
+                                      "default": "Values",
                                       "type": "string"
                                     }
                                   },
@@ -341,6 +451,10 @@
                             ],
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "target": {
+                            "default": "Data",
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -360,9 +474,6 @@
               "additionalProperties": false
             }
           },
-          "required": [
-            "secretStoreRef"
-          ],
           "type": "object",
           "additionalProperties": false
         },

--- a/external-secrets.io/clustersecretstore_v1beta1.json
+++ b/external-secrets.io/clustersecretstore_v1beta1.json
@@ -316,6 +316,13 @@
             "aws": {
               "description": "AWS configures this store to sync secrets using AWS Secret Manager provider",
               "properties": {
+                "additionalRoles": {
+                  "description": "AdditionalRoles is a chained list of Role ARNs which the SecretManager provider will sequentially assume before assuming Role",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "auth": {
                   "description": "Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
                   "properties": {
@@ -375,6 +382,25 @@
                         },
                         "secretAccessKeySecretRef": {
                           "description": "The SecretAccessKey is used for authentication",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sessionTokenSecretRef": {
+                          "description": "The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html",
                           "properties": {
                             "key": {
                               "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -781,6 +807,17 @@
                 "environment": {
                   "description": "Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)",
                   "type": "string"
+                },
+                "groupIDs": {
+                  "description": "GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "inheritFromGroups": {
+                  "description": "InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.",
+                  "type": "boolean"
                 },
                 "projectID": {
                   "description": "ProjectID specifies a project where secrets are located.",
@@ -1899,6 +1936,10 @@
     "status": {
       "description": "SecretStoreStatus defines the observed state of the SecretStore.",
       "properties": {
+        "capabilities": {
+          "description": "SecretStoreCapabilities defines the possible operations a SecretStore can do.",
+          "type": "string"
+        },
         "conditions": {
           "items": {
             "properties": {

--- a/external-secrets.io/externalsecret_v1beta1.json
+++ b/external-secrets.io/externalsecret_v1beta1.json
@@ -21,7 +21,7 @@
             "description": "ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.",
             "properties": {
               "remoteRef": {
-                "description": "ExternalSecretDataRemoteRef defines Provider data location.",
+                "description": "RemoteRef points to the remote secret and defines which secret (version/property/..) to fetch.",
                 "properties": {
                   "conversionStrategy": {
                     "default": "Default",
@@ -57,7 +57,58 @@
                 "additionalProperties": false
               },
               "secretKey": {
+                "description": "SecretKey defines the key in which the controller stores the value. This is the key in the Kind=Secret",
                 "type": "string"
+              },
+              "sourceRef": {
+                "description": "SourceRef allows you to override the source from which the value will pulled from.",
+                "maxProperties": 1,
+                "properties": {
+                  "generatorRef": {
+                    "description": "GeneratorRef points to a generator custom resource in",
+                    "properties": {
+                      "apiVersion": {
+                        "default": "generators.external-secrets.io/v1alpha1",
+                        "description": "Specify the apiVersion of the generator resource",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Specify the name of the generator resource",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storeRef": {
+                    "description": "SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the SecretStore resource",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
               }
             },
             "required": [
@@ -74,7 +125,7 @@
           "items": {
             "properties": {
               "extract": {
-                "description": "Used to extract multiple key/value pairs from one secret",
+                "description": "Used to extract multiple key/value pairs from one secret Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.",
                 "properties": {
                   "conversionStrategy": {
                     "default": "Default",
@@ -110,7 +161,7 @@
                 "additionalProperties": false
               },
               "find": {
-                "description": "Used to find secrets based on tags or regular expressions",
+                "description": "Used to find secrets based on tags or regular expressions Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.",
                 "properties": {
                   "conversionStrategy": {
                     "default": "Default",
@@ -176,6 +227,56 @@
                   "additionalProperties": false
                 },
                 "type": "array"
+              },
+              "sourceRef": {
+                "description": "SourceRef points to a store or generator which contains secret values ready to use. Use this in combination with Extract or Find pull values out of a specific SecretStore. When sourceRef points to a generator Extract or Find is not supported. The generator returns a static map of values",
+                "maxProperties": 1,
+                "properties": {
+                  "generatorRef": {
+                    "description": "GeneratorRef points to a generator custom resource in",
+                    "properties": {
+                      "apiVersion": {
+                        "default": "generators.external-secrets.io/v1alpha1",
+                        "description": "Specify the apiVersion of the generator resource",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Specify the Kind of the resource, e.g. Password, ACRAccessToken etc.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Specify the name of the generator resource",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storeRef": {
+                    "description": "SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.",
+                    "properties": {
+                      "kind": {
+                        "description": "Kind of the SecretStore resource (SecretStore or ClusterSecretStore) Defaults to `SecretStore`",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the SecretStore resource",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
               }
             },
             "type": "object",
@@ -276,8 +377,6 @@
                 },
                 "templateFrom": {
                   "items": {
-                    "maxProperties": 1,
-                    "minProperties": 1,
                     "properties": {
                       "configMap": {
                         "properties": {
@@ -285,6 +384,10 @@
                             "items": {
                               "properties": {
                                 "key": {
+                                  "type": "string"
+                                },
+                                "templateAs": {
+                                  "default": "Values",
                                   "type": "string"
                                 }
                               },
@@ -307,12 +410,19 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "literal": {
+                        "type": "string"
+                      },
                       "secret": {
                         "properties": {
                           "items": {
                             "items": {
                               "properties": {
                                 "key": {
+                                  "type": "string"
+                                },
+                                "templateAs": {
+                                  "default": "Values",
                                   "type": "string"
                                 }
                               },
@@ -334,6 +444,10 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "target": {
+                        "default": "Data",
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -353,9 +467,6 @@
           "additionalProperties": false
         }
       },
-      "required": [
-        "secretStoreRef"
-      ],
       "type": "object",
       "additionalProperties": false
     },

--- a/external-secrets.io/secretstore_v1beta1.json
+++ b/external-secrets.io/secretstore_v1beta1.json
@@ -316,6 +316,13 @@
             "aws": {
               "description": "AWS configures this store to sync secrets using AWS Secret Manager provider",
               "properties": {
+                "additionalRoles": {
+                  "description": "AdditionalRoles is a chained list of Role ARNs which the SecretManager provider will sequentially assume before assuming Role",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "auth": {
                   "description": "Auth defines the information necessary to authenticate against AWS if not set aws sdk will infer credentials from your environment see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
                   "properties": {
@@ -375,6 +382,25 @@
                         },
                         "secretAccessKeySecretRef": {
                           "description": "The SecretAccessKey is used for authentication",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name of the Secret resource being referred to.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sessionTokenSecretRef": {
+                          "description": "The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html",
                           "properties": {
                             "key": {
                               "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -781,6 +807,17 @@
                 "environment": {
                   "description": "Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)",
                   "type": "string"
+                },
+                "groupIDs": {
+                  "description": "GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "inheritFromGroups": {
+                  "description": "InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.",
+                  "type": "boolean"
                 },
                 "projectID": {
                   "description": "ProjectID specifies a project where secrets are located.",
@@ -1899,6 +1936,10 @@
     "status": {
       "description": "SecretStoreStatus defines the observed state of the SecretStore.",
       "properties": {
+        "capabilities": {
+          "description": "SecretStoreCapabilities defines the possible operations a SecretStore can do.",
+          "type": "string"
+        },
         "conditions": {
           "items": {
             "properties": {

--- a/generators.external-secrets.io/acraccesstoken_v1alpha1.json
+++ b/generators.external-secrets.io/acraccesstoken_v1alpha1.json
@@ -1,0 +1,155 @@
+{
+  "description": "ACRAccessToken returns a Azure Container Registry token that can be used for pushing/pulling images. Note: by default it will return an ACR Refresh Token with full access (depending on the identity). This can be scoped down to the repository level using .spec.scope. In case scope is defined it will return an ACR Access Token. \n See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ACRAccessTokenSpec defines how to generate the access token e.g. how to authenticate and which registry to use. see: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#overview",
+      "properties": {
+        "auth": {
+          "properties": {
+            "managedIdentity": {
+              "description": "ManagedIdentity uses Azure Managed Identity to authenticate with Azure.",
+              "properties": {
+                "identityId": {
+                  "description": "If multiple Managed Identity is assigned to the pod, you can select the one to be used",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "servicePrincipal": {
+              "description": "ServicePrincipal uses Azure Service Principal credentials to authenticate with Azure.",
+              "properties": {
+                "secretRef": {
+                  "description": "Configuration used to authenticate with Azure using static credentials stored in a Kind=Secret.",
+                  "properties": {
+                    "clientId": {
+                      "description": "The Azure clientId of the service principle used for authentication.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "clientSecret": {
+                      "description": "The Azure ClientSecret of the service principle used for authentication.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Secret resource being referred to.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "secretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "workloadIdentity": {
+              "description": "WorkloadIdentity uses Azure Workload Identity to authenticate with Azure.",
+              "properties": {
+                "serviceAccountRef": {
+                  "description": "ServiceAccountRef specified the service account that should be used when authenticating with WorkloadIdentity.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the ServiceAccount resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "environmentType": {
+          "default": "PublicCloud",
+          "description": "EnvironmentType specifies the Azure cloud environment endpoints to use for connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint. The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152 PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud",
+          "enum": [
+            "PublicCloud",
+            "USGovernmentCloud",
+            "ChinaCloud",
+            "GermanCloud"
+          ],
+          "type": "string"
+        },
+        "registry": {
+          "description": "the domain name of the ACR registry e.g. foobarexample.azurecr.io",
+          "type": "string"
+        },
+        "scope": {
+          "description": "Define the scope for the access token, e.g. pull/push access for a repository. if not provided it will return a refresh token that has full scope. Note: you need to pin it down to the repository level, there is no wildcard available. \n examples: repository:my-repository:pull,push repository:my-repository:pull \n see docs for details: https://docs.docker.com/registry/spec/auth/scope/",
+          "type": "string"
+        },
+        "tenantId": {
+          "description": "TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "auth",
+        "registry"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/generators.external-secrets.io/ecrauthorizationtoken_v1alpha1.json
+++ b/generators.external-secrets.io/ecrauthorizationtoken_v1alpha1.json
@@ -1,0 +1,137 @@
+{
+  "description": "ECRAuthorizationTokenSpec uses the GetAuthorizationToken API to retrieve an authorization token. The authorization token is valid for 12 hours. The authorizationToken returned is a base64 encoded string that can be decoded and used in a docker login command to authenticate to a registry. For more information, see Registry authentication (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth) in the Amazon Elastic Container Registry User Guide.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "auth": {
+          "description": "Auth defines how to authenticate with AWS",
+          "properties": {
+            "jwt": {
+              "description": "Authenticate against AWS using service account tokens.",
+              "properties": {
+                "serviceAccountRef": {
+                  "description": "A reference to a ServiceAccount resource.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the ServiceAccount resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "AWSAuthSecretRef holds secret references for AWS credentials both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.",
+              "properties": {
+                "accessKeyIDSecretRef": {
+                  "description": "The AccessKeyID is used for authentication",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the Secret resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretAccessKeySecretRef": {
+                  "description": "The SecretAccessKey is used for authentication",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the Secret resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sessionTokenSecretRef": {
+                  "description": "The SessionToken used for authentication This must be defined if AccessKeyID and SecretAccessKey are temporary credentials see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the Secret resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "Region specifies the region to operate in.",
+          "type": "string"
+        },
+        "role": {
+          "description": "You can assume a role before making calls to the desired AWS service.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "region"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/generators.external-secrets.io/fake_v1alpha1.json
+++ b/generators.external-secrets.io/fake_v1alpha1.json
@@ -1,0 +1,31 @@
+{
+  "description": "Fake generator is used for testing. It lets you define a static set of credentials that is always returned.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FakeSpec contains the static data.",
+      "properties": {
+        "data": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Data defines the static data returned by this generator.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/generators.external-secrets.io/gcraccesstoken_v1alpha1.json
+++ b/generators.external-secrets.io/gcraccesstoken_v1alpha1.json
@@ -1,0 +1,108 @@
+{
+  "description": "GCRAccessToken generates an GCP access token that can be used to authenticate with GCR.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "auth": {
+          "description": "Auth defines the means for authenticating with GCP",
+          "properties": {
+            "secretRef": {
+              "properties": {
+                "secretAccessKeySecretRef": {
+                  "description": "The SecretAccessKey is used for authentication",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "The name of the Secret resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "workloadIdentity": {
+              "properties": {
+                "clusterLocation": {
+                  "type": "string"
+                },
+                "clusterName": {
+                  "type": "string"
+                },
+                "clusterProjectID": {
+                  "type": "string"
+                },
+                "serviceAccountRef": {
+                  "description": "A reference to a ServiceAccount resource.",
+                  "properties": {
+                    "audiences": {
+                      "description": "Audience specifies the `aud` claim for the service account token If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity then this audiences will be appended to the list",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the ServiceAccount resource being referred to.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults to the namespace of the referent.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "clusterLocation",
+                "clusterName",
+                "serviceAccountRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "projectID": {
+          "description": "ProjectID defines which project to use to authenticate with",
+          "type": "string"
+        }
+      },
+      "required": [
+        "auth",
+        "projectID"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/generators.external-secrets.io/password_v1alpha1.json
+++ b/generators.external-secrets.io/password_v1alpha1.json
@@ -1,0 +1,56 @@
+{
+  "description": "Password generates a random password based on the configuration parameters in spec. You can specify the length, characterset and other attributes.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PasswordSpec controls the behavior of the password generator.",
+      "properties": {
+        "allowRepeat": {
+          "default": false,
+          "description": "set AllowRepeat to true to allow repeating characters.",
+          "type": "boolean"
+        },
+        "digits": {
+          "description": "Digits specifies the number of digits in the generated password. If omitted it defaults to 25% of the length of the password",
+          "type": "integer"
+        },
+        "length": {
+          "default": 24,
+          "description": "Length of the password to be generated. Defaults to 24",
+          "type": "integer"
+        },
+        "noUpper": {
+          "default": false,
+          "description": "Set NoUpper to disable uppercase characters",
+          "type": "boolean"
+        },
+        "symbolCharacters": {
+          "description": "SymbolCharacters specifies the special characters that should be used in the generated password.",
+          "type": "string"
+        },
+        "symbols": {
+          "description": "Symbols specifies the number of symbol characters in the generated password. If omitted it defaults to 25% of the length of the password",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "allowRepeat",
+        "length",
+        "noUpper"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Updated `external-secrets.io` CRD schemas to v0.7.2, including new CRDs in the `generators.external-secrets.io` group.

See https://github.com/external-secrets/external-secrets/tree/v0.7.2/config/crds/bases.