### PR TITLE
feature: add kong API gateway CRDs

### DIFF
--- a/configuration.konghq.com/ingressclassparameters_v1alpha1.json
+++ b/configuration.konghq.com/ingressclassparameters_v1alpha1.json
@@ -1,0 +1,34 @@
+{
+  "description": "IngressClassParameters is the Schema for the IngressClassParameters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the IngressClassParameters specification.",
+      "properties": {
+        "enableLegacyRegexDetection": {
+          "default": false,
+          "description": "EnableLegacyRegexDetection automatically detects if ImplementationSpecific Ingress paths are regular expression paths using the legacy 2.x heuristic. The controller adds the \"~\" prefix to those paths if the Kong version is 3.0 or higher.",
+          "type": "boolean"
+        },
+        "serviceUpstream": {
+          "default": false,
+          "description": "Offload load-balancing to kube-proxy or sidecar.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/configuration.konghq.com/kongclusterplugin_v1.json
+++ b/configuration.konghq.com/kongclusterplugin_v1.json
@@ -1,0 +1,120 @@
+{
+  "description": "KongClusterPlugin is the Schema for the kongclusterplugins API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "config": {
+      "description": "Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once.",
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "configFrom": {
+      "description": "ConfigFrom references a secret containing the plugin configuration. This should be used when the plugin configuration contains sensitive information, such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin. Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once.",
+      "properties": {
+        "secretKeyRef": {
+          "description": "Specifies a name, a namespace, and a key of a secret to refer to.",
+          "properties": {
+            "key": {
+              "description": "The key containing the value.",
+              "type": "string"
+            },
+            "name": {
+              "description": "The secret containing the key.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "The namespace containing the secret.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "name",
+            "namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "consumerRef": {
+      "description": "ConsumerRef is a reference to a particular consumer.",
+      "type": "string"
+    },
+    "disabled": {
+      "description": "Disabled set if the plugin is disabled or not.",
+      "type": "boolean"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "ordering": {
+      "description": "Ordering overrides the normal plugin execution order. It's only available on Kong Enterprise. `<phase>` is a request processing phase (for example, `access` or `body_filter`) and `<plugin>` is the name of the plugin that will run before or after the KongPlugin. For example, a KongPlugin with `plugin: rate-limiting` and `before.access: [\"key-auth\"]` will create a rate limiting plugin that limits requests _before_ they are authenticated.",
+      "properties": {
+        "after": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "PluginOrderingPhase indicates which plugins in a phase should affect the target plugin's order",
+          "type": "object"
+        },
+        "before": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "PluginOrderingPhase indicates which plugins in a phase should affect the target plugin's order",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "plugin": {
+      "description": "PluginName is the name of the plugin to which to apply the config.",
+      "type": "string"
+    },
+    "protocols": {
+      "description": "Protocols configures plugin to run on requests received on specific protocols.",
+      "items": {
+        "enum": [
+          "http",
+          "https",
+          "grpc",
+          "grpcs",
+          "tcp",
+          "tls",
+          "udp"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "run_on": {
+      "description": "RunOn configures the plugin to run on the first or the second or both nodes in case of a service mesh deployment.",
+      "enum": [
+        "first",
+        "second",
+        "all"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "plugin"
+  ],
+  "type": "object"
+}

--- a/configuration.konghq.com/kongconsumer_v1.json
+++ b/configuration.konghq.com/kongconsumer_v1.json
@@ -1,0 +1,32 @@
+{
+  "description": "KongConsumer is the Schema for the kongconsumers API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "credentials": {
+      "description": "Credentials are references to secrets containing a credential to be provisioned in Kong.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "custom_id": {
+      "description": "CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping Kong with users in your existing database.",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "username": {
+      "description": "Username is a Kong cluster-unique username of the consumer.",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/configuration.konghq.com/kongingress_v1.json
+++ b/configuration.konghq.com/kongingress_v1.json
@@ -1,0 +1,354 @@
+{
+  "description": "KongIngress is the Schema for the kongingresses API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "proxy": {
+      "description": "Proxy defines additional connection options for the routes to be configured in the Kong Gateway, e.g. `connection_timeout`, `retries`, etc.",
+      "properties": {
+        "connect_timeout": {
+          "description": "The timeout in milliseconds for\testablishing a connection to the upstream server. Deprecated: use Service's \"konghq.com/connect-timeout\" annotation instead.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "path": {
+          "description": "(optional) The path to be used in requests to the upstream server. Deprecated: use Service's \"konghq.com/path\" annotation instead.",
+          "pattern": "^/.*$",
+          "type": "string"
+        },
+        "protocol": {
+          "description": "The protocol used to communicate with the upstream. Deprecated: use Service's \"konghq.com/protocol\" annotation instead.",
+          "enum": [
+            "http",
+            "https",
+            "grpc",
+            "grpcs",
+            "tcp",
+            "tls",
+            "udp"
+          ],
+          "type": "string"
+        },
+        "read_timeout": {
+          "description": "The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server. Deprecated: use Service's \"konghq.com/read-timeout\" annotation instead.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "retries": {
+          "description": "The number of retries to execute upon failure to proxy. Deprecated: use Service's \"konghq.com/retries\" annotation instead.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "write_timeout": {
+          "description": "The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server. Deprecated: use Service's \"konghq.com/write-timeout\" annotation instead.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "route": {
+      "description": "Route define rules to match client requests. Each Route is associated with a Service, and a Service may have multiple Routes associated to it.",
+      "properties": {
+        "headers": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Headers contains one or more lists of values indexed by header name that will cause this Route to match if present in the request. The Host header cannot be used with this attribute. Deprecated: use Ingress' \"konghq.com/headers\" annotation instead.",
+          "type": "object"
+        },
+        "https_redirect_status_code": {
+          "description": "HTTPSRedirectStatusCode is the status code Kong responds with when all properties of a Route match except the protocol. Deprecated: use Ingress' \"ingress.kubernetes.io/force-ssl-redirect\" or \"konghq.com/https-redirect-status-code\" annotations instead.",
+          "type": "integer"
+        },
+        "methods": {
+          "description": "Methods is a list of HTTP methods that match this Route. Deprecated: use Ingress' \"konghq.com/override-protocols\" annotation instead.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "path_handling": {
+          "description": "PathHandling controls how the Service path, Route path and requested path are combined when sending a request to the upstream. Deprecated: use Ingress' \"konghq.com/path-handling\" annotation instead.",
+          "enum": [
+            "v0",
+            "v1"
+          ],
+          "type": "string"
+        },
+        "preserve_host": {
+          "description": "PreserveHost sets When matching a Route via one of the hosts domain names, use the request Host header in the upstream request headers. If set to false, the upstream Host header will be that of the Service\u2019s host. Deprecated: use Ingress' \"konghq.com/preserve-host\" annotation instead.",
+          "type": "boolean"
+        },
+        "protocols": {
+          "description": "Protocols is an array of the protocols this Route should allow. Deprecated: use Ingress' \"konghq.com/protocols\" annotation instead.",
+          "items": {
+            "enum": [
+              "http",
+              "https",
+              "grpc",
+              "grpcs",
+              "tcp",
+              "tls",
+              "udp"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "regex_priority": {
+          "description": "RegexPriority is a number used to choose which route resolves a given request when several routes match it using regexes simultaneously. Deprecated: use Ingress' \"konghq.com/regex-priority\" annotation instead.",
+          "type": "integer"
+        },
+        "request_buffering": {
+          "description": "RequestBuffering sets whether to enable request body buffering or not. Deprecated: use Ingress' \"konghq.com/request-buffering\" annotation instead.",
+          "type": "boolean"
+        },
+        "response_buffering": {
+          "description": "ResponseBuffering sets whether to enable response body buffering or not. Deprecated: use Ingress' \"konghq.com/response-buffering\" annotation instead.",
+          "type": "boolean"
+        },
+        "snis": {
+          "description": "SNIs is a list of SNIs that match this Route when using stream routing. Deprecated: use Ingress' \"konghq.com/snis\" annotation instead.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "strip_path": {
+          "description": "StripPath sets When matching a Route via one of the paths strip the matching prefix from the upstream request URL. Deprecated: use Ingress' \"konghq.com/strip-path\" annotation instead.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "upstream": {
+      "description": "Upstream represents a virtual hostname and can be used to loadbalance incoming requests over multiple targets (e.g. Kubernetes `Services` can be a target, OR `Endpoints` can be targets).",
+      "properties": {
+        "algorithm": {
+          "description": "Algorithm is the load balancing algorithm to use.",
+          "enum": [
+            "round-robin",
+            "consistent-hashing",
+            "least-connections"
+          ],
+          "type": "string"
+        },
+        "hash_fallback": {
+          "description": "HashFallback defines What to use as hashing input if the primary hash_on does not return a hash. Accepted values are: \"none\", \"consumer\", \"ip\", \"header\", \"cookie\".",
+          "type": "string"
+        },
+        "hash_fallback_header": {
+          "description": "HashFallbackHeader is the header name to take the value from as hash input. Only required when \"hash_fallback\" is set to \"header\".",
+          "type": "string"
+        },
+        "hash_fallback_query_arg": {
+          "description": "HashFallbackQueryArg is the \"hash_fallback\" version of HashOnQueryArg.",
+          "type": "string"
+        },
+        "hash_fallback_uri_capture": {
+          "description": "HashFallbackURICapture is the \"hash_fallback\" version of HashOnURICapture.",
+          "type": "string"
+        },
+        "hash_on": {
+          "description": "HashOn defines what to use as hashing input. Accepted values are: \"none\", \"consumer\", \"ip\", \"header\", \"cookie\", \"path\", \"query_arg\", \"uri_capture\".",
+          "type": "string"
+        },
+        "hash_on_cookie": {
+          "description": "The cookie name to take the value from as hash input. Only required when \"hash_on\" or \"hash_fallback\" is set to \"cookie\".",
+          "type": "string"
+        },
+        "hash_on_cookie_path": {
+          "description": "The cookie path to set in the response headers. Only required when \"hash_on\" or \"hash_fallback\" is set to \"cookie\".",
+          "type": "string"
+        },
+        "hash_on_header": {
+          "description": "HashOnHeader defines the header name to take the value from as hash input. Only required when \"hash_on\" is set to \"header\".",
+          "type": "string"
+        },
+        "hash_on_query_arg": {
+          "description": "HashOnQueryArg is the query string parameter whose value is the hash input when \"hash_on\" is set to \"query_arg\".",
+          "type": "string"
+        },
+        "hash_on_uri_capture": {
+          "description": "HashOnURICapture is the name of the capture group whose value is the hash input when \"hash_on\" is set to \"uri_capture\".",
+          "type": "string"
+        },
+        "healthchecks": {
+          "description": "Healthchecks defines the health check configurations in Kong.",
+          "properties": {
+            "active": {
+              "description": "ActiveHealthcheck configures active health check probing.",
+              "properties": {
+                "concurrency": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "healthy": {
+                  "description": "Healthy configures thresholds and HTTP status codes to mark targets healthy for an upstream.",
+                  "properties": {
+                    "http_statuses": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "interval": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "successes": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "http_path": {
+                  "pattern": "^/.*$",
+                  "type": "string"
+                },
+                "https_sni": {
+                  "type": "string"
+                },
+                "https_verify_certificate": {
+                  "type": "boolean"
+                },
+                "timeout": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "unhealthy": {
+                  "description": "Unhealthy configures thresholds and HTTP status codes to mark targets unhealthy.",
+                  "properties": {
+                    "http_failures": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "http_statuses": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "interval": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tcp_failures": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "timeouts": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "passive": {
+              "description": "PassiveHealthcheck configures passive checks around passive health checks.",
+              "properties": {
+                "healthy": {
+                  "description": "Healthy configures thresholds and HTTP status codes to mark targets healthy for an upstream.",
+                  "properties": {
+                    "http_statuses": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "interval": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "successes": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "type": "string"
+                },
+                "unhealthy": {
+                  "description": "Unhealthy configures thresholds and HTTP status codes to mark targets unhealthy.",
+                  "properties": {
+                    "http_failures": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "http_statuses": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "interval": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tcp_failures": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "timeouts": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "threshold": {
+              "type": "number"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "host_header": {
+          "description": "HostHeader is The hostname to be used as Host header when proxying requests through Kong.",
+          "type": "string"
+        },
+        "slots": {
+          "description": "Slots is the number of slots in the load balancer algorithm.",
+          "minimum": 10,
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/configuration.konghq.com/kongplugin_v1.json
+++ b/configuration.konghq.com/kongplugin_v1.json
@@ -1,0 +1,115 @@
+{
+  "description": "KongPlugin is the Schema for the kongplugins API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "config": {
+      "description": "Config contains the plugin configuration. It's a list of keys and values required to configure the plugin. Please read the documentation of the plugin being configured to set values in here. For any plugin in Kong, anything that goes in the `config` JSON key in the Admin API request, goes into this property. Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once.",
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    },
+    "configFrom": {
+      "description": "ConfigFrom references a secret containing the plugin configuration. This should be used when the plugin configuration contains sensitive information, such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin. Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once.",
+      "properties": {
+        "secretKeyRef": {
+          "description": "Specifies a name and a key of a secret to refer to. The namespace is implicitly set to the one of referring object.",
+          "properties": {
+            "key": {
+              "description": "The key containing the value.",
+              "type": "string"
+            },
+            "name": {
+              "description": "The secret containing the key.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "consumerRef": {
+      "description": "ConsumerRef is a reference to a particular consumer.",
+      "type": "string"
+    },
+    "disabled": {
+      "description": "Disabled set if the plugin is disabled or not.",
+      "type": "boolean"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "ordering": {
+      "description": "Ordering overrides the normal plugin execution order. It's only available on Kong Enterprise. `<phase>` is a request processing phase (for example, `access` or `body_filter`) and `<plugin>` is the name of the plugin that will run before or after the KongPlugin. For example, a KongPlugin with `plugin: rate-limiting` and `before.access: [\"key-auth\"]` will create a rate limiting plugin that limits requests _before_ they are authenticated.",
+      "properties": {
+        "after": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "PluginOrderingPhase indicates which plugins in a phase should affect the target plugin's order",
+          "type": "object"
+        },
+        "before": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "PluginOrderingPhase indicates which plugins in a phase should affect the target plugin's order",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "plugin": {
+      "description": "PluginName is the name of the plugin to which to apply the config.",
+      "type": "string"
+    },
+    "protocols": {
+      "description": "Protocols configures plugin to run on requests received on specific protocols.",
+      "items": {
+        "enum": [
+          "http",
+          "https",
+          "grpc",
+          "grpcs",
+          "tcp",
+          "tls",
+          "udp"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "run_on": {
+      "description": "RunOn configures the plugin to run on the first or the second or both nodes in case of a service mesh deployment.",
+      "enum": [
+        "first",
+        "second",
+        "all"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "plugin"
+  ],
+  "type": "object"
+}

--- a/configuration.konghq.com/tcpingress_v1beta1.json
+++ b/configuration.konghq.com/tcpingress_v1beta1.json
@@ -1,0 +1,159 @@
+{
+  "description": "TCPIngress is the Schema for the tcpingresses API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the TCPIngress specification.",
+      "properties": {
+        "rules": {
+          "description": "A list of rules used to configure the Ingress.",
+          "items": {
+            "description": "IngressRule represents a rule to apply against incoming requests. Matching is performed based on an (optional) SNI and port.",
+            "properties": {
+              "backend": {
+                "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to.",
+                "properties": {
+                  "serviceName": {
+                    "description": "Specifies the name of the referenced service.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "servicePort": {
+                    "description": "Specifies the port of the referenced service.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "serviceName",
+                  "servicePort"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "host": {
+                "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. If a Host is not specified, then port-based TCP routing is performed. Kong doesn't care about the content of the TCP stream in this case. If a Host is specified, the protocol must be TLS over TCP. A plain-text TCP request cannot be routed based on Host. It can only be routed based on Port.",
+                "type": "string"
+              },
+              "port": {
+                "description": "Port is the port on which to accept TCP or TLS over TCP sessions and route. It is a required field. If a Host is not specified, the requested are routed based only on Port.",
+                "format": "int32",
+                "maximum": 65535,
+                "minimum": 1,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "backend",
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "tls": {
+          "description": "TLS configuration. This is similar to the `tls` section in the Ingress resource in networking.v1beta1 group. The mapping of SNIs to TLS cert-key pair defined here will be used for HTTP Ingress rules as well. Once can define the mapping in this resource or the original Ingress resource, both have the same effect.",
+          "items": {
+            "description": "IngressTLS describes the transport layer security.",
+            "properties": {
+              "hosts": {
+                "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "secretName": {
+                "description": "SecretName is the name of the secret used to terminate SSL traffic.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TCPIngressStatus defines the observed state of TCPIngress.",
+      "properties": {
+        "loadBalancer": {
+          "description": "LoadBalancer contains the current status of the load-balancer.",
+          "properties": {
+            "ingress": {
+              "description": "Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.",
+              "items": {
+                "description": "LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.",
+                "properties": {
+                  "hostname": {
+                    "description": "Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)",
+                    "type": "string"
+                  },
+                  "ip": {
+                    "description": "IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)",
+                    "type": "string"
+                  },
+                  "ports": {
+                    "description": "Ports is a list of records of service ports If used, every port defined in the service should have an entry in it",
+                    "items": {
+                      "properties": {
+                        "error": {
+                          "description": "Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use CamelCase names - cloud provider specific error values must have names that comply with the format foo.example.com/CamelCase. --- The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                          "maxLength": 316,
+                          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Port is the port number of the service port of which status is recorded here",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "default": "TCP",
+                          "description": "Protocol is the protocol of the service port of which status is recorded here The supported values are: \"TCP\", \"UDP\", \"SCTP\"",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port",
+                        "protocol"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/configuration.konghq.com/udpingress_v1beta1.json
+++ b/configuration.konghq.com/udpingress_v1beta1.json
@@ -1,0 +1,133 @@
+{
+  "description": "UDPIngress is the Schema for the udpingresses API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the UDPIngress specification.",
+      "properties": {
+        "rules": {
+          "description": "A list of rules used to configure the Ingress.",
+          "items": {
+            "description": "UDPIngressRule represents a rule to apply against incoming requests wherein no Host matching is available for request routing, only the port is used to match requests.",
+            "properties": {
+              "backend": {
+                "description": "Backend defines the Kubernetes service which accepts traffic from the listening Port defined above.",
+                "properties": {
+                  "serviceName": {
+                    "description": "Specifies the name of the referenced service.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "servicePort": {
+                    "description": "Specifies the port of the referenced service.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "serviceName",
+                  "servicePort"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "port": {
+                "description": "Port indicates the port for the Kong proxy to accept incoming traffic on, which will then be routed to the service Backend.",
+                "format": "int32",
+                "maximum": 65535,
+                "minimum": 1,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "backend",
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "UDPIngressStatus defines the observed state of UDPIngress.",
+      "properties": {
+        "loadBalancer": {
+          "description": "LoadBalancer contains the current status of the load-balancer.",
+          "properties": {
+            "ingress": {
+              "description": "Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.",
+              "items": {
+                "description": "LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.",
+                "properties": {
+                  "hostname": {
+                    "description": "Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)",
+                    "type": "string"
+                  },
+                  "ip": {
+                    "description": "IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)",
+                    "type": "string"
+                  },
+                  "ports": {
+                    "description": "Ports is a list of records of service ports If used, every port defined in the service should have an entry in it",
+                    "items": {
+                      "properties": {
+                        "error": {
+                          "description": "Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use CamelCase names - cloud provider specific error values must have names that comply with the format foo.example.com/CamelCase. --- The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                          "maxLength": 316,
+                          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Port is the port number of the service port of which status is recorded here",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "default": "TCP",
+                          "description": "Protocol is the protocol of the service port of which status is recorded here The supported values are: \"TCP\", \"UDP\", \"SCTP\"",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port",
+                        "protocol"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds kong CRDs (regular + enterprise ones)
https://konghq.com/

These schemas were created using crd-extractor.sh on a fresh minikube cluster after installing kong enterprise with the provided yaml file