### PR TITLE
feature: add eks-anywhere CRDs

### DIFF
--- a/anywhere.eks.amazonaws.com/awsdatacenterconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/awsdatacenterconfig_v1alpha1.json
@@ -1,0 +1,38 @@
+{
+  "description": "AWSDatacenterConfig is the Schema for the AWSDatacenterConfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSDatacenterConfigSpec defines the desired state of AWSDatacenterConfig.",
+      "properties": {
+        "amiID": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "amiID",
+        "region"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSDatacenterConfigStatus defines the observed state of AWSDatacenterConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/awsiamconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/awsiamconfig_v1alpha1.json
@@ -1,0 +1,100 @@
+{
+  "description": "AWSIamConfig is the Schema for the awsiamconfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSIamConfigSpec defines the desired state of AWSIamConfig.",
+      "properties": {
+        "awsRegion": {
+          "description": "AWSRegion defines a region in an AWS partition",
+          "type": "string"
+        },
+        "backendMode": {
+          "description": "BackendMode defines multiple backends for aws-iam-authenticator server The server searches for mappings in order",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mapRoles": {
+          "items": {
+            "description": "MapRoles defines IAM role to a username and set of groups mapping using EKSConfigMap BackendMode.",
+            "properties": {
+              "groups": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "roleARN": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "roleARN",
+              "username"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mapUsers": {
+          "items": {
+            "description": "MapUsers defines IAM role to a username and set of groups mapping using EKSConfigMap BackendMode.",
+            "properties": {
+              "groups": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "userARN": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "userARN",
+              "username"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "partition": {
+          "default": "aws",
+          "description": "Partition defines the AWS partition on which the IAM roles exist",
+          "type": "string"
+        }
+      },
+      "required": [
+        "awsRegion",
+        "backendMode"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSIamConfigStatus defines the observed state of AWSIamConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/bundles_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/bundles_v1alpha1.json
@@ -1,0 +1,4112 @@
+{
+  "description": "Bundles is the Schema for the bundles API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BundlesSpec defines the desired state of Bundles.",
+      "properties": {
+        "cliMaxVersion": {
+          "type": "string"
+        },
+        "cliMinVersion": {
+          "type": "string"
+        },
+        "number": {
+          "description": "Monotonically increasing release number",
+          "type": "integer"
+        },
+        "versionsBundles": {
+          "items": {
+            "properties": {
+              "aws": {
+                "description": "This field has been deprecated",
+                "properties": {
+                  "clusterTemplate": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "controller": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeProxy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "clusterTemplate",
+                  "components",
+                  "controller",
+                  "kubeProxy",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "bootstrap": {
+                "properties": {
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "controller": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeProxy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "components",
+                  "controller",
+                  "kubeProxy",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "bottlerocketHostContainers": {
+                "properties": {
+                  "admin": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "control": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeadmBootstrap": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "admin",
+                  "control",
+                  "kubeadmBootstrap"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "certManager": {
+                "properties": {
+                  "acmesolver": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cainjector": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "controller": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ctl": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "manifest": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "webhook": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "acmesolver",
+                  "cainjector",
+                  "controller",
+                  "ctl",
+                  "manifest",
+                  "webhook"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cilium": {
+                "properties": {
+                  "cilium": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "helmChart": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "manifest": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "operator": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cilium",
+                  "manifest",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cloudStack": {
+                "properties": {
+                  "clusterAPIController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeRbacProxy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeVip": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "clusterAPIController",
+                  "components",
+                  "kubeRbacProxy",
+                  "kubeVip",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "clusterAPI": {
+                "properties": {
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "controller": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeProxy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "components",
+                  "controller",
+                  "kubeProxy",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "controlPlane": {
+                "properties": {
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "controller": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeProxy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "components",
+                  "controller",
+                  "kubeProxy",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "docker": {
+                "properties": {
+                  "clusterTemplate": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeProxy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "manager": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "clusterTemplate",
+                  "components",
+                  "kubeProxy",
+                  "manager",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "eksD": {
+                "properties": {
+                  "channel": {
+                    "description": "Release branch of the EKS-D release like 1-19, 1-20",
+                    "type": "string"
+                  },
+                  "components": {
+                    "description": "Components refers to the url that points to the EKS-D release CRD",
+                    "type": "string"
+                  },
+                  "crictl": {
+                    "description": "Crictl points to the crictl binary/tarball built for this eks-d kube version",
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "sha256": {
+                        "description": "The sha256 of the asset, only applies for 'file' store",
+                        "type": "string"
+                      },
+                      "sha512": {
+                        "description": "The sha512 of the asset, only applies for 'file' store",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The URI where the asset is located",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "etcdadm": {
+                    "description": "Etcdadm points to the etcdadm binary/tarball built for this eks-d kube version",
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "sha256": {
+                        "description": "The sha256 of the asset, only applies for 'file' store",
+                        "type": "string"
+                      },
+                      "sha512": {
+                        "description": "The sha512 of the asset, only applies for 'file' store",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The URI where the asset is located",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitCommit": {
+                    "description": "Git commit the component is built from, before any patches",
+                    "type": "string"
+                  },
+                  "imagebuilder": {
+                    "description": "ImageBuilder points to the image-builder binary used to build eks-D based node images",
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "sha256": {
+                        "description": "The sha256 of the asset, only applies for 'file' store",
+                        "type": "string"
+                      },
+                      "sha512": {
+                        "description": "The sha512 of the asset, only applies for 'file' store",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The URI where the asset is located",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kindNode": {
+                    "description": "KindNode points to a kind image built with this eks-d version",
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeVersion": {
+                    "description": "Release number of EKS-D release",
+                    "type": "string"
+                  },
+                  "manifestUrl": {
+                    "description": "Url pointing to the EKS-D release manifest using which assets where created",
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "ova": {
+                    "description": "Ova points to a collection of Ovas built with this eks-d version",
+                    "properties": {
+                      "bottlerocket": {
+                        "properties": {
+                          "arch": {
+                            "description": "Architectures of the asset",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The asset name",
+                            "type": "string"
+                          },
+                          "os": {
+                            "description": "Operating system of the asset",
+                            "enum": [
+                              "linux",
+                              "darwin",
+                              "windows"
+                            ],
+                            "type": "string"
+                          },
+                          "osName": {
+                            "description": "Name of the OS like ubuntu, bottlerocket",
+                            "type": "string"
+                          },
+                          "sha256": {
+                            "description": "The sha256 of the asset, only applies for 'file' store",
+                            "type": "string"
+                          },
+                          "sha512": {
+                            "description": "The sha512 of the asset, only applies for 'file' store",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "The URI where the asset is located",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "raw": {
+                    "description": "Raw points to a collection of Raw images built with this eks-d version",
+                    "properties": {
+                      "bottlerocket": {
+                        "properties": {
+                          "arch": {
+                            "description": "Architectures of the asset",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The asset name",
+                            "type": "string"
+                          },
+                          "os": {
+                            "description": "Operating system of the asset",
+                            "enum": [
+                              "linux",
+                              "darwin",
+                              "windows"
+                            ],
+                            "type": "string"
+                          },
+                          "osName": {
+                            "description": "Name of the OS like ubuntu, bottlerocket",
+                            "type": "string"
+                          },
+                          "sha256": {
+                            "description": "The sha256 of the asset, only applies for 'file' store",
+                            "type": "string"
+                          },
+                          "sha512": {
+                            "description": "The sha512 of the asset, only applies for 'file' store",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "The URI where the asset is located",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "eksa": {
+                "properties": {
+                  "cliTools": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "clusterController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "diagnosticCollector": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cliTools",
+                  "clusterController",
+                  "components",
+                  "diagnosticCollector"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "etcdadmBootstrap": {
+                "properties": {
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "controller": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeProxy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "components",
+                  "controller",
+                  "kubeProxy",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "etcdadmController": {
+                "properties": {
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "controller": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeProxy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "components",
+                  "controller",
+                  "kubeProxy",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "flux": {
+                "properties": {
+                  "helmController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kustomizeController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "notificationController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "sourceController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "helmController",
+                  "kustomizeController",
+                  "notificationController",
+                  "sourceController"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "haproxy": {
+                "properties": {
+                  "image": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "image"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kindnetd": {
+                "properties": {
+                  "manifest": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "manifest"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kubeVersion": {
+                "type": "string"
+              },
+              "nutanix": {
+                "properties": {
+                  "clusterAPIController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "clusterTemplate": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeVip": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "clusterAPIController",
+                  "clusterTemplate",
+                  "components",
+                  "kubeVip",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "packageController": {
+                "properties": {
+                  "helmChart": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "packageController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tokenRefresher": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "packageController",
+                  "tokenRefresher"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "snow": {
+                "properties": {
+                  "bottlerocketBootstrapSnow": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeVip": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "manager": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "bottlerocketBootstrapSnow",
+                  "components",
+                  "kubeVip",
+                  "manager",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "tinkerbell": {
+                "properties": {
+                  "clusterAPIController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "clusterTemplate": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "envoy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeVip": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tinkerbellStack": {
+                    "properties": {
+                      "actions": {
+                        "description": "Tinkerbell Template Actions.",
+                        "properties": {
+                          "cexec": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "imageToDisk": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "kexec": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ociToDisk": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "reboot": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "writeFile": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "cexec",
+                          "imageToDisk",
+                          "kexec",
+                          "ociToDisk",
+                          "reboot",
+                          "writeFile"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "boots": {
+                        "properties": {
+                          "arch": {
+                            "description": "Architectures of the asset",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "imageDigest": {
+                            "description": "The SHA256 digest of the image manifest",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The asset name",
+                            "type": "string"
+                          },
+                          "os": {
+                            "description": "Operating system of the asset",
+                            "enum": [
+                              "linux",
+                              "darwin",
+                              "windows"
+                            ],
+                            "type": "string"
+                          },
+                          "osName": {
+                            "description": "Name of the OS like ubuntu, bottlerocket",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "The image repository, name, and tag",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hegel": {
+                        "properties": {
+                          "arch": {
+                            "description": "Architectures of the asset",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "imageDigest": {
+                            "description": "The SHA256 digest of the image manifest",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The asset name",
+                            "type": "string"
+                          },
+                          "os": {
+                            "description": "Operating system of the asset",
+                            "enum": [
+                              "linux",
+                              "darwin",
+                              "windows"
+                            ],
+                            "type": "string"
+                          },
+                          "osName": {
+                            "description": "Name of the OS like ubuntu, bottlerocket",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "The image repository, name, and tag",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hook": {
+                        "description": "Tinkerbell hook OS.",
+                        "properties": {
+                          "bootkit": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "docker": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initramfs": {
+                            "properties": {
+                              "amd": {
+                                "properties": {
+                                  "arch": {
+                                    "description": "Architectures of the asset",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "The asset name",
+                                    "type": "string"
+                                  },
+                                  "os": {
+                                    "description": "Operating system of the asset",
+                                    "enum": [
+                                      "linux",
+                                      "darwin",
+                                      "windows"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "osName": {
+                                    "description": "Name of the OS like ubuntu, bottlerocket",
+                                    "type": "string"
+                                  },
+                                  "sha256": {
+                                    "description": "The sha256 of the asset, only applies for 'file' store",
+                                    "type": "string"
+                                  },
+                                  "sha512": {
+                                    "description": "The sha512 of the asset, only applies for 'file' store",
+                                    "type": "string"
+                                  },
+                                  "uri": {
+                                    "description": "The URI where the asset is located",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "arm": {
+                                "properties": {
+                                  "arch": {
+                                    "description": "Architectures of the asset",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "The asset name",
+                                    "type": "string"
+                                  },
+                                  "os": {
+                                    "description": "Operating system of the asset",
+                                    "enum": [
+                                      "linux",
+                                      "darwin",
+                                      "windows"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "osName": {
+                                    "description": "Name of the OS like ubuntu, bottlerocket",
+                                    "type": "string"
+                                  },
+                                  "sha256": {
+                                    "description": "The sha256 of the asset, only applies for 'file' store",
+                                    "type": "string"
+                                  },
+                                  "sha512": {
+                                    "description": "The sha512 of the asset, only applies for 'file' store",
+                                    "type": "string"
+                                  },
+                                  "uri": {
+                                    "description": "The URI where the asset is located",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "amd",
+                              "arm"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "kernel": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vmlinuz": {
+                            "properties": {
+                              "amd": {
+                                "properties": {
+                                  "arch": {
+                                    "description": "Architectures of the asset",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "The asset name",
+                                    "type": "string"
+                                  },
+                                  "os": {
+                                    "description": "Operating system of the asset",
+                                    "enum": [
+                                      "linux",
+                                      "darwin",
+                                      "windows"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "osName": {
+                                    "description": "Name of the OS like ubuntu, bottlerocket",
+                                    "type": "string"
+                                  },
+                                  "sha256": {
+                                    "description": "The sha256 of the asset, only applies for 'file' store",
+                                    "type": "string"
+                                  },
+                                  "sha512": {
+                                    "description": "The sha512 of the asset, only applies for 'file' store",
+                                    "type": "string"
+                                  },
+                                  "uri": {
+                                    "description": "The URI where the asset is located",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "arm": {
+                                "properties": {
+                                  "arch": {
+                                    "description": "Architectures of the asset",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "The asset name",
+                                    "type": "string"
+                                  },
+                                  "os": {
+                                    "description": "Operating system of the asset",
+                                    "enum": [
+                                      "linux",
+                                      "darwin",
+                                      "windows"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "osName": {
+                                    "description": "Name of the OS like ubuntu, bottlerocket",
+                                    "type": "string"
+                                  },
+                                  "sha256": {
+                                    "description": "The sha256 of the asset, only applies for 'file' store",
+                                    "type": "string"
+                                  },
+                                  "sha512": {
+                                    "description": "The sha512 of the asset, only applies for 'file' store",
+                                    "type": "string"
+                                  },
+                                  "uri": {
+                                    "description": "The URI where the asset is located",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "amd",
+                              "arm"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "bootkit",
+                          "docker",
+                          "initramfs",
+                          "kernel",
+                          "vmlinuz"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rufio": {
+                        "properties": {
+                          "arch": {
+                            "description": "Architectures of the asset",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "imageDigest": {
+                            "description": "The SHA256 digest of the image manifest",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The asset name",
+                            "type": "string"
+                          },
+                          "os": {
+                            "description": "Operating system of the asset",
+                            "enum": [
+                              "linux",
+                              "darwin",
+                              "windows"
+                            ],
+                            "type": "string"
+                          },
+                          "osName": {
+                            "description": "Name of the OS like ubuntu, bottlerocket",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "The image repository, name, and tag",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tink": {
+                        "properties": {
+                          "tinkController": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "tinkServer": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "tinkWorker": {
+                            "properties": {
+                              "arch": {
+                                "description": "Architectures of the asset",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "imageDigest": {
+                                "description": "The SHA256 digest of the image manifest",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The asset name",
+                                "type": "string"
+                              },
+                              "os": {
+                                "description": "Operating system of the asset",
+                                "enum": [
+                                  "linux",
+                                  "darwin",
+                                  "windows"
+                                ],
+                                "type": "string"
+                              },
+                              "osName": {
+                                "description": "Name of the OS like ubuntu, bottlerocket",
+                                "type": "string"
+                              },
+                              "uri": {
+                                "description": "The image repository, name, and tag",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "tinkController",
+                          "tinkServer",
+                          "tinkWorker"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tinkerbellChart": {
+                        "properties": {
+                          "arch": {
+                            "description": "Architectures of the asset",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "imageDigest": {
+                            "description": "The SHA256 digest of the image manifest",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The asset name",
+                            "type": "string"
+                          },
+                          "os": {
+                            "description": "Operating system of the asset",
+                            "enum": [
+                              "linux",
+                              "darwin",
+                              "windows"
+                            ],
+                            "type": "string"
+                          },
+                          "osName": {
+                            "description": "Name of the OS like ubuntu, bottlerocket",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "The image repository, name, and tag",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "actions",
+                      "boots",
+                      "hegel",
+                      "hook",
+                      "rufio",
+                      "tink",
+                      "tinkerbellChart"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "clusterAPIController",
+                  "clusterTemplate",
+                  "components",
+                  "envoy",
+                  "kubeVip",
+                  "metadata",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "vSphere": {
+                "properties": {
+                  "clusterAPIController": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "clusterTemplate": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "components": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "driver": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeProxy": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kubeVip": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "manager": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "metadata": {
+                    "properties": {
+                      "uri": {
+                        "description": "URI points to the manifest yaml file",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "syncer": {
+                    "properties": {
+                      "arch": {
+                        "description": "Architectures of the asset",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "imageDigest": {
+                        "description": "The SHA256 digest of the image manifest",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The asset name",
+                        "type": "string"
+                      },
+                      "os": {
+                        "description": "Operating system of the asset",
+                        "enum": [
+                          "linux",
+                          "darwin",
+                          "windows"
+                        ],
+                        "type": "string"
+                      },
+                      "osName": {
+                        "description": "Name of the OS like ubuntu, bottlerocket",
+                        "type": "string"
+                      },
+                      "uri": {
+                        "description": "The image repository, name, and tag",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "clusterAPIController",
+                  "clusterTemplate",
+                  "components",
+                  "driver",
+                  "kubeProxy",
+                  "kubeVip",
+                  "manager",
+                  "metadata",
+                  "syncer",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "bootstrap",
+              "bottlerocketHostContainers",
+              "certManager",
+              "cilium",
+              "clusterAPI",
+              "controlPlane",
+              "docker",
+              "eksD",
+              "eksa",
+              "etcdadmBootstrap",
+              "etcdadmController",
+              "flux",
+              "kindnetd",
+              "kubeVersion",
+              "packageController",
+              "vSphere"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cliMaxVersion",
+        "cliMinVersion",
+        "number",
+        "versionsBundles"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "BundlesStatus defines the observed state of Bundles.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/cloudstackdatacenterconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/cloudstackdatacenterconfig_v1alpha1.json
@@ -1,0 +1,162 @@
+{
+  "description": "CloudStackDatacenterConfig is the Schema for the cloudstackdatacenterconfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "CloudStackDatacenterConfigSpec defines the desired state of CloudStackDatacenterConfig.",
+      "properties": {
+        "account": {
+          "description": "Account typically represents a customer of the service provider or a department in a large organization. Multiple users can exist in an account, and all CloudStack resources belong to an account. Accounts have users and users have credentials to operate on resources within that account. If an account name is provided, a domain must also be provided. Deprecated: Please use AvailabilityZones instead",
+          "type": "string"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones list of different partitions to distribute VMs across - corresponds to a list of CAPI failure domains",
+          "items": {
+            "description": "CloudStackAvailabilityZone maps to a CAPI failure domain to distribute machines across Cloudstack infrastructure.",
+            "properties": {
+              "account": {
+                "description": "Account typically represents a customer of the service provider or a department in a large organization. Multiple users can exist in an account, and all CloudStack resources belong to an account. Accounts have users and users have credentials to operate on resources within that account. If an account name is provided, a domain must also be provided.",
+                "type": "string"
+              },
+              "credentialsRef": {
+                "description": "CredentialRef is used to reference a secret in the eksa-system namespace",
+                "type": "string"
+              },
+              "domain": {
+                "description": "Domain contains a grouping of accounts. Domains usually contain multiple accounts that have some logical relationship to each other and a set of delegated administrators with some authority over the domain and its subdomains This field is considered as a fully qualified domain name which is the same as the domain path without \"ROOT/\" prefix. For example, if \"foo\" is specified then a domain with \"ROOT/foo\" domain path is picked. The value \"ROOT\" is a special case that points to \"the\" ROOT domain of the CloudStack. That is, a domain with a path \"ROOT/ROOT\" is not allowed.",
+                "type": "string"
+              },
+              "managementApiEndpoint": {
+                "description": "CloudStack Management API endpoint's IP. It is added to VM's noproxy list",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is used as a unique identifier for each availability zone",
+                "type": "string"
+              },
+              "zone": {
+                "description": "Zone represents the properties of the CloudStack zone in which clusters should be created, like the network.",
+                "properties": {
+                  "id": {
+                    "description": "Zone is the name or UUID of the CloudStack zone in which clusters should be created. Zones should be managed by a single CloudStack Management endpoint.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "network": {
+                    "description": "Network is the name or UUID of the CloudStack network in which clusters should be created. It can either be an isolated or shared network. If it doesn\u2019t already exist in CloudStack, it\u2019ll automatically be created by CAPC as an isolated network. It can either be specified as a UUID or name In multiple-zones situation, only 'Shared' network is supported.",
+                    "properties": {
+                      "id": {
+                        "description": "Id of a resource in the CloudStack environment. Mutually exclusive with Name",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of a resource in the CloudStack environment. Mutually exclusive with Id",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "network"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "credentialsRef",
+              "domain",
+              "managementApiEndpoint",
+              "name",
+              "zone"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "domain": {
+          "description": "Domain contains a grouping of accounts. Domains usually contain multiple accounts that have some logical relationship to each other and a set of delegated administrators with some authority over the domain and its subdomains This field is considered as a fully qualified domain name which is the same as the domain path without \"ROOT/\" prefix. For example, if \"foo\" is specified then a domain with \"ROOT/foo\" domain path is picked. The value \"ROOT\" is a special case that points to \"the\" ROOT domain of the CloudStack. That is, a domain with a path \"ROOT/ROOT\" is not allowed. Deprecated: Please use AvailabilityZones instead",
+          "type": "string"
+        },
+        "managementApiEndpoint": {
+          "description": "CloudStack Management API endpoint's IP. It is added to VM's noproxy list Deprecated: Please use AvailabilityZones instead",
+          "type": "string"
+        },
+        "zones": {
+          "description": "Zones is a list of one or more zones that are managed by a single CloudStack management endpoint. Deprecated: Please use AvailabilityZones instead",
+          "items": {
+            "description": "CloudStackZone is an organizational construct typically used to represent a single datacenter, and all its physical and virtual resources exist inside that zone. It can either be specified as a UUID or name.",
+            "properties": {
+              "id": {
+                "description": "Zone is the name or UUID of the CloudStack zone in which clusters should be created. Zones should be managed by a single CloudStack Management endpoint.",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "network": {
+                "description": "Network is the name or UUID of the CloudStack network in which clusters should be created. It can either be an isolated or shared network. If it doesn\u2019t already exist in CloudStack, it\u2019ll automatically be created by CAPC as an isolated network. It can either be specified as a UUID or name In multiple-zones situation, only 'Shared' network is supported.",
+                "properties": {
+                  "id": {
+                    "description": "Id of a resource in the CloudStack environment. Mutually exclusive with Name",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of a resource in the CloudStack environment. Mutually exclusive with Id",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "network"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "CloudStackDatacenterConfigStatus defines the observed state of CloudStackDatacenterConfig.",
+      "properties": {
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "specValid": {
+          "description": "SpecValid is set to true if cloudstackdatacenterconfig is validated.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/cloudstackmachineconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/cloudstackmachineconfig_v1alpha1.json
@@ -1,0 +1,164 @@
+{
+  "description": "CloudStackMachineConfig is the Schema for the cloudstackmachineconfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "CloudStackMachineConfigSpec defines the desired state of CloudStackMachineConfig.",
+      "properties": {
+        "affinity": {
+          "description": "Defaults to `no`. Can be `pro` or `anti`. If set to `pro` or `anti`, will create an affinity group per machine set of the corresponding type",
+          "type": "string"
+        },
+        "affinityGroupIds": {
+          "description": "AffinityGroupIds allows users to pass in a list of UUIDs for previously-created Affinity Groups. Any VM\u2019s created with this spec will be added to the affinity group, which will dictate which physical host(s) they can be placed on. Affinity groups can be type \u201caffinity\u201d or \u201canti-affinity\u201d in CloudStack. If they are type \u201canti-affinity\u201d, all VM\u2019s in the group must be on separate physical hosts for high availability. If they are type \u201caffinity\u201d, all VM\u2019s in the group must be on the same physical host for improved performance",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "computeOffering": {
+          "description": "ComputeOffering refers to a compute offering which has been previously registered in CloudStack. It represents a VM\u2019s instance size including number of CPU\u2019s, memory, and CPU speed. It can either be specified as a UUID or name",
+          "properties": {
+            "id": {
+              "description": "Id of a resource in the CloudStack environment. Mutually exclusive with Name",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of a resource in the CloudStack environment. Mutually exclusive with Id",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "diskOffering": {
+          "description": "DiskOffering refers to a disk offering which has been previously registered in CloudStack. It represents a disk offering with pre-defined size or custom specified disk size. It can either be specified as a UUID or name",
+          "properties": {
+            "customSizeInGB": {
+              "description": "disk size in GB, > 0 for customized disk offering; = 0 for non-customized disk offering",
+              "format": "int64",
+              "type": "integer"
+            },
+            "device": {
+              "description": "device name of the disk offering in VM, shows up in lsblk command",
+              "type": "string"
+            },
+            "filesystem": {
+              "description": "filesystem used to mkfs in disk offering partition",
+              "type": "string"
+            },
+            "id": {
+              "description": "Id of a resource in the CloudStack environment. Mutually exclusive with Name",
+              "type": "string"
+            },
+            "label": {
+              "description": "disk label used to label disk partition",
+              "type": "string"
+            },
+            "mountPath": {
+              "description": "path the filesystem will use to mount in VM",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of a resource in the CloudStack environment. Mutually exclusive with Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "device",
+            "filesystem",
+            "label",
+            "mountPath"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "symlinks": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Symlinks create soft symbolic links folders. One use case is to use data disk to store logs",
+          "type": "object"
+        },
+        "template": {
+          "description": "Template refers to a VM image template which has been previously registered in CloudStack. It can either be specified as a UUID or name",
+          "properties": {
+            "id": {
+              "description": "Id of a resource in the CloudStack environment. Mutually exclusive with Name",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of a resource in the CloudStack environment. Mutually exclusive with Id",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "userCustomDetails": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "UserCustomDetails allows users to pass in non-standard key value inputs, outside those defined [here](https://github.com/shapeblue/cloudstack/blob/main/api/src/main/java/com/cloud/vm/VmDetailConstants.java)",
+          "type": "object"
+        },
+        "users": {
+          "description": "Users consists of an array of objects containing the username, as well as a list of their public keys. These users will be authorized to ssh into the machines",
+          "items": {
+            "description": "UserConfiguration defines the configuration of the user to be added to the VM.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "sshAuthorizedKeys": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name",
+              "sshAuthorizedKeys"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "computeOffering",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "CloudStackMachineConfigStatus defines the observed state of CloudStackMachineConfig.",
+      "properties": {
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "specValid": {
+          "description": "SpecValid is set to true if cloudstackmachineconfig is validated.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/cluster_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/cluster_v1alpha1.json
@@ -1,0 +1,574 @@
+{
+  "description": "Cluster is the Schema for the clusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterSpec defines the desired state of Cluster.",
+      "properties": {
+        "bundlesRef": {
+          "description": "BundlesRef contains a reference to the Bundles containing the desired dependencies for the cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion refers to the Bundles APIVersion",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name refers to the name of the Bundles object in the cluster",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace refers to the Bundles's namespace",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiVersion",
+            "name",
+            "namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "clusterNetwork": {
+          "properties": {
+            "cni": {
+              "description": "Deprecated. Use CNIConfig",
+              "type": "string"
+            },
+            "cniConfig": {
+              "description": "CNIConfig specifies the CNI plugin to be installed in the cluster",
+              "properties": {
+                "cilium": {
+                  "properties": {
+                    "policyEnforcementMode": {
+                      "description": "PolicyEnforcementMode determines communication allowed between pods. Accepted values are default, always, never.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "kindnetd": {
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dns": {
+              "properties": {
+                "resolvConf": {
+                  "description": "ResolvConf refers to the DNS resolver configuration",
+                  "properties": {
+                    "path": {
+                      "description": "Path defines the path to the file that contains the DNS resolver configuration",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodes": {
+              "properties": {
+                "cidrMaskSize": {
+                  "description": "CIDRMaskSize defines the mask size for node cidr in the cluster, default for ipv4 is 24. This is an optional field",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "pods": {
+              "description": "Comma-separated list of CIDR blocks to use for pod and service subnets. Defaults to 192.168.0.0/16 for pod subnet.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "services": {
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneConfiguration": {
+          "properties": {
+            "count": {
+              "description": "Count defines the number of desired control plane nodes. Defaults to 1.",
+              "type": "integer"
+            },
+            "endpoint": {
+              "description": "Endpoint defines the host ip and port to use for the control plane.",
+              "properties": {
+                "host": {
+                  "description": "Host defines the ip that you want to use to connect to the control plane",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "host"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Labels define the labels to assign to the node",
+              "type": "object"
+            },
+            "machineGroupRef": {
+              "description": "MachineGroupRef defines the machine group configuration for the control plane.",
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "taints": {
+              "description": "Taints define the set of taints to be applied on control plane nodes",
+              "items": {
+                "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                "properties": {
+                  "effect": {
+                    "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Required. The taint key to be applied to a node.",
+                    "type": "string"
+                  },
+                  "timeAdded": {
+                    "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "The taint value corresponding to the taint key.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "effect",
+                  "key"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "upgradeRolloutStrategy": {
+              "description": "UpgradeRolloutStrategy determines the rollout strategy to use for rolling upgrades and related parameters/knobs",
+              "properties": {
+                "rollingUpdate": {
+                  "description": "ControlPlaneRollingUpdateParams is API for rolling update strategy knobs.",
+                  "properties": {
+                    "maxSurge": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "maxSurge"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "datacenterRef": {
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalEtcdConfiguration": {
+          "description": "ExternalEtcdConfiguration defines the configuration options for using unstacked etcd topology.",
+          "properties": {
+            "count": {
+              "type": "integer"
+            },
+            "machineGroupRef": {
+              "description": "MachineGroupRef defines the machine group configuration for the etcd machines.",
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gitOpsRef": {
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityProviderRefs": {
+          "items": {
+            "properties": {
+              "kind": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "kubernetesVersion": {
+          "type": "string"
+        },
+        "managementCluster": {
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "podIamConfig": {
+          "properties": {
+            "serviceAccountIssuer": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "serviceAccountIssuer"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "proxyConfiguration": {
+          "properties": {
+            "httpProxy": {
+              "type": "string"
+            },
+            "httpsProxy": {
+              "type": "string"
+            },
+            "noProxy": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "registryMirrorConfiguration": {
+          "description": "RegistryMirrorConfiguration defines the settings for image registry mirror.",
+          "properties": {
+            "authenticate": {
+              "description": "Authenticate defines if registry requires authentication",
+              "type": "boolean"
+            },
+            "caCertContent": {
+              "description": "CACertContent defines the contents registry mirror CA certificate",
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "Endpoint defines the registry mirror endpoint to use for pulling images",
+              "type": "string"
+            },
+            "insecureSkipVerify": {
+              "description": "InsecureSkipVerify skips the registry certificate verification. Only use this solution for isolated testing or in a tightly controlled, air-gapped environment. Currently only supported for snow provider",
+              "type": "boolean"
+            },
+            "ociNamespaces": {
+              "description": "OCINamespaces defines the mapping from an upstream registry to a local namespace where upstream artifacts are placed into",
+              "items": {
+                "description": "OCINamespace represents an entity in a local reigstry to group related images.",
+                "properties": {
+                  "namespace": {
+                    "description": "Namespace refers to the name of a namespace in the local registry",
+                    "type": "string"
+                  },
+                  "registry": {
+                    "description": "Name refers to the name of the upstream registry",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "namespace",
+                  "registry"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "port": {
+              "description": "Port defines the port exposed for registry mirror endpoint",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "workerNodeGroupConfigurations": {
+          "items": {
+            "properties": {
+              "autoscalingConfiguration": {
+                "description": "AutoScalingConfiguration defines the auto scaling configuration",
+                "properties": {
+                  "maxCount": {
+                    "description": "MaxCount defines the maximum number of nodes for the associated resource group.",
+                    "type": "integer"
+                  },
+                  "minCount": {
+                    "description": "MinCount defines the minimum number of nodes for the associated resource group.",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "count": {
+                "description": "Count defines the number of desired worker nodes. Defaults to 1.",
+                "type": "integer"
+              },
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Labels define the labels to assign to the node",
+                "type": "object"
+              },
+              "machineGroupRef": {
+                "description": "MachineGroupRef defines the machine group configuration for the worker nodes.",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name refers to the name of the worker node group",
+                "type": "string"
+              },
+              "taints": {
+                "description": "Taints define the set of taints to be applied on worker nodes",
+                "items": {
+                  "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                  "properties": {
+                    "effect": {
+                      "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                      "type": "string"
+                    },
+                    "key": {
+                      "description": "Required. The taint key to be applied to a node.",
+                      "type": "string"
+                    },
+                    "timeAdded": {
+                      "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The taint value corresponding to the taint key.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "effect",
+                    "key"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "upgradeRolloutStrategy": {
+                "description": "UpgradeRolloutStrategy determines the rollout strategy to use for rolling upgrades and related parameters/knobs",
+                "properties": {
+                  "rollingUpdate": {
+                    "description": "WorkerNodesRollingUpdateParams is API for rolling update strategy knobs.",
+                    "properties": {
+                      "maxSurge": {
+                        "type": "integer"
+                      },
+                      "maxUnavailable": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "maxSurge",
+                      "maxUnavailable"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterStatus defines the observed state of Cluster.",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "eksdReleaseRef": {
+          "description": "EksdReleaseRef defines the properties of the EKS-D object on the cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "ApiVersion refers to the EKS-D API version",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind refers to the Release kind for the EKS-D object",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name refers to the name of the EKS-D object on the cluster",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace refers to the namespace for the EKS-D release resources",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiVersion",
+            "kind",
+            "name",
+            "namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureMessage": {
+          "description": "Descriptive message about a fatal problem while reconciling a cluster",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/cluster_v1alpha3.json
+++ b/anywhere.eks.amazonaws.com/cluster_v1alpha3.json
@@ -1,0 +1,310 @@
+{
+  "description": "Cluster is the Schema for the clusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterSpec defines the desired state of Cluster.",
+      "properties": {
+        "clusterNetwork": {
+          "description": "Cluster network configuration.",
+          "properties": {
+            "apiServerPort": {
+              "description": "APIServerPort specifies the port the API Server should bind to. Defaults to 6443.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "pods": {
+              "description": "The network ranges from which Pod networks are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceDomain": {
+              "description": "Domain name for services.",
+              "type": "string"
+            },
+            "services": {
+              "description": "The network ranges from which service VIPs are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneRef": {
+          "description": "ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "managedExternalEtcdRef": {
+          "description": "ManagedExternalEtcdRef is an optional reference to an etcd provider resource that holds details for provisioning an external etcd cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "paused": {
+          "description": "Paused can be used to prevent controllers from processing the Cluster and all its associated objects.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterStatus defines the observed state of Cluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the cluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlPlaneInitialized": {
+          "description": "ControlPlaneInitialized defines if the control plane has been initialized.",
+          "type": "boolean"
+        },
+        "controlPlaneReady": {
+          "description": "ControlPlaneReady defines if the control plane is ready.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of failure domain objects synced from the infrastructure provider.",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "managedExternalEtcdInitialized": {
+          "description": "ManagedExternalEtcdInitialized indicates that first etcd member's IP address is set by machine controller, so remaining etcd members can lookup the address to join the cluster",
+          "type": "boolean"
+        },
+        "managedExternalEtcdReady": {
+          "description": "ManagedExternalEtcdReady indicates external etcd cluster is fully provisioned",
+          "type": "boolean"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/cluster_v1alpha4.json
+++ b/anywhere.eks.amazonaws.com/cluster_v1alpha4.json
@@ -1,0 +1,419 @@
+{
+  "description": "Cluster is the Schema for the clusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterSpec defines the desired state of Cluster.",
+      "properties": {
+        "clusterNetwork": {
+          "description": "Cluster network configuration.",
+          "properties": {
+            "apiServerPort": {
+              "description": "APIServerPort specifies the port the API Server should bind to. Defaults to 6443.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "pods": {
+              "description": "The network ranges from which Pod networks are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceDomain": {
+              "description": "Domain name for services.",
+              "type": "string"
+            },
+            "services": {
+              "description": "The network ranges from which service VIPs are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneRef": {
+          "description": "ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "managedExternalEtcdRef": {
+          "description": "ManagedExternalEtcdRef is an optional reference to an etcd provider resource that holds details for provisioning an external etcd cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "paused": {
+          "description": "Paused can be used to prevent controllers from processing the Cluster and all its associated objects.",
+          "type": "boolean"
+        },
+        "topology": {
+          "description": "This encapsulates the topology for the cluster. NOTE: It is required to enable the ClusterTopology feature gate flag to activate managed topologies support; this feature is highly experimental, and parts of it might still be not implemented.",
+          "properties": {
+            "class": {
+              "description": "The name of the ClusterClass object to create the topology.",
+              "type": "string"
+            },
+            "controlPlane": {
+              "description": "ControlPlane describes the cluster control plane.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass. \n This field is supported if and only if the control plane provider template referenced in the ClusterClass is Machine based.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "replicas": {
+                  "description": "Replicas is the number of control plane nodes. If the value is nil, the ControlPlane object is created without the number of Replicas and it's assumed that the control plane controller does not implement support for this field. When specified against a control plane provider that lacks support for this field, this value will be ignored.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rolloutAfter": {
+              "description": "RolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "version": {
+              "description": "The Kubernetes version of the cluster.",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Workers encapsulates the different constructs that form the worker nodes for the cluster.",
+              "properties": {
+                "machineDeployments": {
+                  "description": "MachineDeployments is a list of machine deployments in the cluster.",
+                  "items": {
+                    "description": "MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology. This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.",
+                    "properties": {
+                      "class": {
+                        "description": "Class is the name of the MachineDeploymentClass used to create the set of worker nodes. This should match one of the deployment classes defined in the ClusterClass object mentioned in the `Cluster.Spec.Class` field.",
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "description": "Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "description": "Name is the unique identifier for this MachineDeploymentTopology. The value is used with other unique identifiers to create a MachineDeployment's Name (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length, the values are hashed together.",
+                        "type": "string"
+                      },
+                      "replicas": {
+                        "description": "Replicas is the number of worker nodes belonging to this set. If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero) and it's assumed that an external entity (like cluster autoscaler) is responsible for the management of this value.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "class",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "class",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterStatus defines the observed state of Cluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the cluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlPlaneReady": {
+          "description": "ControlPlaneReady defines if the control plane is ready.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of failure domain objects synced from the infrastructure provider.",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "managedExternalEtcdInitialized": {
+          "description": "ManagedExternalEtcdInitialized indicates that first etcd member's IP address is set by machine controller, so remaining etcd members can lookup the address to join the cluster",
+          "type": "boolean"
+        },
+        "managedExternalEtcdReady": {
+          "description": "ManagedExternalEtcdReady indicates external etcd cluster is fully provisioned",
+          "type": "boolean"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/cluster_v1beta1.json
+++ b/anywhere.eks.amazonaws.com/cluster_v1beta1.json
@@ -1,0 +1,485 @@
+{
+  "description": "Cluster is the Schema for the clusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterSpec defines the desired state of Cluster.",
+      "properties": {
+        "clusterNetwork": {
+          "description": "Cluster network configuration.",
+          "properties": {
+            "apiServerPort": {
+              "description": "APIServerPort specifies the port the API Server should bind to. Defaults to 6443.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "pods": {
+              "description": "The network ranges from which Pod networks are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceDomain": {
+              "description": "Domain name for services.",
+              "type": "string"
+            },
+            "services": {
+              "description": "The network ranges from which service VIPs are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneRef": {
+          "description": "ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "managedExternalEtcdRef": {
+          "description": "ManagedExternalEtcdRef is an optional reference to an etcd provider resource that holds details for provisioning an external etcd cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "paused": {
+          "description": "Paused can be used to prevent controllers from processing the Cluster and all its associated objects.",
+          "type": "boolean"
+        },
+        "topology": {
+          "description": "This encapsulates the topology for the cluster. NOTE: It is required to enable the ClusterTopology feature gate flag to activate managed topologies support; this feature is highly experimental, and parts of it might still be not implemented.",
+          "properties": {
+            "class": {
+              "description": "The name of the ClusterClass object to create the topology.",
+              "type": "string"
+            },
+            "controlPlane": {
+              "description": "ControlPlane describes the cluster control plane.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass. \n This field is supported if and only if the control plane provider template referenced in the ClusterClass is Machine based.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "replicas": {
+                  "description": "Replicas is the number of control plane nodes. If the value is nil, the ControlPlane object is created without the number of Replicas and it's assumed that the control plane controller does not implement support for this field. When specified against a control plane provider that lacks support for this field, this value will be ignored.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rolloutAfter": {
+              "description": "RolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "variables": {
+              "description": "Variables can be used to customize the Cluster through patches. They must comply to the corresponding VariableClasses defined in the ClusterClass.",
+              "items": {
+                "description": "ClusterVariable can be used to customize the Cluster through patches. It must comply to the corresponding ClusterClassVariable defined in the ClusterClass.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the variable.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value of the variable. Note: the value will be validated against the schema of the corresponding ClusterClassVariable from the ClusterClass. Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools, i.e. it is not possible to have no type field. Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "version": {
+              "description": "The Kubernetes version of the cluster.",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Workers encapsulates the different constructs that form the worker nodes for the cluster.",
+              "properties": {
+                "machineDeployments": {
+                  "description": "MachineDeployments is a list of machine deployments in the cluster.",
+                  "items": {
+                    "description": "MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology. This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.",
+                    "properties": {
+                      "class": {
+                        "description": "Class is the name of the MachineDeploymentClass used to create the set of worker nodes. This should match one of the deployment classes defined in the ClusterClass object mentioned in the `Cluster.Spec.Class` field.",
+                        "type": "string"
+                      },
+                      "failureDomain": {
+                        "description": "FailureDomain is the failure domain the machines will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "description": "Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "description": "Name is the unique identifier for this MachineDeploymentTopology. The value is used with other unique identifiers to create a MachineDeployment's Name (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length, the values are hashed together.",
+                        "type": "string"
+                      },
+                      "nodeDrainTimeout": {
+                        "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                        "type": "string"
+                      },
+                      "replicas": {
+                        "description": "Replicas is the number of worker nodes belonging to this set. If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero) and it's assumed that an external entity (like cluster autoscaler) is responsible for the management of this value.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "variables": {
+                        "description": "Variables can be used to customize the MachineDeployment through patches.",
+                        "properties": {
+                          "overrides": {
+                            "description": "Overrides can be used to override Cluster level variables.",
+                            "items": {
+                              "description": "ClusterVariable can be used to customize the Cluster through patches. It must comply to the corresponding ClusterClassVariable defined in the ClusterClass.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the variable.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value of the variable. Note: the value will be validated against the schema of the corresponding ClusterClassVariable from the ClusterClass. Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools, i.e. it is not possible to have no type field. Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "class",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "class",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterStatus defines the observed state of Cluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the cluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlPlaneReady": {
+          "description": "ControlPlaneReady defines if the control plane is ready.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of failure domain objects synced from the infrastructure provider.",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "managedExternalEtcdInitialized": {
+          "description": "ManagedExternalEtcdInitialized indicates that first etcd member's IP address is set by machine controller, so remaining etcd members can lookup the address to join the cluster",
+          "type": "boolean"
+        },
+        "managedExternalEtcdReady": {
+          "description": "ManagedExternalEtcdReady indicates external etcd cluster is fully provisioned",
+          "type": "boolean"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/clusterclass_v1alpha4.json
+++ b/anywhere.eks.amazonaws.com/clusterclass_v1alpha4.json
@@ -1,0 +1,333 @@
+{
+  "description": "ClusterClass is a template which can be used to create managed topologies.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterClassSpec describes the desired state of the ClusterClass.",
+      "properties": {
+        "controlPlane": {
+          "description": "ControlPlane is a reference to a local struct that holds the details for provisioning the Control Plane for the Cluster.",
+          "properties": {
+            "machineInfrastructure": {
+              "description": "MachineTemplate defines the metadata and infrastructure information for control plane machines. \n This field is supported if and only if the control plane provider template referenced above is Machine based and supports setting replicas.",
+              "properties": {
+                "ref": {
+                  "description": "Ref is a required reference to a custom resource offered by a provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "ref"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "metadata": {
+              "description": "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the topology. \n This field is supported if and only if the control plane provider template referenced is Machine based.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ref": {
+              "description": "Ref is a required reference to a custom resource offered by a provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "ref"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "infrastructure": {
+          "description": "Infrastructure is a reference to a provider-specific template that holds the details for provisioning infrastructure specific cluster for the underlying provider. The underlying provider is responsible for the implementation of the template to an infrastructure cluster.",
+          "properties": {
+            "ref": {
+              "description": "Ref is a required reference to a custom resource offered by a provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "ref"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "workers": {
+          "description": "Workers describes the worker nodes for the cluster. It is a collection of node types which can be used to create the worker nodes of the cluster.",
+          "properties": {
+            "machineDeployments": {
+              "description": "MachineDeployments is a list of machine deployment classes that can be used to create a set of worker nodes.",
+              "items": {
+                "description": "MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster provisioned using the `ClusterClass`.",
+                "properties": {
+                  "class": {
+                    "description": "Class denotes a type of worker node present in the cluster, this name MUST be unique within a ClusterClass and can be referenced in the Cluster to create a managed MachineDeployment.",
+                    "type": "string"
+                  },
+                  "template": {
+                    "description": "Template is a local struct containing a collection of templates for creation of MachineDeployment objects representing a set of worker nodes.",
+                    "properties": {
+                      "bootstrap": {
+                        "description": "Bootstrap contains the bootstrap template reference to be used for the creation of worker Machines.",
+                        "properties": {
+                          "ref": {
+                            "description": "Ref is a required reference to a custom resource offered by a provider.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "API version of the referent.",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                "type": "string"
+                              },
+                              "resourceVersion": {
+                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "ref"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "infrastructure": {
+                        "description": "Infrastructure contains the infrastructure template reference to be used for the creation of worker Machines.",
+                        "properties": {
+                          "ref": {
+                            "description": "Ref is a required reference to a custom resource offered by a provider.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "API version of the referent.",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                "type": "string"
+                              },
+                              "resourceVersion": {
+                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "ref"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "metadata": {
+                        "description": "Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the topology.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "bootstrap",
+                      "infrastructure"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "class",
+                  "template"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/clusterclass_v1beta1.json
+++ b/anywhere.eks.amazonaws.com/clusterclass_v1beta1.json
@@ -1,0 +1,796 @@
+{
+  "description": "ClusterClass is a template which can be used to create managed topologies.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterClassSpec describes the desired state of the ClusterClass.",
+      "properties": {
+        "controlPlane": {
+          "description": "ControlPlane is a reference to a local struct that holds the details for provisioning the Control Plane for the Cluster.",
+          "properties": {
+            "machineHealthCheck": {
+              "description": "MachineHealthCheck defines a MachineHealthCheck for this ControlPlaneClass. This field is supported if and only if the ControlPlane provider template referenced above is Machine based and supports setting replicas.",
+              "properties": {
+                "maxUnhealthy": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "nodeStartupTimeout": {
+                  "description": "Machines older than this duration without a node will be considered to have failed and will be remediated. If you wish to disable this feature, set the value explicitly to 0.",
+                  "type": "string"
+                },
+                "remediationTemplate": {
+                  "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "unhealthyConditions": {
+                  "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy. The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+                  "items": {
+                    "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+                    "properties": {
+                      "status": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "status",
+                      "timeout",
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "unhealthyRange": {
+                  "description": "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "machineInfrastructure": {
+              "description": "MachineInfrastructure defines the metadata and infrastructure information for control plane machines. \n This field is supported if and only if the control plane provider template referenced above is Machine based and supports setting replicas.",
+              "properties": {
+                "ref": {
+                  "description": "Ref is a required reference to a custom resource offered by a provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "ref"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "metadata": {
+              "description": "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the topology. \n This field is supported if and only if the control plane provider template referenced is Machine based.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ref": {
+              "description": "Ref is a required reference to a custom resource offered by a provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "ref"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "infrastructure": {
+          "description": "Infrastructure is a reference to a provider-specific template that holds the details for provisioning infrastructure specific cluster for the underlying provider. The underlying provider is responsible for the implementation of the template to an infrastructure cluster.",
+          "properties": {
+            "ref": {
+              "description": "Ref is a required reference to a custom resource offered by a provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "ref"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "patches": {
+          "description": "Patches defines the patches which are applied to customize referenced templates of a ClusterClass. Note: Patches will be applied in the order of the array.",
+          "items": {
+            "description": "ClusterClassPatch defines a patch which is applied to customize the referenced templates.",
+            "properties": {
+              "definitions": {
+                "description": "Definitions define inline patches. Note: Patches will be applied in the order of the array. Note: Exactly one of Definitions or External must be set.",
+                "items": {
+                  "description": "PatchDefinition defines a patch which is applied to customize the referenced templates.",
+                  "properties": {
+                    "jsonPatches": {
+                      "description": "JSONPatches defines the patches which should be applied on the templates matching the selector. Note: Patches will be applied in the order of the array.",
+                      "items": {
+                        "description": "JSONPatch defines a JSON patch.",
+                        "properties": {
+                          "op": {
+                            "description": "Op defines the operation of the patch. Note: Only `add`, `replace` and `remove` are supported.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path defines the path of the patch. Note: Only the spec of a template can be patched, thus the path has to start with /spec/. Note: For now the only allowed array modifications are `append` and `prepend`, i.e.: * for op: `add`: only index 0 (prepend) and - (append) are allowed * for op: `replace` or `remove`: no indexes are allowed",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value defines the value of the patch. Note: Either Value or ValueFrom is required for add and replace operations. Only one of them is allowed to be set at the same time. Note: We have to use apiextensionsv1.JSON instead of our JSON type, because controller-tools has a hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type (unset type field). Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "valueFrom": {
+                            "description": "ValueFrom defines the value of the patch. Note: Either Value or ValueFrom is required for add and replace operations. Only one of them is allowed to be set at the same time.",
+                            "properties": {
+                              "template": {
+                                "description": "Template is the Go template to be used to calculate the value. A template can reference variables defined in .spec.variables and builtin variables. Note: The template must evaluate to a valid YAML or JSON value.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable is the variable to be used as value. Variable can be one of the variables defined in .spec.variables or a builtin variable.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "op",
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "selector": {
+                      "description": "Selector defines on which templates the patch should be applied.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion filters templates by apiVersion.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind filters templates by kind.",
+                          "type": "string"
+                        },
+                        "matchResources": {
+                          "description": "MatchResources selects templates based on where they are referenced.",
+                          "properties": {
+                            "controlPlane": {
+                              "description": "ControlPlane selects templates referenced in .spec.ControlPlane. Note: this will match the controlPlane and also the controlPlane machineInfrastructure (depending on the kind and apiVersion).",
+                              "type": "boolean"
+                            },
+                            "infrastructureCluster": {
+                              "description": "InfrastructureCluster selects templates referenced in .spec.infrastructure.",
+                              "type": "boolean"
+                            },
+                            "machineDeploymentClass": {
+                              "description": "MachineDeploymentClass selects templates referenced in specific MachineDeploymentClasses in .spec.workers.machineDeployments.",
+                              "properties": {
+                                "names": {
+                                  "description": "Names selects templates by class names.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "apiVersion",
+                        "kind",
+                        "matchResources"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "jsonPatches",
+                    "selector"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "description": {
+                "description": "Description is a human-readable description of this patch.",
+                "type": "string"
+              },
+              "enabledIf": {
+                "description": "EnabledIf is a Go template to be used to calculate if a patch should be enabled. It can reference variables defined in .spec.variables and builtin variables. The patch will be enabled if the template evaluates to `true`, otherwise it will be disabled. If EnabledIf is not set, the patch will be enabled per default.",
+                "type": "string"
+              },
+              "external": {
+                "description": "External defines an external patch. Note: Exactly one of Definitions or External must be set.",
+                "properties": {
+                  "generateExtension": {
+                    "description": "GenerateExtension references an extension which is called to generate patches.",
+                    "type": "string"
+                  },
+                  "validateExtension": {
+                    "description": "ValidateExtension references an extension which is called to validate the topology.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name of the patch.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "variables": {
+          "description": "Variables defines the variables which can be configured in the Cluster topology and are then used in patches.",
+          "items": {
+            "description": "ClusterClassVariable defines a variable which can be configured in the Cluster topology and used in patches.",
+            "properties": {
+              "name": {
+                "description": "Name of the variable.",
+                "type": "string"
+              },
+              "required": {
+                "description": "Required specifies if the variable is required. Note: this applies to the variable as a whole and thus the top-level object defined in the schema. If nested fields are required, this will be specified inside the schema.",
+                "type": "boolean"
+              },
+              "schema": {
+                "description": "Schema defines the schema of the variable.",
+                "properties": {
+                  "openAPIV3Schema": {
+                    "description": "OpenAPIV3Schema defines the schema of a variable via OpenAPI v3 schema. The schema is a subset of the schema used in Kubernetes CRDs.",
+                    "properties": {
+                      "additionalProperties": {
+                        "description": "AdditionalProperties specifies the schema of values in a map (keys are always strings). NOTE: Can only be set if type is object. NOTE: AdditionalProperties is mutually exclusive with Properties. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "default": {
+                        "description": "Default is the default value of the variable. NOTE: Can be set for all types.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "description": {
+                        "description": "Description is a human-readable description of this variable.",
+                        "type": "string"
+                      },
+                      "enum": {
+                        "description": "Enum is the list of valid values of the variable. NOTE: Can be set for all types.",
+                        "items": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "type": "array"
+                      },
+                      "example": {
+                        "description": "Example is an example for this variable.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "exclusiveMaximum": {
+                        "description": "ExclusiveMaximum specifies if the Maximum is exclusive. NOTE: Can only be set if type is integer or number.",
+                        "type": "boolean"
+                      },
+                      "exclusiveMinimum": {
+                        "description": "ExclusiveMinimum specifies if the Minimum is exclusive. NOTE: Can only be set if type is integer or number.",
+                        "type": "boolean"
+                      },
+                      "format": {
+                        "description": "Format is an OpenAPI v3 format string. Unknown formats are ignored. For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using) https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go NOTE: Can only be set if type is string.",
+                        "type": "string"
+                      },
+                      "items": {
+                        "description": "Items specifies fields of an array. NOTE: Can only be set if type is array. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "maxItems": {
+                        "description": "MaxItems is the max length of an array variable. NOTE: Can only be set if type is array.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "maxLength": {
+                        "description": "MaxLength is the max length of a string variable. NOTE: Can only be set if type is string.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "maximum": {
+                        "description": "Maximum is the maximum of an integer or number variable. If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum. If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum. NOTE: Can only be set if type is integer or number.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "minItems": {
+                        "description": "MinItems is the min length of an array variable. NOTE: Can only be set if type is array.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "minLength": {
+                        "description": "MinLength is the min length of a string variable. NOTE: Can only be set if type is string.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "minimum": {
+                        "description": "Minimum is the minimum of an integer or number variable. If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum. If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum. NOTE: Can only be set if type is integer or number.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "pattern": {
+                        "description": "Pattern is the regex which a string variable must match. NOTE: Can only be set if type is string.",
+                        "type": "string"
+                      },
+                      "properties": {
+                        "description": "Properties specifies fields of an object. NOTE: Can only be set if type is object. NOTE: Properties is mutually exclusive with AdditionalProperties. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "required": {
+                        "description": "Required specifies which fields of an object are required. NOTE: Can only be set if type is object.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "type": {
+                        "description": "Type is the type of the variable. Valid values are: object, array, string, integer, number or boolean.",
+                        "type": "string"
+                      },
+                      "uniqueItems": {
+                        "description": "UniqueItems specifies if items in an array must be unique. NOTE: Can only be set if type is array.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "openAPIV3Schema"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name",
+              "required",
+              "schema"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "workers": {
+          "description": "Workers describes the worker nodes for the cluster. It is a collection of node types which can be used to create the worker nodes of the cluster.",
+          "properties": {
+            "machineDeployments": {
+              "description": "MachineDeployments is a list of machine deployment classes that can be used to create a set of worker nodes.",
+              "items": {
+                "description": "MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster provisioned using the `ClusterClass`.",
+                "properties": {
+                  "class": {
+                    "description": "Class denotes a type of worker node present in the cluster, this name MUST be unique within a ClusterClass and can be referenced in the Cluster to create a managed MachineDeployment.",
+                    "type": "string"
+                  },
+                  "machineHealthCheck": {
+                    "description": "MachineHealthCheck defines a MachineHealthCheck for this MachineDeploymentClass.",
+                    "properties": {
+                      "maxUnhealthy": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "nodeStartupTimeout": {
+                        "description": "Machines older than this duration without a node will be considered to have failed and will be remediated. If you wish to disable this feature, set the value explicitly to 0.",
+                        "type": "string"
+                      },
+                      "remediationTemplate": {
+                        "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                            "type": "string"
+                          },
+                          "resourceVersion": {
+                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                          },
+                          "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "unhealthyConditions": {
+                        "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy. The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+                        "items": {
+                          "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+                          "properties": {
+                            "status": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "timeout": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "timeout",
+                            "type"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "unhealthyRange": {
+                        "description": "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "template": {
+                    "description": "Template is a local struct containing a collection of templates for creation of MachineDeployment objects representing a set of worker nodes.",
+                    "properties": {
+                      "bootstrap": {
+                        "description": "Bootstrap contains the bootstrap template reference to be used for the creation of worker Machines.",
+                        "properties": {
+                          "ref": {
+                            "description": "Ref is a required reference to a custom resource offered by a provider.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "API version of the referent.",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                "type": "string"
+                              },
+                              "resourceVersion": {
+                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "ref"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "infrastructure": {
+                        "description": "Infrastructure contains the infrastructure template reference to be used for the creation of worker Machines.",
+                        "properties": {
+                          "ref": {
+                            "description": "Ref is a required reference to a custom resource offered by a provider.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "API version of the referent.",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                "type": "string"
+                              },
+                              "resourceVersion": {
+                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "ref"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "metadata": {
+                        "description": "Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the topology.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "bootstrap",
+                      "infrastructure"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "class",
+                  "template"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/clusterissuer_v1.json
+++ b/anywhere.eks.amazonaws.com/clusterissuer_v1.json
@@ -1,0 +1,1794 @@
+{
+  "description": "A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Desired state of the ClusterIssuer resource.",
+      "properties": {
+        "acme": {
+          "description": "ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.",
+          "properties": {
+            "disableAccountKeyGeneration": {
+              "description": "Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.",
+              "type": "boolean"
+            },
+            "email": {
+              "description": "Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.",
+              "type": "string"
+            },
+            "enableDurationFeature": {
+              "description": "Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.",
+              "type": "boolean"
+            },
+            "externalAccountBinding": {
+              "description": "ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.",
+              "properties": {
+                "keyAlgorithm": {
+                  "description": "Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512"
+                  ],
+                  "type": "string"
+                },
+                "keyID": {
+                  "description": "keyID is the ID of the CA key that the External Account is bound to.",
+                  "type": "string"
+                },
+                "keySecretRef": {
+                  "description": "keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "keyID",
+                "keySecretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "preferredChain": {
+              "description": "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN",
+              "maxLength": 64,
+              "type": "string"
+            },
+            "privateKeySecretRef": {
+              "description": "PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.",
+              "properties": {
+                "key": {
+                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "server": {
+              "description": "Server is the URL used to access the ACME server's 'directory' endpoint. For example, for Let's Encrypt's staging endpoint, you would use: \"https://acme-staging-v02.api.letsencrypt.org/directory\". Only ACME v2 endpoints (i.e. RFC 8555) are supported.",
+              "type": "string"
+            },
+            "skipTLSVerify": {
+              "description": "Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.",
+              "type": "boolean"
+            },
+            "solvers": {
+              "description": "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+              "items": {
+                "description": "An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.",
+                "properties": {
+                  "dns01": {
+                    "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                    "properties": {
+                      "acmeDNS": {
+                        "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                        "properties": {
+                          "accountSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "host": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "accountSecretRef",
+                          "host"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "akamai": {
+                        "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
+                        "properties": {
+                          "accessTokenSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientSecretSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientTokenSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceConsumerDomain": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "accessTokenSecretRef",
+                          "clientSecretSecretRef",
+                          "clientTokenSecretRef",
+                          "serviceConsumerDomain"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureDNS": {
+                        "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                        "properties": {
+                          "clientID": {
+                            "description": "if both this and ClientSecret are left unset MSI will be used",
+                            "type": "string"
+                          },
+                          "clientSecretSecretRef": {
+                            "description": "if both this and ClientID are left unset MSI will be used",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "environment": {
+                            "description": "name of the Azure environment (default AzurePublicCloud)",
+                            "enum": [
+                              "AzurePublicCloud",
+                              "AzureChinaCloud",
+                              "AzureGermanCloud",
+                              "AzureUSGovernmentCloud"
+                            ],
+                            "type": "string"
+                          },
+                          "hostedZoneName": {
+                            "description": "name of the DNS zone that should be used",
+                            "type": "string"
+                          },
+                          "managedIdentity": {
+                            "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                            "properties": {
+                              "clientID": {
+                                "description": "client ID of the managed identity, can not be used at the same time as resourceID",
+                                "type": "string"
+                              },
+                              "resourceID": {
+                                "description": "resource ID of the managed identity, can not be used at the same time as clientID",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resourceGroupName": {
+                            "description": "resource group the DNS zone is located in",
+                            "type": "string"
+                          },
+                          "subscriptionID": {
+                            "description": "ID of the Azure subscription",
+                            "type": "string"
+                          },
+                          "tenantID": {
+                            "description": "when specifying ClientID and ClientSecret then this field is also needed",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resourceGroupName",
+                          "subscriptionID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cloudDNS": {
+                        "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                        "properties": {
+                          "hostedZoneName": {
+                            "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
+                            "type": "string"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "serviceAccountSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cloudflare": {
+                        "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                        "properties": {
+                          "apiKeySecretRef": {
+                            "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "apiTokenSecretRef": {
+                            "description": "API token used to authenticate with Cloudflare.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "email": {
+                            "description": "Email of the account, only required when using API key based authentication.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cnameStrategy": {
+                        "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                        "enum": [
+                          "None",
+                          "Follow"
+                        ],
+                        "type": "string"
+                      },
+                      "digitalocean": {
+                        "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                        "properties": {
+                          "tokenSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "tokenSecretRef"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rfc2136": {
+                        "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                        "properties": {
+                          "nameserver": {
+                            "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1])\u00a0; port is optional. This field is required.",
+                            "type": "string"
+                          },
+                          "tsigAlgorithm": {
+                            "description": "The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.",
+                            "type": "string"
+                          },
+                          "tsigKeyName": {
+                            "description": "The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.",
+                            "type": "string"
+                          },
+                          "tsigSecretSecretRef": {
+                            "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "nameserver"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "route53": {
+                        "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                        "properties": {
+                          "accessKeyID": {
+                            "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "type": "string"
+                          },
+                          "accessKeyIDSecretRef": {
+                            "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "hostedZoneID": {
+                            "description": "If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.",
+                            "type": "string"
+                          },
+                          "region": {
+                            "description": "Always set the region when using AccessKeyID and SecretAccessKey",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata",
+                            "type": "string"
+                          },
+                          "secretAccessKeySecretRef": {
+                            "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "region"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "webhook": {
+                        "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                        "properties": {
+                          "config": {
+                            "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "groupName": {
+                            "description": "The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.",
+                            "type": "string"
+                          },
+                          "solverName": {
+                            "description": "The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "groupName",
+                          "solverName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "http01": {
+                    "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                    "properties": {
+                      "gatewayHTTPRoute": {
+                        "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                        "properties": {
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                            "type": "object"
+                          },
+                          "parentRefs": {
+                            "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                            "items": {
+                              "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
+                              "properties": {
+                                "group": {
+                                  "default": "gateway.networking.k8s.io",
+                                  "description": "Group is the group of the referent. \n Support: Core",
+                                  "maxLength": 253,
+                                  "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "default": "Gateway",
+                                  "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
+                                  "maxLength": 63,
+                                  "minLength": 1,
+                                  "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the referent. \n Support: Core",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
+                                  "maxLength": 63,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                  "type": "string"
+                                },
+                                "sectionName": {
+                                  "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "serviceType": {
+                            "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ingress": {
+                        "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                        "properties": {
+                          "class": {
+                            "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
+                            "type": "string"
+                          },
+                          "ingressTemplate": {
+                            "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                            "properties": {
+                              "metadata": {
+                                "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "description": "The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.",
+                            "type": "string"
+                          },
+                          "podTemplate": {
+                            "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                            "properties": {
+                              "metadata": {
+                                "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spec": {
+                                "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                "properties": {
+                                  "affinity": {
+                                    "description": "If specified, the pod's scheduling constraints",
+                                    "properties": {
+                                      "nodeAffinity": {
+                                        "description": "Describes node affinity scheduling rules for the pod.",
+                                        "properties": {
+                                          "preferredDuringSchedulingIgnoredDuringExecution": {
+                                            "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                            "items": {
+                                              "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                              "properties": {
+                                                "preference": {
+                                                  "description": "A node selector term, associated with the corresponding weight.",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "A list of node selector requirements by node's labels.",
+                                                      "items": {
+                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "The label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchFields": {
+                                                      "description": "A list of node selector requirements by node's fields.",
+                                                      "items": {
+                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "The label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "weight": {
+                                                  "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "required": [
+                                                "preference",
+                                                "weight"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "requiredDuringSchedulingIgnoredDuringExecution": {
+                                            "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                            "properties": {
+                                              "nodeSelectorTerms": {
+                                                "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                "items": {
+                                                  "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "A list of node selector requirements by node's labels.",
+                                                      "items": {
+                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "The label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchFields": {
+                                                      "description": "A list of node selector requirements by node's fields.",
+                                                      "items": {
+                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "The label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "required": [
+                                              "nodeSelectorTerms"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "podAffinity": {
+                                        "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                        "properties": {
+                                          "preferredDuringSchedulingIgnoredDuringExecution": {
+                                            "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                            "items": {
+                                              "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                              "properties": {
+                                                "podAffinityTerm": {
+                                                  "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                  "properties": {
+                                                    "labelSelector": {
+                                                      "description": "A label query over a set of resources, in this case pods.",
+                                                      "properties": {
+                                                        "matchExpressions": {
+                                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                              "key": {
+                                                                "description": "key is the label key that the selector applies to.",
+                                                                "type": "string"
+                                                              },
+                                                              "operator": {
+                                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                "type": "string"
+                                                              },
+                                                              "values": {
+                                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "matchLabels": {
+                                                          "additionalProperties": {
+                                                            "type": "string"
+                                                          },
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "namespaceSelector": {
+                                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                      "properties": {
+                                                        "matchExpressions": {
+                                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                              "key": {
+                                                                "description": "key is the label key that the selector applies to.",
+                                                                "type": "string"
+                                                              },
+                                                              "operator": {
+                                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                "type": "string"
+                                                              },
+                                                              "values": {
+                                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "matchLabels": {
+                                                          "additionalProperties": {
+                                                            "type": "string"
+                                                          },
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "namespaces": {
+                                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "topologyKey": {
+                                                      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "topologyKey"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "weight": {
+                                                  "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "required": [
+                                                "podAffinityTerm",
+                                                "weight"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "requiredDuringSchedulingIgnoredDuringExecution": {
+                                            "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                            "items": {
+                                              "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "description": "A label query over a set of resources, in this case pods.",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "namespaceSelector": {
+                                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "namespaces": {
+                                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "topologyKey": {
+                                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "topologyKey"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "podAntiAffinity": {
+                                        "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                        "properties": {
+                                          "preferredDuringSchedulingIgnoredDuringExecution": {
+                                            "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                            "items": {
+                                              "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                              "properties": {
+                                                "podAffinityTerm": {
+                                                  "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                  "properties": {
+                                                    "labelSelector": {
+                                                      "description": "A label query over a set of resources, in this case pods.",
+                                                      "properties": {
+                                                        "matchExpressions": {
+                                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                              "key": {
+                                                                "description": "key is the label key that the selector applies to.",
+                                                                "type": "string"
+                                                              },
+                                                              "operator": {
+                                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                "type": "string"
+                                                              },
+                                                              "values": {
+                                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "matchLabels": {
+                                                          "additionalProperties": {
+                                                            "type": "string"
+                                                          },
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "namespaceSelector": {
+                                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                      "properties": {
+                                                        "matchExpressions": {
+                                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                              "key": {
+                                                                "description": "key is the label key that the selector applies to.",
+                                                                "type": "string"
+                                                              },
+                                                              "operator": {
+                                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                "type": "string"
+                                                              },
+                                                              "values": {
+                                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "matchLabels": {
+                                                          "additionalProperties": {
+                                                            "type": "string"
+                                                          },
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "namespaces": {
+                                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "topologyKey": {
+                                                      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "topologyKey"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "weight": {
+                                                  "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "required": [
+                                                "podAffinityTerm",
+                                                "weight"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "requiredDuringSchedulingIgnoredDuringExecution": {
+                                            "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                            "items": {
+                                              "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "description": "A label query over a set of resources, in this case pods.",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "namespaceSelector": {
+                                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "namespaces": {
+                                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "topologyKey": {
+                                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "topologyKey"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "nodeSelector": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                    "type": "object"
+                                  },
+                                  "priorityClassName": {
+                                    "description": "If specified, the pod's priorityClassName.",
+                                    "type": "string"
+                                  },
+                                  "serviceAccountName": {
+                                    "description": "If specified, the pod's service account",
+                                    "type": "string"
+                                  },
+                                  "tolerations": {
+                                    "description": "If specified, the pod's tolerations.",
+                                    "items": {
+                                      "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                      "properties": {
+                                        "effect": {
+                                          "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                          "type": "string"
+                                        },
+                                        "key": {
+                                          "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                          "type": "string"
+                                        },
+                                        "tolerationSeconds": {
+                                          "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                          "format": "int64",
+                                          "type": "integer"
+                                        },
+                                        "value": {
+                                          "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceType": {
+                            "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "selector": {
+                    "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                    "properties": {
+                      "dnsNames": {
+                        "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "dnsZones": {
+                        "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "privateKeySecretRef",
+            "server"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ca": {
+          "description": "CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.",
+          "properties": {
+            "crlDistributionPoints": {
+              "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ocspServers": {
+              "description": "The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \"http://ocsp.int-x3.letsencrypt.org\".",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secretName": {
+              "description": "SecretName is the name of the secret used to sign Certificates issued by this Issuer.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "secretName"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selfSigned": {
+          "description": "SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.",
+          "properties": {
+            "crlDistributionPoints": {
+              "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "vault": {
+          "description": "Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.",
+          "properties": {
+            "auth": {
+              "description": "Auth configures how cert-manager authenticates with the Vault server.",
+              "properties": {
+                "appRole": {
+                  "description": "AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.",
+                  "properties": {
+                    "path": {
+                      "description": "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
+                      "type": "string"
+                    },
+                    "roleId": {
+                      "description": "RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "roleId",
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "kubernetes": {
+                  "description": "Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.",
+                  "properties": {
+                    "mountPath": {
+                      "description": "The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \"/v1/auth/kubernetes\" will be used.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "role",
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tokenSecretRef": {
+                  "description": "TokenSecretRef authenticates with Vault by presenting a token.",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "caBundle": {
+              "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.",
+              "format": "byte",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
+              "type": "string"
+            },
+            "path": {
+              "description": "Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g: \"my_pki_mount/sign/my-role-name\".",
+              "type": "string"
+            },
+            "server": {
+              "description": "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
+              "type": "string"
+            }
+          },
+          "required": [
+            "auth",
+            "path",
+            "server"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "venafi": {
+          "description": "Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.",
+          "properties": {
+            "cloud": {
+              "description": "Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.",
+              "properties": {
+                "apiTokenSecretRef": {
+                  "description": "APITokenSecretRef is a secret key selector for the Venafi Cloud API token.",
+                  "properties": {
+                    "key": {
+                      "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "description": "URL is the base URL for Venafi Cloud. Defaults to \"https://api.venafi.cloud/v1\".",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "apiTokenSecretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tpp": {
+              "description": "TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.",
+              "properties": {
+                "caBundle": {
+                  "description": "CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.",
+                  "format": "byte",
+                  "type": "string"
+                },
+                "credentialsRef": {
+                  "description": "CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "description": "URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: \"https://tpp.example.com/vedsdk\".",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "credentialsRef",
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "zone": {
+              "description": "Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "zone"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status of the ClusterIssuer. This is set and managed automatically.",
+      "properties": {
+        "acme": {
+          "description": "ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.",
+          "properties": {
+            "lastRegisteredEmail": {
+              "description": "LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer",
+              "type": "string"
+            },
+            "uri": {
+              "description": "URI is the unique account identifier, which can also be used to retrieve account details from the CA",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.",
+          "items": {
+            "description": "IssuerCondition contains condition information for an Issuer.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of the condition, known values are (`Ready`).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/clusterresourceset_v1alpha3.json
+++ b/anywhere.eks.amazonaws.com/clusterresourceset_v1alpha3.json
@@ -1,0 +1,158 @@
+{
+  "description": "ClusterResourceSet is the Schema for the clusterresourcesets API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetSpec defines the desired state of ClusterResourceSet.",
+      "properties": {
+        "clusterSelector": {
+          "description": "Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.",
+          "items": {
+            "description": "ResourceRef specifies a resource.",
+            "properties": {
+              "kind": {
+                "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                "enum": [
+                  "Secret",
+                  "ConfigMap"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "strategy": {
+          "description": "Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.",
+          "enum": [
+            "ApplyOnce"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "clusterSelector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterResourceSetStatus defines the observed state of ClusterResourceSet.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the ClusterResourceSet.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/clusterresourceset_v1alpha4.json
+++ b/anywhere.eks.amazonaws.com/clusterresourceset_v1alpha4.json
@@ -1,0 +1,158 @@
+{
+  "description": "ClusterResourceSet is the Schema for the clusterresourcesets API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetSpec defines the desired state of ClusterResourceSet.",
+      "properties": {
+        "clusterSelector": {
+          "description": "Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable. Label selector cannot be empty.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.",
+          "items": {
+            "description": "ResourceRef specifies a resource.",
+            "properties": {
+              "kind": {
+                "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                "enum": [
+                  "Secret",
+                  "ConfigMap"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "strategy": {
+          "description": "Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.",
+          "enum": [
+            "ApplyOnce"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "clusterSelector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterResourceSetStatus defines the observed state of ClusterResourceSet.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the ClusterResourceSet.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/clusterresourceset_v1beta1.json
+++ b/anywhere.eks.amazonaws.com/clusterresourceset_v1beta1.json
@@ -1,0 +1,160 @@
+{
+  "description": "ClusterResourceSet is the Schema for the clusterresourcesets API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetSpec defines the desired state of ClusterResourceSet.",
+      "properties": {
+        "clusterSelector": {
+          "description": "Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable. Label selector cannot be empty.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.",
+          "items": {
+            "description": "ResourceRef specifies a resource.",
+            "properties": {
+              "kind": {
+                "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                "enum": [
+                  "Secret",
+                  "ConfigMap"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "strategy": {
+          "description": "Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.",
+          "enum": [
+            "ApplyOnce",
+            "Reconcile"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "clusterSelector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterResourceSetStatus defines the observed state of ClusterResourceSet.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the ClusterResourceSet.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/clusterresourcesetbinding_v1alpha3.json
+++ b/anywhere.eks.amazonaws.com/clusterresourcesetbinding_v1alpha3.json
@@ -1,0 +1,84 @@
+{
+  "description": "ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.",
+      "properties": {
+        "bindings": {
+          "description": "Bindings is a list of ClusterResourceSets and their resources.",
+          "items": {
+            "description": "ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.",
+            "properties": {
+              "clusterResourceSetName": {
+                "description": "ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.",
+                "type": "string"
+              },
+              "resources": {
+                "description": "Resources is a list of resources that the ClusterResourceSet has.",
+                "items": {
+                  "description": "ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.",
+                  "properties": {
+                    "applied": {
+                      "description": "Applied is to track if a resource is applied to the cluster or not.",
+                      "type": "boolean"
+                    },
+                    "hash": {
+                      "description": "Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For \"ApplyOnce\" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    },
+                    "lastAppliedTime": {
+                      "description": "LastAppliedTime identifies when this resource was last applied to the cluster.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "applied",
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "clusterResourceSetName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/clusterresourcesetbinding_v1alpha4.json
+++ b/anywhere.eks.amazonaws.com/clusterresourcesetbinding_v1alpha4.json
@@ -1,0 +1,84 @@
+{
+  "description": "ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.",
+      "properties": {
+        "bindings": {
+          "description": "Bindings is a list of ClusterResourceSets and their resources.",
+          "items": {
+            "description": "ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.",
+            "properties": {
+              "clusterResourceSetName": {
+                "description": "ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.",
+                "type": "string"
+              },
+              "resources": {
+                "description": "Resources is a list of resources that the ClusterResourceSet has.",
+                "items": {
+                  "description": "ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.",
+                  "properties": {
+                    "applied": {
+                      "description": "Applied is to track if a resource is applied to the cluster or not.",
+                      "type": "boolean"
+                    },
+                    "hash": {
+                      "description": "Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For \"ApplyOnce\" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    },
+                    "lastAppliedTime": {
+                      "description": "LastAppliedTime identifies when this resource was last applied to the cluster.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "applied",
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "clusterResourceSetName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/clusterresourcesetbinding_v1beta1.json
+++ b/anywhere.eks.amazonaws.com/clusterresourcesetbinding_v1beta1.json
@@ -1,0 +1,84 @@
+{
+  "description": "ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.",
+      "properties": {
+        "bindings": {
+          "description": "Bindings is a list of ClusterResourceSets and their resources.",
+          "items": {
+            "description": "ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.",
+            "properties": {
+              "clusterResourceSetName": {
+                "description": "ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.",
+                "type": "string"
+              },
+              "resources": {
+                "description": "Resources is a list of resources that the ClusterResourceSet has.",
+                "items": {
+                  "description": "ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.",
+                  "properties": {
+                    "applied": {
+                      "description": "Applied is to track if a resource is applied to the cluster or not.",
+                      "type": "boolean"
+                    },
+                    "hash": {
+                      "description": "Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For \"ApplyOnce\" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    },
+                    "lastAppliedTime": {
+                      "description": "LastAppliedTime identifies when this resource was last applied to the cluster.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "applied",
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "clusterResourceSetName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockercluster_v1alpha3.json
+++ b/anywhere.eks.amazonaws.com/dockercluster_v1alpha3.json
@@ -1,0 +1,141 @@
+{
+  "description": "DockerCluster is the Schema for the dockerclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "Host is the hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port is the port on which the API server is serving.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains are not usulaly defined on the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerClusterStatus defines the observed state of DockerCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API will use this if we populate it.",
+          "type": "object"
+        },
+        "ready": {
+          "description": "Ready denotes that the docker cluster (infrastructure) is ready.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockercluster_v1alpha4.json
+++ b/anywhere.eks.amazonaws.com/dockercluster_v1alpha4.json
@@ -1,0 +1,156 @@
+{
+  "description": "DockerCluster is the Schema for the dockerclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "Host is the hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port is the port on which the API server is serving.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains are not usulaly defined on the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+          "type": "object"
+        },
+        "loadBalancer": {
+          "description": "LoadBalancer allows defining configurations for the cluster load balancer.",
+          "properties": {
+            "imageRepository": {
+              "description": "ImageRepository sets the container registry to pull the haproxy image from. if not set, \"kindest\" will be used instead.",
+              "type": "string"
+            },
+            "imageTag": {
+              "description": "ImageTag allows to specify a tag for the haproxy image. if not set, \"v20210715-a6da3463\" will be used instead.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerClusterStatus defines the observed state of DockerCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API will use this if we populate it.",
+          "type": "object"
+        },
+        "ready": {
+          "description": "Ready denotes that the docker cluster (infrastructure) is ready.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockercluster_v1beta1.json
+++ b/anywhere.eks.amazonaws.com/dockercluster_v1beta1.json
@@ -1,0 +1,154 @@
+{
+  "description": "DockerCluster is the Schema for the dockerclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "Host is the hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port is the port on which the API server is serving.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains are usually not defined in the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+          "type": "object"
+        },
+        "loadBalancer": {
+          "description": "LoadBalancer allows defining configurations for the cluster load balancer.",
+          "properties": {
+            "imageRepository": {
+              "description": "ImageRepository sets the container registry to pull the haproxy image from. if not set, \"kindest\" will be used instead.",
+              "type": "string"
+            },
+            "imageTag": {
+              "description": "ImageTag allows to specify a tag for the haproxy image. if not set, \"v20210715-a6da3463\" will be used instead.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerClusterStatus defines the observed state of DockerCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API will use this if we populate it.",
+          "type": "object"
+        },
+        "ready": {
+          "description": "Ready denotes that the docker cluster (infrastructure) is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockerclustertemplate_v1alpha4.json
+++ b/anywhere.eks.amazonaws.com/dockerclustertemplate_v1alpha4.json
@@ -1,0 +1,100 @@
+{
+  "description": "DockerClusterTemplate is the Schema for the dockerclustertemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterTemplateSpec defines the desired state of DockerClusterTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerClusterTemplateResource describes the data needed to create a DockerCluster from a template.",
+          "properties": {
+            "spec": {
+              "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+              "properties": {
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+                  "properties": {
+                    "host": {
+                      "description": "Host is the hostname on which the API server is serving.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port is the port on which the API server is serving.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "host",
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureDomains": {
+                  "additionalProperties": {
+                    "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+                    "properties": {
+                      "attributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                        "type": "object"
+                      },
+                      "controlPlane": {
+                        "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "description": "FailureDomains are not usulaly defined on the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+                  "type": "object"
+                },
+                "loadBalancer": {
+                  "description": "LoadBalancer allows defining configurations for the cluster load balancer.",
+                  "properties": {
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull the haproxy image from. if not set, \"kindest\" will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the haproxy image. if not set, \"v20210715-a6da3463\" will be used instead.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockerclustertemplate_v1beta1.json
+++ b/anywhere.eks.amazonaws.com/dockerclustertemplate_v1beta1.json
@@ -1,0 +1,121 @@
+{
+  "description": "DockerClusterTemplate is the Schema for the dockerclustertemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterTemplateSpec defines the desired state of DockerClusterTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerClusterTemplateResource describes the data needed to create a DockerCluster from a template.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+              "properties": {
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+                  "properties": {
+                    "host": {
+                      "description": "Host is the hostname on which the API server is serving.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port is the port on which the API server is serving.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "host",
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureDomains": {
+                  "additionalProperties": {
+                    "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+                    "properties": {
+                      "attributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                        "type": "object"
+                      },
+                      "controlPlane": {
+                        "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "description": "FailureDomains are usually not defined in the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+                  "type": "object"
+                },
+                "loadBalancer": {
+                  "description": "LoadBalancer allows defining configurations for the cluster load balancer.",
+                  "properties": {
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull the haproxy image from. if not set, \"kindest\" will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the haproxy image. if not set, \"v20210715-a6da3463\" will be used instead.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockerdatacenterconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/dockerdatacenterconfig_v1alpha1.json
@@ -1,0 +1,25 @@
+{
+  "description": "DockerDatacenterConfig is the Schema for the DockerDatacenterConfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerDatacenterConfigSpec defines the desired state of DockerDatacenterConfig.",
+      "type": "object"
+    },
+    "status": {
+      "description": "DockerDatacenterConfigStatus defines the observed state of DockerDatacenterConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockermachine_v1alpha3.json
+++ b/anywhere.eks.amazonaws.com/dockermachine_v1alpha3.json
@@ -1,0 +1,144 @@
+{
+  "description": "DockerMachine is the Schema for the dockermachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineSpec defines the desired state of DockerMachine.",
+      "properties": {
+        "bootstrapped": {
+          "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+          "type": "boolean"
+        },
+        "customImage": {
+          "description": "CustomImage allows customizing the container image that is used for running the machine",
+          "type": "string"
+        },
+        "extraMounts": {
+          "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+          "items": {
+            "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+            "properties": {
+              "containerPath": {
+                "description": "Path of the mount within the container.",
+                "type": "string"
+              },
+              "hostPath": {
+                "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "If set, the mount is read-only.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "preLoadImages": {
+          "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachineStatus defines the observed state of DockerMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the associated addresses for the docker machine.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "loadBalancerConfigured": {
+          "description": "LoadBalancerConfigured denotes that the machine has been added to the load balancer",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine (docker container) is ready",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockermachine_v1alpha4.json
+++ b/anywhere.eks.amazonaws.com/dockermachine_v1alpha4.json
@@ -1,0 +1,144 @@
+{
+  "description": "DockerMachine is the Schema for the dockermachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineSpec defines the desired state of DockerMachine.",
+      "properties": {
+        "bootstrapped": {
+          "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+          "type": "boolean"
+        },
+        "customImage": {
+          "description": "CustomImage allows customizing the container image that is used for running the machine",
+          "type": "string"
+        },
+        "extraMounts": {
+          "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+          "items": {
+            "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+            "properties": {
+              "containerPath": {
+                "description": "Path of the mount within the container.",
+                "type": "string"
+              },
+              "hostPath": {
+                "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "If set, the mount is read-only.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "preLoadImages": {
+          "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachineStatus defines the observed state of DockerMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the associated addresses for the docker machine.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "loadBalancerConfigured": {
+          "description": "LoadBalancerConfigured denotes that the machine has been added to the load balancer",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine (docker container) is ready",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockermachine_v1beta1.json
+++ b/anywhere.eks.amazonaws.com/dockermachine_v1beta1.json
@@ -1,0 +1,145 @@
+{
+  "description": "DockerMachine is the Schema for the dockermachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineSpec defines the desired state of DockerMachine.",
+      "properties": {
+        "bootstrapped": {
+          "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+          "type": "boolean"
+        },
+        "customImage": {
+          "description": "CustomImage allows customizing the container image that is used for running the machine",
+          "type": "string"
+        },
+        "extraMounts": {
+          "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+          "items": {
+            "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+            "properties": {
+              "containerPath": {
+                "description": "Path of the mount within the container.",
+                "type": "string"
+              },
+              "hostPath": {
+                "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "If set, the mount is read-only.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "preLoadImages": {
+          "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachineStatus defines the observed state of DockerMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the associated addresses for the docker machine.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "loadBalancerConfigured": {
+          "description": "LoadBalancerConfigured denotes that the machine has been added to the load balancer",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine (docker container) is ready",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockermachinepool_v1alpha3.json
+++ b/anywhere.eks.amazonaws.com/dockermachinepool_v1alpha3.json
@@ -1,0 +1,191 @@
+{
+  "description": "DockerMachinePool is the Schema for the dockermachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachinePoolSpec defines the desired state of DockerMachinePool.",
+      "properties": {
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Machine Pool",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList is the list of identification IDs of machine instances managed by this Machine Pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "template": {
+          "description": "Template contains the details used to build a replica machine within the Machine Pool",
+          "properties": {
+            "customImage": {
+              "description": "CustomImage allows customizing the container image that is used for running the machine",
+              "type": "string"
+            },
+            "extraMounts": {
+              "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+              "items": {
+                "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                "properties": {
+                  "containerPath": {
+                    "description": "Path of the mount within the container.",
+                    "type": "string"
+                  },
+                  "hostPath": {
+                    "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "If set, the mount is read-only.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "preLoadImages": {
+              "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachinePoolStatus defines the observed state of DockerMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "DockerMachinePoolInstanceStatus contains status information about a DockerMachinePool.",
+            "properties": {
+              "addresses": {
+                "description": "Addresses contains the associated addresses for the docker machine.",
+                "items": {
+                  "description": "MachineAddress contains information for the node's address.",
+                  "properties": {
+                    "address": {
+                      "description": "The machine address.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "bootstrapped": {
+                "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                "type": "boolean"
+              },
+              "instanceName": {
+                "description": "InstanceName is the identification of the Machine Instance within the Machine Pool",
+                "type": "string"
+              },
+              "providerID": {
+                "description": "ProviderID is the provider identification of the Machine Pool Instance",
+                "type": "string"
+              },
+              "ready": {
+                "description": "Ready denotes that the machine (docker container) is ready",
+                "type": "boolean"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine pool is ready",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockermachinepool_v1alpha4.json
+++ b/anywhere.eks.amazonaws.com/dockermachinepool_v1alpha4.json
@@ -1,0 +1,191 @@
+{
+  "description": "DockerMachinePool is the Schema for the dockermachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachinePoolSpec defines the desired state of DockerMachinePool.",
+      "properties": {
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Machine Pool",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList is the list of identification IDs of machine instances managed by this Machine Pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "template": {
+          "description": "Template contains the details used to build a replica machine within the Machine Pool",
+          "properties": {
+            "customImage": {
+              "description": "CustomImage allows customizing the container image that is used for running the machine",
+              "type": "string"
+            },
+            "extraMounts": {
+              "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+              "items": {
+                "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                "properties": {
+                  "containerPath": {
+                    "description": "Path of the mount within the container.",
+                    "type": "string"
+                  },
+                  "hostPath": {
+                    "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "If set, the mount is read-only.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "preLoadImages": {
+              "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachinePoolStatus defines the observed state of DockerMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "DockerMachinePoolInstanceStatus contains status information about a DockerMachinePool.",
+            "properties": {
+              "addresses": {
+                "description": "Addresses contains the associated addresses for the docker machine.",
+                "items": {
+                  "description": "MachineAddress contains information for the node's address.",
+                  "properties": {
+                    "address": {
+                      "description": "The machine address.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "bootstrapped": {
+                "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                "type": "boolean"
+              },
+              "instanceName": {
+                "description": "InstanceName is the identification of the Machine Instance within the Machine Pool",
+                "type": "string"
+              },
+              "providerID": {
+                "description": "ProviderID is the provider identification of the Machine Pool Instance",
+                "type": "string"
+              },
+              "ready": {
+                "description": "Ready denotes that the machine (docker container) is ready",
+                "type": "boolean"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine pool is ready",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockermachinepool_v1beta1.json
+++ b/anywhere.eks.amazonaws.com/dockermachinepool_v1beta1.json
@@ -1,0 +1,192 @@
+{
+  "description": "DockerMachinePool is the Schema for the dockermachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachinePoolSpec defines the desired state of DockerMachinePool.",
+      "properties": {
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Machine Pool",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList is the list of identification IDs of machine instances managed by this Machine Pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "template": {
+          "description": "Template contains the details used to build a replica machine within the Machine Pool",
+          "properties": {
+            "customImage": {
+              "description": "CustomImage allows customizing the container image that is used for running the machine",
+              "type": "string"
+            },
+            "extraMounts": {
+              "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+              "items": {
+                "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                "properties": {
+                  "containerPath": {
+                    "description": "Path of the mount within the container.",
+                    "type": "string"
+                  },
+                  "hostPath": {
+                    "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "If set, the mount is read-only.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "preLoadImages": {
+              "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachinePoolStatus defines the observed state of DockerMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "DockerMachinePoolInstanceStatus contains status information about a DockerMachinePool.",
+            "properties": {
+              "addresses": {
+                "description": "Addresses contains the associated addresses for the docker machine.",
+                "items": {
+                  "description": "MachineAddress contains information for the node's address.",
+                  "properties": {
+                    "address": {
+                      "description": "The machine address.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "bootstrapped": {
+                "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                "type": "boolean"
+              },
+              "instanceName": {
+                "description": "InstanceName is the identification of the Machine Instance within the Machine Pool",
+                "type": "string"
+              },
+              "providerID": {
+                "description": "ProviderID is the provider identification of the Machine Pool Instance",
+                "type": "string"
+              },
+              "ready": {
+                "description": "Ready denotes that the machine (docker container) is ready",
+                "type": "boolean"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine pool is ready",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockermachinetemplate_v1alpha3.json
+++ b/anywhere.eks.amazonaws.com/dockermachinetemplate_v1alpha3.json
@@ -1,0 +1,86 @@
+{
+  "description": "DockerMachineTemplate is the Schema for the dockermachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template.",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "bootstrapped": {
+                  "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                  "type": "boolean"
+                },
+                "customImage": {
+                  "description": "CustomImage allows customizing the container image that is used for running the machine",
+                  "type": "string"
+                },
+                "extraMounts": {
+                  "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+                  "items": {
+                    "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                    "properties": {
+                      "containerPath": {
+                        "description": "Path of the mount within the container.",
+                        "type": "string"
+                      },
+                      "hostPath": {
+                        "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "If set, the mount is read-only.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "preLoadImages": {
+                  "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockermachinetemplate_v1alpha4.json
+++ b/anywhere.eks.amazonaws.com/dockermachinetemplate_v1alpha4.json
@@ -1,0 +1,86 @@
+{
+  "description": "DockerMachineTemplate is the Schema for the dockermachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template.",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "bootstrapped": {
+                  "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                  "type": "boolean"
+                },
+                "customImage": {
+                  "description": "CustomImage allows customizing the container image that is used for running the machine",
+                  "type": "string"
+                },
+                "extraMounts": {
+                  "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+                  "items": {
+                    "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                    "properties": {
+                      "containerPath": {
+                        "description": "Path of the mount within the container.",
+                        "type": "string"
+                      },
+                      "hostPath": {
+                        "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "If set, the mount is read-only.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "preLoadImages": {
+                  "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/dockermachinetemplate_v1beta1.json
+++ b/anywhere.eks.amazonaws.com/dockermachinetemplate_v1beta1.json
@@ -1,0 +1,107 @@
+{
+  "description": "DockerMachineTemplate is the Schema for the dockermachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "bootstrapped": {
+                  "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                  "type": "boolean"
+                },
+                "customImage": {
+                  "description": "CustomImage allows customizing the container image that is used for running the machine",
+                  "type": "string"
+                },
+                "extraMounts": {
+                  "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+                  "items": {
+                    "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                    "properties": {
+                      "containerPath": {
+                        "description": "Path of the mount within the container.",
+                        "type": "string"
+                      },
+                      "hostPath": {
+                        "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "If set, the mount is read-only.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "preLoadImages": {
+                  "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/fluxconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/fluxconfig_v1alpha1.json
@@ -1,0 +1,82 @@
+{
+  "description": "FluxConfig is the Schema for the fluxconfigs API and defines the configurations of the Flux GitOps Toolkit and Git repository it links to.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FluxConfigSpec defines the desired state of FluxConfig.",
+      "properties": {
+        "branch": {
+          "default": "main",
+          "description": "Git branch. Defaults to main.",
+          "type": "string"
+        },
+        "clusterConfigPath": {
+          "description": "ClusterConfigPath relative to the repository root, when specified the cluster sync will be scoped to this path.",
+          "type": "string"
+        },
+        "git": {
+          "description": "Used to specify Git provider that will be used to host the git files",
+          "properties": {
+            "repositoryUrl": {
+              "description": "Repository URL for the repository to be used with flux. Can be either an SSH or HTTPS url.",
+              "type": "string"
+            },
+            "sshKeyAlgorithm": {
+              "description": "SSH public key algorithm for the private key specified (rsa, ecdsa, ed25519) (default ecdsa)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repositoryUrl"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "github": {
+          "description": "Used to specify Github provider to host the Git repo and host the git files",
+          "properties": {
+            "owner": {
+              "description": "Owner is the user or organization name of the Git provider.",
+              "type": "string"
+            },
+            "personal": {
+              "description": "if true, the owner is assumed to be a Git user; otherwise an org.",
+              "type": "boolean"
+            },
+            "repository": {
+              "description": "Repository name.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "owner",
+            "repository"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "systemNamespace": {
+          "description": "SystemNamespace scope for this operation. Defaults to flux-system",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FluxConfigStatus defines the observed state of FluxConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/gitopsconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/gitopsconfig_v1alpha1.json
@@ -1,0 +1,70 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "GitOps defines the configurations of GitOps Toolkit and Git repository it links to.",
+      "properties": {
+        "flux": {
+          "description": "Flux defines the Git repository options for Flux v2.",
+          "properties": {
+            "github": {
+              "description": "github is the name of the Git Provider to host the Git repo.",
+              "properties": {
+                "branch": {
+                  "default": "main",
+                  "description": "Git branch. Defaults to main.",
+                  "type": "string"
+                },
+                "clusterConfigPath": {
+                  "description": "ClusterConfigPath relative to the repository root, when specified the cluster sync will be scoped to this path.",
+                  "type": "string"
+                },
+                "fluxSystemNamespace": {
+                  "description": "FluxSystemNamespace scope for this operation. Defaults to flux-system.",
+                  "type": "string"
+                },
+                "owner": {
+                  "description": "Owner is the user or organization name of the Git provider.",
+                  "type": "string"
+                },
+                "personal": {
+                  "description": "if true, the owner is assumed to be a Git user; otherwise an org.",
+                  "type": "boolean"
+                },
+                "repository": {
+                  "description": "Repository name.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "owner",
+                "repository"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "GitOpsConfigStatus defines the observed state of GitOpsConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/nutanixdatacenterconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/nutanixdatacenterconfig_v1alpha1.json
@@ -1,0 +1,49 @@
+{
+  "description": "NutanixDatacenterConfig is the Schema for the NutanixDatacenterConfigs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "NutanixDatacenterConfigSpec defines the desired state of NutanixDatacenterConfig.",
+      "properties": {
+        "additionalTrustBundle": {
+          "description": "AdditionalTrustBundle is the optional PEM-encoded certificate bundle for users that configured their Prism Central with certificates from non-publicly trusted CAs",
+          "type": "string"
+        },
+        "endpoint": {
+          "description": "Endpoint is the Endpoint of Nutanix Prism Central",
+          "type": "string"
+        },
+        "insecure": {
+          "description": "Insecure is the optional flag to skip TLS verification. Nutanix Prism Central installation by default ships with a self-signed certificate that will fail TLS verification because the certificate is not issued by a public CA and does not have the IP SANs with the Prism Central endpoint. To accommodate the scenario where the user has not changed the default Certificate that ships with Prism Central, we allow the user to skip TLS verification. This is not recommended for production use.",
+          "type": "boolean"
+        },
+        "port": {
+          "description": "Port is the Port of Nutanix Prism Central",
+          "minimum": 9440,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "endpoint",
+        "port"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "NutanixDatacenterConfigStatus defines the observed state of NutanixDatacenterConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/nutanixmachineconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/nutanixmachineconfig_v1alpha1.json
@@ -1,0 +1,290 @@
+{
+  "description": "NutanixMachineConfig is the Schema for the nutanix machine configs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "NutanixMachineConfigSpec defines the desired state of NutanixMachineConfig.",
+      "properties": {
+        "cluster": {
+          "description": "cluster is to identify the cluster (the Prism Element under management of the Prism Central), in which the Machine's VM will be created. The cluster identifier (uuid or name) can be obtained from the Prism Central console or using the prism_central API.",
+          "properties": {
+            "name": {
+              "description": "name is the resource name in the PC",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type is the identifier type to use for this resource.",
+              "enum": [
+                "uuid",
+                "name"
+              ],
+              "type": "string"
+            },
+            "uuid": {
+              "description": "uuid is the UUID of the resource in the PC.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "image is to identify the OS image uploaded to the Prism Central (PC) The image identifier (uuid or name) can be obtained from the Prism Central console or using the Prism Central API.",
+          "properties": {
+            "name": {
+              "description": "name is the resource name in the PC",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type is the identifier type to use for this resource.",
+              "enum": [
+                "uuid",
+                "name"
+              ],
+              "type": "string"
+            },
+            "uuid": {
+              "description": "uuid is the UUID of the resource in the PC.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "memorySize": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "memorySize is the memory size (in Quantity format) of the VM The minimum memorySize is 2Gi bytes",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
+        "osFamily": {
+          "type": "string"
+        },
+        "subnet": {
+          "description": "subnet is to identify the cluster's network subnet to use for the Machine's VM The cluster identifier (uuid or name) can be obtained from the Prism Central console or using the Prism Central API.",
+          "properties": {
+            "name": {
+              "description": "name is the resource name in the PC",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type is the identifier type to use for this resource.",
+              "enum": [
+                "uuid",
+                "name"
+              ],
+              "type": "string"
+            },
+            "uuid": {
+              "description": "uuid is the UUID of the resource in the PC.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "systemDiskSize": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "systemDiskSize is size (in Quantity format) of the system disk of the VM The minimum systemDiskSize is 20Gi bytes",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
+        "users": {
+          "items": {
+            "description": "UserConfiguration defines the configuration of the user to be added to the VM.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "sshAuthorizedKeys": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name",
+              "sshAuthorizedKeys"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "vcpuSockets": {
+          "description": "vcpuSockets is the number of vCPU sockets of the VM",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "vcpusPerSocket": {
+          "description": "vcpusPerSocket is the number of vCPUs per socket of the VM",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cluster",
+        "image",
+        "memorySize",
+        "osFamily",
+        "subnet",
+        "systemDiskSize",
+        "vcpuSockets",
+        "vcpusPerSocket"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "NutanixMachineConfigStatus defines the observed state of NutanixMachineConfig.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the Nutanix VM associated addresses. Address type is one of Hostname, ExternalIP, InternalIP, ExternalDNS, InternalDNS",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the NutanixMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "nodeRef": {
+          "description": "NodeRef is a reference to the corresponding workload cluster Node if it exists.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "vmUUID": {
+          "description": "The Nutanix VM's UUID",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/oidcconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/oidcconfig_v1alpha1.json
@@ -1,0 +1,68 @@
+{
+  "description": "OIDCConfig is the Schema for the oidcconfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OIDCConfigSpec defines the desired state of OIDCConfig.",
+      "properties": {
+        "clientId": {
+          "description": "ClientId defines the client ID for the OpenID Connect client",
+          "type": "string"
+        },
+        "groupsClaim": {
+          "description": "GroupsClaim defines the name of a custom OpenID Connect claim for specifying user groups",
+          "type": "string"
+        },
+        "groupsPrefix": {
+          "description": "GroupsPrefix defines a string to be prefixed to all groups to prevent conflicts with other authentication strategies",
+          "type": "string"
+        },
+        "issuerUrl": {
+          "description": "IssuerUrl defines the URL of the OpenID issuer, only HTTPS scheme will be accepted",
+          "type": "string"
+        },
+        "requiredClaims": {
+          "description": "RequiredClaims defines a key=value pair that describes a required claim in the ID Token",
+          "items": {
+            "properties": {
+              "claim": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "usernameClaim": {
+          "description": "UsernameClaim defines the OpenID claim to use as the user name. Note that claims other than the default ('sub') is not guaranteed to be unique and immutable",
+          "type": "string"
+        },
+        "usernamePrefix": {
+          "description": "UsernamePrefix defines a string to prefixed to all usernames. If not provided, username claims other than 'email' are prefixed by the issuer URL to avoid clashes. To skip any prefixing, provide the value '-'.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "OIDCConfigStatus defines the observed state of OIDCConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/snowdatacenterconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/snowdatacenterconfig_v1alpha1.json
@@ -1,0 +1,41 @@
+{
+  "description": "SnowDatacenterConfig is the Schema for the SnowDatacenterConfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "SnowDatacenterConfigSpec defines the desired state of SnowDatacenterConfig.",
+      "properties": {
+        "identityRef": {
+          "description": "IdentityRef is a reference to an identity for the Snow API to be used when reconciling this cluster",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "SnowDatacenterConfigStatus defines the observed state of SnowDatacenterConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/snowippool_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/snowippool_v1alpha1.json
@@ -1,0 +1,61 @@
+{
+  "description": "SnowIPPool is the Schema for the SnowIPPools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "SnowIPPoolSpec defines the desired state of SnowIPPool.",
+      "properties": {
+        "pools": {
+          "description": "IPPools defines a list of ip pool for the DNI.",
+          "items": {
+            "description": "IPPool defines an ip pool with ip range, subnet and gateway.",
+            "properties": {
+              "gateway": {
+                "description": "Gateway is the gateway of the subnet for routing purpose.",
+                "type": "string"
+              },
+              "ipEnd": {
+                "description": "IPEnd is the end address of an ip range.",
+                "type": "string"
+              },
+              "ipStart": {
+                "description": "IPStart is the start address of an ip range.",
+                "type": "string"
+              },
+              "subnet": {
+                "description": "Subnet is used to determine whether an ip is within subnet.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "gateway",
+              "ipEnd",
+              "ipStart",
+              "subnet"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "SnowIPPoolStatus defines the observed state of SnowIPPool.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/snowmachineconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/snowmachineconfig_v1alpha1.json
@@ -1,0 +1,160 @@
+{
+  "description": "SnowMachineConfig is the Schema for the SnowMachineConfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "SnowMachineConfigSpec defines the desired state of SnowMachineConfigSpec.",
+      "properties": {
+        "amiID": {
+          "description": "The AMI ID from which to create the machine instance.",
+          "type": "string"
+        },
+        "containersVolume": {
+          "description": "ContainersVolume provides the configuration options for the containers data storage volume.",
+          "properties": {
+            "deviceName": {
+              "description": "Device name",
+              "type": "string"
+            },
+            "encrypted": {
+              "description": "Encrypted is whether the volume should be encrypted or not.",
+              "type": "boolean"
+            },
+            "encryptionKey": {
+              "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+              "type": "string"
+            },
+            "iops": {
+              "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "size": {
+              "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+              "format": "int64",
+              "minimum": 8,
+              "type": "integer"
+            },
+            "type": {
+              "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "size"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "devices": {
+          "description": "Devices contains a device ip list assigned by the user to provision machines.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "instanceType": {
+          "description": "InstanceType is the type of instance to create. Valid values: \"sbe-c.large\" (default), \"sbe-c.xlarge\", \"sbe-c.2xlarge\" and \"sbe-c.4xlarge\".",
+          "type": "string"
+        },
+        "network": {
+          "description": "Network provides the custom network setting for the machine.",
+          "properties": {
+            "directNetworkInterfaces": {
+              "description": "DirectNetworkInterfaces contains a list of direct network interface (DNI) configuration.",
+              "items": {
+                "description": "SnowDirectNetworkInterface defines a direct network interface (DNI) configuration.",
+                "properties": {
+                  "dhcp": {
+                    "description": "DHCP defines whether DHCP is used to assign ip for the DNI.",
+                    "type": "boolean"
+                  },
+                  "index": {
+                    "description": "Index is the index number of DNI used to clarify the position in the list. Usually starts with 1.",
+                    "maximum": 8,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "ipPoolRef": {
+                    "description": "IPPool contains a reference to a snow ip pool which provides a range of ip addresses. When specified, an ip address selected from the pool is allocated to this DNI.",
+                    "properties": {
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "primary": {
+                    "description": "Primary indicates whether the DNI is primary or not.",
+                    "type": "boolean"
+                  },
+                  "vlanID": {
+                    "description": "VlanID is the vlan id assigned by the user for the DNI.",
+                    "format": "int32",
+                    "maximum": 4095,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 8,
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "osFamily": {
+          "description": "OSFamily is the node instance OS. Valid values: \"bottlerocket\" and \"ubuntu\".",
+          "type": "string"
+        },
+        "physicalNetworkConnector": {
+          "description": "PhysicalNetworkConnector is the physical network connector type to use for creating direct network interfaces (DNI). Valid values: \"SFP_PLUS\" (default), \"QSFP\" and \"RJ45\".",
+          "type": "string"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key defined in the aws snow key pairs, to attach to the instance.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "network"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "SnowMachineConfigStatus defines the observed state of SnowMachineConfig.",
+      "properties": {
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "specValid": {
+          "description": "SpecValid is set to true if vspheredatacenterconfig is validated.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/tinkerbelldatacenterconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/tinkerbelldatacenterconfig_v1alpha1.json
@@ -1,0 +1,47 @@
+{
+  "description": "TinkerbellDatacenterConfig is the Schema for the TinkerbellDatacenterConfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TinkerbellDatacenterConfigSpec defines the desired state of TinkerbellDatacenterConfig.",
+      "properties": {
+        "hookImagesURLPath": {
+          "description": "HookImagesURLPath can be used to override the default Hook images path to pull from a local server.",
+          "type": "string"
+        },
+        "osImageURL": {
+          "description": "OSImageURL can be used to override the default OS image path to pull from a local server.",
+          "type": "string"
+        },
+        "skipLoadBalancerDeployment": {
+          "description": "SkipLoadBalancerDeployment when set to \"true\" can be used to skip deploying a load balancer to expose Tinkerbell stack. Users will need to deploy and configure a load balancer manually after the cluster is created.",
+          "type": "boolean"
+        },
+        "tinkerbellIP": {
+          "description": "TinkerbellIP is used to configure a VIP for hosting the Tinkerbell services.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tinkerbellIP"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TinkerbellDatacenterConfigStatus defines the observed state of TinkerbellDatacenterConfig \n Important: Run \"make generate\" to regenerate code after modifying this file.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/tinkerbellmachineconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/tinkerbellmachineconfig_v1alpha1.json
@@ -1,0 +1,77 @@
+{
+  "description": "TinkerbellMachineConfig is the Schema for the tinkerbellmachineconfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TinkerbellMachineConfigSpec defines the desired state of TinkerbellMachineConfig.",
+      "properties": {
+        "hardwareSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "HardwareSelector models a simple key-value selector used in Tinkerbell provisioning.",
+          "type": "object"
+        },
+        "osFamily": {
+          "type": "string"
+        },
+        "templateRef": {
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "users": {
+          "items": {
+            "description": "UserConfiguration defines the configuration of the user to be added to the VM.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "sshAuthorizedKeys": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name",
+              "sshAuthorizedKeys"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "hardwareSelector",
+        "osFamily"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TinkerbellMachineConfigStatus defines the observed state of TinkerbellMachineConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/tinkerbelltemplateconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/tinkerbelltemplateconfig_v1alpha1.json
@@ -1,0 +1,148 @@
+{
+  "description": "TinkerbellTemplateConfig is the Schema for the TinkerbellTemplateConfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TinkerbellTemplateConfigSpec defines the desired state of TinkerbellTemplateConfig.",
+      "properties": {
+        "template": {
+          "description": "Template defines a Tinkerbell workflow template with specific tasks and actions.",
+          "properties": {
+            "global_timeout": {
+              "type": "integer"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "tasks": {
+              "items": {
+                "description": "Task represents a task to be executed as part of a workflow.",
+                "properties": {
+                  "actions": {
+                    "items": {
+                      "description": "Action is the basic executional unit for a workflow.",
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "environment": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "on-failure": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "on-timeout": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "pid": {
+                          "type": "string"
+                        },
+                        "timeout": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "volumes": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "image",
+                        "name",
+                        "timeout"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "environment": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "volumes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "worker": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "actions",
+                  "name",
+                  "worker"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "global_timeout",
+            "id",
+            "name",
+            "tasks",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TinkerbellTemplateConfigStatus defines the observed state of TinkerbellTemplateConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/vspheredatacenterconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/vspheredatacenterconfig_v1alpha1.json
@@ -1,0 +1,69 @@
+{
+  "description": "VSphereDatacenterConfig is the Schema for the VSphereDatacenterConfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "VSphereDatacenterConfigSpec defines the desired state of VSphereDatacenterConfig.",
+      "properties": {
+        "datacenter": {
+          "type": "string"
+        },
+        "disableCSI": {
+          "type": "boolean"
+        },
+        "insecure": {
+          "type": "boolean"
+        },
+        "network": {
+          "type": "string"
+        },
+        "server": {
+          "type": "string"
+        },
+        "thumbprint": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "datacenter",
+        "insecure",
+        "network",
+        "server",
+        "thumbprint"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "VSphereDatacenterConfigStatus defines the observed state of VSphereDatacenterConfig.",
+      "properties": {
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "specValid": {
+          "description": "SpecValid is set to true if vspheredatacenterconfig is validated.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/anywhere.eks.amazonaws.com/vspheremachineconfig_v1alpha1.json
+++ b/anywhere.eks.amazonaws.com/vspheremachineconfig_v1alpha1.json
@@ -1,0 +1,92 @@
+{
+  "description": "VSphereMachineConfig is the Schema for the vspheremachineconfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "VSphereMachineConfigSpec defines the desired state of VSphereMachineConfig.",
+      "properties": {
+        "datastore": {
+          "type": "string"
+        },
+        "diskGiB": {
+          "type": "integer"
+        },
+        "folder": {
+          "type": "string"
+        },
+        "memoryMiB": {
+          "type": "integer"
+        },
+        "numCPUs": {
+          "type": "integer"
+        },
+        "osFamily": {
+          "type": "string"
+        },
+        "resourcePool": {
+          "type": "string"
+        },
+        "storagePolicyName": {
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "template": {
+          "type": "string"
+        },
+        "users": {
+          "items": {
+            "description": "UserConfiguration defines the configuration of the user to be added to the VM.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "sshAuthorizedKeys": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name",
+              "sshAuthorizedKeys"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "datastore",
+        "folder",
+        "memoryMiB",
+        "numCPUs",
+        "osFamily",
+        "resourcePool"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "VSphereMachineConfigStatus defines the observed state of VSphereMachineConfig.",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/distro.eks.amazonaws.com/release_v1alpha1.json
+++ b/distro.eks.amazonaws.com/release_v1alpha1.json
@@ -1,0 +1,139 @@
+{
+  "description": "Release is the Schema for the releases API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ReleaseSpec defines the desired state of Release",
+      "properties": {
+        "buildRepoCommit": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "number": {
+          "description": "Monotonically increasing release number",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ReleaseStatus defines the observed state of Release",
+      "properties": {
+        "components": {
+          "items": {
+            "description": "A component of a release",
+            "properties": {
+              "assets": {
+                "items": {
+                  "properties": {
+                    "arch": {
+                      "description": "Architectures of the asset",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "archive": {
+                      "properties": {
+                        "sha256": {
+                          "description": "The sha256 of the asset, only applies for 'file' store",
+                          "type": "string"
+                        },
+                        "sha512": {
+                          "description": "The sha512 of the asset, only applies for 'file' store",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "The URI where the asset is located",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "image": {
+                      "properties": {
+                        "imageDigest": {
+                          "description": "SHA256 digest for the image",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "The image repository, name, and tag",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "name": {
+                      "description": "The asset name",
+                      "type": "string"
+                    },
+                    "os": {
+                      "description": "Operating system of the asset",
+                      "enum": [
+                        "linux",
+                        "darwin",
+                        "windows"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "The type of the asset",
+                      "enum": [
+                        "Archive",
+                        "Image"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "gitCommit": {
+                "description": "Git commit the component is built from, before any patches",
+                "type": "string"
+              },
+              "gitTag": {
+                "description": "Git tag the component is built from, before any patches",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "date": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/packages.eks.amazonaws.com/package_v1alpha1.json
+++ b/packages.eks.amazonaws.com/package_v1alpha1.json
@@ -1,0 +1,157 @@
+{
+  "description": "Package is the Schema for the package API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PackageSpec defines the desired state of an package.",
+      "properties": {
+        "config": {
+          "description": "Config for the package.",
+          "type": "string"
+        },
+        "packageName": {
+          "description": "PackageName is the name of the package as specified in the bundle.",
+          "type": "string"
+        },
+        "packageVersion": {
+          "description": "PackageVersion is a human-friendly version name or sha256 checksum for the package, as specified in the bundle.",
+          "type": "string"
+        },
+        "targetNamespace": {
+          "description": "TargetNamespace defines where package resources will be deployed.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "packageName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "PackageStatus defines the observed state of Package.",
+      "properties": {
+        "currentVersion": {
+          "description": "Version currently installed.",
+          "type": "string"
+        },
+        "detail": {
+          "description": "Detail of the state.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Source associated with the installation.",
+          "properties": {
+            "digest": {
+              "description": "Digest is a checksum value identifying the version of the package and its contents.",
+              "type": "string"
+            },
+            "registry": {
+              "description": "Registry in which the package is found.",
+              "type": "string"
+            },
+            "repository": {
+              "description": "Repository within the Registry where the package is found.",
+              "type": "string"
+            },
+            "version": {
+              "description": "Versions of the package supported.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "digest",
+            "registry",
+            "repository",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "spec": {
+          "description": "Spec previous settings",
+          "properties": {
+            "config": {
+              "description": "Config for the package.",
+              "type": "string"
+            },
+            "packageName": {
+              "description": "PackageName is the name of the package as specified in the bundle.",
+              "type": "string"
+            },
+            "packageVersion": {
+              "description": "PackageVersion is a human-friendly version name or sha256 checksum for the package, as specified in the bundle.",
+              "type": "string"
+            },
+            "targetNamespace": {
+              "description": "TargetNamespace defines where package resources will be deployed.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "packageName"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "state": {
+          "description": "State of the installation.",
+          "enum": [
+            "initializing",
+            "installing",
+            "installing dependencies",
+            "installed",
+            "updating",
+            "uninstalling",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "targetVersion": {
+          "description": "Version to be installed.",
+          "type": "string"
+        },
+        "upgradesAvailable": {
+          "description": "UpgradesAvailable indicates upgraded versions in the bundle.",
+          "items": {
+            "description": "PackageAvailableUpgrade details the package's available upgrade versions.",
+            "properties": {
+              "tag": {
+                "description": "Tag is a specific version number or sha256 checksum for the package upgrade.",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version is a human-friendly version name for the package upgrade.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "tag",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "currentVersion",
+        "source"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/packages.eks.amazonaws.com/packagebundle_v1alpha1.json
+++ b/packages.eks.amazonaws.com/packagebundle_v1alpha1.json
@@ -1,0 +1,263 @@
+{
+  "description": "PackageBundle is the Schema for the packagebundle API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PackageBundleSpec defines the desired state of PackageBundle.",
+      "properties": {
+        "minControllerVersion": {
+          "description": "Minimum required packages controller version",
+          "type": "string"
+        },
+        "packages": {
+          "description": "Packages supported by this bundle.",
+          "items": {
+            "description": "BundlePackage specifies a package within a bundle.",
+            "properties": {
+              "name": {
+                "description": "Name of the package.",
+                "type": "string"
+              },
+              "source": {
+                "description": "Source location for the package (probably a helm chart).",
+                "properties": {
+                  "registry": {
+                    "description": "Registry in which the package is found.",
+                    "type": "string"
+                  },
+                  "repository": {
+                    "description": "Repository within the Registry where the package is found.",
+                    "type": "string"
+                  },
+                  "versions": {
+                    "description": "Versions of the package supported by this bundle.",
+                    "items": {
+                      "description": "SourceVersion describes a version of a package within a repository.",
+                      "properties": {
+                        "dependencies": {
+                          "description": "Dependencies to be installed before the package",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "digest": {
+                          "description": "Digest is a checksum value identifying the version of the package and its contents.",
+                          "type": "string"
+                        },
+                        "images": {
+                          "description": "Images is a list of images used by this version of the package.",
+                          "items": {
+                            "description": "VersionImages is an image used by a version of a package.",
+                            "properties": {
+                              "digest": {
+                                "description": "Digest is a checksum value identifying the version of the package and its contents.",
+                                "type": "string"
+                              },
+                              "repository": {
+                                "description": "Repository within the Registry where the package is found.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "digest",
+                              "repository"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "Name is a human-friendly description of the version, e.g. \"v1.0\".",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "description": "Schema is a base64 encoded, gzipped json schema used to validate package configurations.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "digest",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "repository",
+                  "versions"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "workloadonly": {
+                "description": "WorkloadOnly specifies if the package should be installed only on the workload cluster",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "source"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "packages"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "PackageBundleStatus defines the observed state of PackageBundle.",
+      "properties": {
+        "spec": {
+          "description": "PackageBundleSpec defines the desired state of PackageBundle.",
+          "properties": {
+            "minControllerVersion": {
+              "description": "Minimum required packages controller version",
+              "type": "string"
+            },
+            "packages": {
+              "description": "Packages supported by this bundle.",
+              "items": {
+                "description": "BundlePackage specifies a package within a bundle.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the package.",
+                    "type": "string"
+                  },
+                  "source": {
+                    "description": "Source location for the package (probably a helm chart).",
+                    "properties": {
+                      "registry": {
+                        "description": "Registry in which the package is found.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "Repository within the Registry where the package is found.",
+                        "type": "string"
+                      },
+                      "versions": {
+                        "description": "Versions of the package supported by this bundle.",
+                        "items": {
+                          "description": "SourceVersion describes a version of a package within a repository.",
+                          "properties": {
+                            "dependencies": {
+                              "description": "Dependencies to be installed before the package",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "digest": {
+                              "description": "Digest is a checksum value identifying the version of the package and its contents.",
+                              "type": "string"
+                            },
+                            "images": {
+                              "description": "Images is a list of images used by this version of the package.",
+                              "items": {
+                                "description": "VersionImages is an image used by a version of a package.",
+                                "properties": {
+                                  "digest": {
+                                    "description": "Digest is a checksum value identifying the version of the package and its contents.",
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "description": "Repository within the Registry where the package is found.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "digest",
+                                  "repository"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is a human-friendly description of the version, e.g. \"v1.0\".",
+                              "type": "string"
+                            },
+                            "schema": {
+                              "description": "Schema is a base64 encoded, gzipped json schema used to validate package configurations.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "digest",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "repository",
+                      "versions"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "workloadonly": {
+                    "description": "WorkloadOnly specifies if the package should be installed only on the workload cluster",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "source"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "packages"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "state": {
+          "description": "PackageBundleStateEnum defines the observed state of PackageBundle.",
+          "enum": [
+            "available",
+            "ignored",
+            "invalid",
+            "controller upgrade required"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/packages.eks.amazonaws.com/packagebundlecontroller_v1alpha1.json
+++ b/packages.eks.amazonaws.com/packagebundlecontroller_v1alpha1.json
@@ -1,0 +1,138 @@
+{
+  "description": "PackageBundleController is the Schema for the packagebundlecontroller API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PackageBundleControllerSpec defines the desired state of PackageBundleController.",
+      "properties": {
+        "activeBundle": {
+          "description": "ActiveBundle is name of the bundle from which packages should be sourced.",
+          "type": "string"
+        },
+        "bundleRepository": {
+          "default": "eks-anywhere-packages-bundles",
+          "description": "Repository portion of an OCI address to the bundle",
+          "type": "string"
+        },
+        "createNamespace": {
+          "default": false,
+          "description": "Allow target namespace creation by the controller",
+          "type": "boolean"
+        },
+        "defaultImageRegistry": {
+          "default": "783794618700.dkr.ecr.us-west-2.amazonaws.com",
+          "description": "DefaultImageRegistry for pulling images",
+          "type": "string"
+        },
+        "defaultRegistry": {
+          "default": "public.ecr.aws/eks-anywhere",
+          "description": "DefaultRegistry for pulling helm charts and the bundle",
+          "type": "string"
+        },
+        "logLevel": {
+          "description": "LogLevel controls the verbosity of logging in the controller.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "privateRegistry": {
+          "description": "PrivateRegistry is the registry being used for all images, charts and bundles",
+          "type": "string"
+        },
+        "upgradeCheckInterval": {
+          "default": "24h",
+          "description": "UpgradeCheckInterval is the time between upgrade checks. \n The format is that of time's ParseDuration.",
+          "type": "string"
+        },
+        "upgradeCheckShortInterval": {
+          "default": "1h",
+          "description": "UpgradeCheckShortInterval time between upgrade checks if there is a problem. \n The format is that of time's ParseDuration.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "PackageBundleControllerStatus defines the observed state of PackageBundleController.",
+      "properties": {
+        "detail": {
+          "description": "Detail of the state.",
+          "type": "string"
+        },
+        "spec": {
+          "description": "Spec previous settings",
+          "properties": {
+            "activeBundle": {
+              "description": "ActiveBundle is name of the bundle from which packages should be sourced.",
+              "type": "string"
+            },
+            "bundleRepository": {
+              "default": "eks-anywhere-packages-bundles",
+              "description": "Repository portion of an OCI address to the bundle",
+              "type": "string"
+            },
+            "createNamespace": {
+              "default": false,
+              "description": "Allow target namespace creation by the controller",
+              "type": "boolean"
+            },
+            "defaultImageRegistry": {
+              "default": "783794618700.dkr.ecr.us-west-2.amazonaws.com",
+              "description": "DefaultImageRegistry for pulling images",
+              "type": "string"
+            },
+            "defaultRegistry": {
+              "default": "public.ecr.aws/eks-anywhere",
+              "description": "DefaultRegistry for pulling helm charts and the bundle",
+              "type": "string"
+            },
+            "logLevel": {
+              "description": "LogLevel controls the verbosity of logging in the controller.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "privateRegistry": {
+              "description": "PrivateRegistry is the registry being used for all images, charts and bundles",
+              "type": "string"
+            },
+            "upgradeCheckInterval": {
+              "default": "24h",
+              "description": "UpgradeCheckInterval is the time between upgrade checks. \n The format is that of time's ParseDuration.",
+              "type": "string"
+            },
+            "upgradeCheckShortInterval": {
+              "default": "1h",
+              "description": "UpgradeCheckShortInterval time between upgrade checks if there is a problem. \n The format is that of time's ParseDuration.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "state": {
+          "description": "State of the bundle controller.",
+          "enum": [
+            "ignored",
+            "active",
+            "disconnected",
+            "upgrade available"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds extracted CRDs from a 1.24 EKS anywhere cluster to the CRD pool.

https://aws.amazon.com/eks/eks-anywhere/

These schemas were created using crd-extractor.sh on a fresh eks-a cluster created by their installation guidelines for a local docker cluster (but apparently contain all drivers: snow, vsphere. cloudstack, tinkerbell)
