### PR TITLE
feature: add gloo CRDs

### DIFF
--- a/enterprise.gloo.solo.io/authconfig_v1.json
+++ b/enterprise.gloo.solo.io/authconfig_v1.json
@@ -1,0 +1,1064 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "booleanExpr": {
+          "nullable": true,
+          "type": "string"
+        },
+        "configs": {
+          "items": {
+            "properties": {
+              "apiKeyAuth": {
+                "properties": {
+                  "aerospikeApikeyStorage": {
+                    "properties": {
+                      "allowInsecure": {
+                        "type": "boolean"
+                      },
+                      "batchSize": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "certPath": {
+                        "type": "string"
+                      },
+                      "commitAll": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "commitMaster": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "hostname": {
+                        "type": "string"
+                      },
+                      "keyPath": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "nodeTlsName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readModeAp": {
+                        "properties": {
+                          "readModeApAll": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readModeApOne": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "readModeSc": {
+                        "properties": {
+                          "readModeScAllowUnavailable": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readModeScLinearize": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readModeScReplica": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readModeScSession": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rootCaPath": {
+                        "type": "string"
+                      },
+                      "set": {
+                        "type": "string"
+                      },
+                      "tlsCurveGroups": {
+                        "items": {
+                          "properties": {
+                            "curveP256": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "curveP384": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "curveP521": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "x25519": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "tlsVersion": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "apiKeySecretRefs": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "headerName": {
+                    "type": "string"
+                  },
+                  "headersFromMetadata": {
+                    "additionalProperties": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "object"
+                  },
+                  "headersFromMetadataEntry": {
+                    "additionalProperties": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "object"
+                  },
+                  "k8sSecretApikeyStorage": {
+                    "properties": {
+                      "apiKeySecretRefs": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "labelSelector": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "labelSelector": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "basicAuth": {
+                "properties": {
+                  "apr": {
+                    "properties": {
+                      "users": {
+                        "additionalProperties": {
+                          "properties": {
+                            "hashedPassword": {
+                              "type": "string"
+                            },
+                            "salt": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "realm": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "jwt": {
+                "maxProperties": 0,
+                "type": "object"
+              },
+              "ldap": {
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  },
+                  "allowedGroups": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "disableGroupChecking": {
+                    "type": "boolean"
+                  },
+                  "groupLookupSettings": {
+                    "properties": {
+                      "checkGroupsWithServiceAccount": {
+                        "type": "boolean"
+                      },
+                      "credentialsSecretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "membershipAttributeName": {
+                    "type": "string"
+                  },
+                  "pool": {
+                    "properties": {
+                      "initialSize": {
+                        "maximum": 4294967295,
+                        "minimum": 0,
+                        "nullable": true,
+                        "type": "integer"
+                      },
+                      "maxSize": {
+                        "maximum": 4294967295,
+                        "minimum": 0,
+                        "nullable": true,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "searchFilter": {
+                    "type": "string"
+                  },
+                  "userDnTemplate": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "nullable": true,
+                "type": "string"
+              },
+              "oauth": {
+                "properties": {
+                  "appUrl": {
+                    "type": "string"
+                  },
+                  "authEndpointQueryParams": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "callbackPath": {
+                    "type": "string"
+                  },
+                  "clientId": {
+                    "type": "string"
+                  },
+                  "clientSecretRef": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "issuerUrl": {
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "oauth2": {
+                "properties": {
+                  "accessTokenValidation": {
+                    "properties": {
+                      "cacheTimeout": {
+                        "type": "string"
+                      },
+                      "introspection": {
+                        "properties": {
+                          "clientId": {
+                            "type": "string"
+                          },
+                          "clientSecretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "introspectionUrl": {
+                            "type": "string"
+                          },
+                          "userIdAttributeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "introspectionUrl": {
+                        "type": "string"
+                      },
+                      "jwt": {
+                        "properties": {
+                          "issuer": {
+                            "type": "string"
+                          },
+                          "localJwks": {
+                            "properties": {
+                              "inlineString": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "remoteJwks": {
+                            "properties": {
+                              "refreshInterval": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "requiredScopes": {
+                        "properties": {
+                          "scope": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "userinfoUrl": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "oauth2": {
+                    "properties": {
+                      "afterLogoutUrl": {
+                        "type": "string"
+                      },
+                      "appUrl": {
+                        "type": "string"
+                      },
+                      "authEndpoint": {
+                        "type": "string"
+                      },
+                      "authEndpointQueryParams": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "callbackPath": {
+                        "type": "string"
+                      },
+                      "clientId": {
+                        "type": "string"
+                      },
+                      "clientSecretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "logoutPath": {
+                        "type": "string"
+                      },
+                      "revocationEndpoint": {
+                        "type": "string"
+                      },
+                      "scopes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "session": {
+                        "properties": {
+                          "cookie": {
+                            "properties": {
+                              "allowRefreshing": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "keyPrefix": {
+                                "type": "string"
+                              },
+                              "targetDomain": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cookieOptions": {
+                            "properties": {
+                              "domain": {
+                                "type": "string"
+                              },
+                              "httpOnly": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "maxAge": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "notSecure": {
+                                "type": "boolean"
+                              },
+                              "path": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "sameSite": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failOnFetchFailure": {
+                            "type": "boolean"
+                          },
+                          "redis": {
+                            "properties": {
+                              "allowRefreshing": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "cookieName": {
+                                "type": "string"
+                              },
+                              "headerName": {
+                                "type": "string"
+                              },
+                              "keyPrefix": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "properties": {
+                                  "db": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "poolSize": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "socketType": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "tlsCertMountPath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preExpiryBuffer": {
+                                "type": "string"
+                              },
+                              "targetDomain": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tokenEndpoint": {
+                        "type": "string"
+                      },
+                      "tokenEndpointQueryParams": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "oidcAuthorizationCode": {
+                    "properties": {
+                      "afterLogoutUrl": {
+                        "type": "string"
+                      },
+                      "appUrl": {
+                        "type": "string"
+                      },
+                      "authEndpointQueryParams": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "autoMapFromMetadata": {
+                        "properties": {
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "callbackPath": {
+                        "type": "string"
+                      },
+                      "clientId": {
+                        "type": "string"
+                      },
+                      "clientSecretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "discoveryOverride": {
+                        "properties": {
+                          "authEndpoint": {
+                            "type": "string"
+                          },
+                          "authMethods": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "claims": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "endSessionEndpoint": {
+                            "type": "string"
+                          },
+                          "idTokenAlgs": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "jwksUri": {
+                            "type": "string"
+                          },
+                          "responseTypes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "revocationEndpoint": {
+                            "type": "string"
+                          },
+                          "scopes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "subjects": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "tokenEndpoint": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "discoveryPollInterval": {
+                        "type": "string"
+                      },
+                      "endSessionProperties": {
+                        "properties": {
+                          "methodType": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "headers": {
+                        "properties": {
+                          "accessTokenHeader": {
+                            "type": "string"
+                          },
+                          "idTokenHeader": {
+                            "type": "string"
+                          },
+                          "useBearerSchemaForAuthorization": {
+                            "nullable": true,
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "issuerUrl": {
+                        "type": "string"
+                      },
+                      "jwksCacheRefreshPolicy": {
+                        "properties": {
+                          "always": {
+                            "maxProperties": 0,
+                            "type": "object"
+                          },
+                          "maxIdpReqPerPollingInterval": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "never": {
+                            "maxProperties": 0,
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "logoutPath": {
+                        "type": "string"
+                      },
+                      "parseCallbackPathAsRegex": {
+                        "type": "boolean"
+                      },
+                      "scopes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "session": {
+                        "properties": {
+                          "cookie": {
+                            "properties": {
+                              "allowRefreshing": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "keyPrefix": {
+                                "type": "string"
+                              },
+                              "targetDomain": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cookieOptions": {
+                            "properties": {
+                              "domain": {
+                                "type": "string"
+                              },
+                              "httpOnly": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "maxAge": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "notSecure": {
+                                "type": "boolean"
+                              },
+                              "path": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "sameSite": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failOnFetchFailure": {
+                            "type": "boolean"
+                          },
+                          "redis": {
+                            "properties": {
+                              "allowRefreshing": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "cookieName": {
+                                "type": "string"
+                              },
+                              "headerName": {
+                                "type": "string"
+                              },
+                              "keyPrefix": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "properties": {
+                                  "db": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "poolSize": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "socketType": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "tlsCertMountPath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preExpiryBuffer": {
+                                "type": "string"
+                              },
+                              "targetDomain": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "sessionIdHeaderName": {
+                        "type": "string"
+                      },
+                      "tokenEndpointQueryParams": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "opaAuth": {
+                "properties": {
+                  "modules": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "options": {
+                    "properties": {
+                      "fastInputConversion": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "query": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "passThroughAuth": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "failureModeAllow": {
+                    "type": "boolean"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "address": {
+                        "type": "string"
+                      },
+                      "connectionTimeout": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "http": {
+                    "properties": {
+                      "connectionTimeout": {
+                        "type": "string"
+                      },
+                      "request": {
+                        "properties": {
+                          "allowedHeaders": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "headersToAdd": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "passThroughBody": {
+                            "type": "boolean"
+                          },
+                          "passThroughFilterMetadata": {
+                            "type": "boolean"
+                          },
+                          "passThroughState": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "response": {
+                        "properties": {
+                          "allowedClientHeadersOnDenied": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allowedUpstreamHeaders": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "readStateFromResponse": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "pluginAuth": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "exportedSymbolName": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "pluginFileName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failOnRedirect": {
+          "type": "boolean"
+        },
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gateway.solo.io/gateway_v1.json
+++ b/gateway.solo.io/gateway_v1.json
@@ -1,0 +1,9170 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "bindAddress": {
+          "type": "string"
+        },
+        "bindPort": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "httpGateway": {
+          "properties": {
+            "options": {
+              "properties": {
+                "buffer": {
+                  "properties": {
+                    "maxRequestBytes": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "caching": {
+                  "properties": {
+                    "allowedVaryHeaders": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "cachingServiceRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "maxPayloadSize": {
+                      "properties": {
+                        "value": {
+                          "format": "int64",
+                          "type": "integer",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "timeout": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "csrf": {
+                  "properties": {
+                    "additionalOrigins": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "filterEnabled": {
+                      "properties": {
+                        "defaultValue": {
+                          "properties": {
+                            "denominator": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "numerator": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "runtimeKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "shadowEnabled": {
+                      "properties": {
+                        "defaultValue": {
+                          "properties": {
+                            "denominator": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "numerator": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "runtimeKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dlp": {
+                  "properties": {
+                    "dlpRules": {
+                      "items": {
+                        "properties": {
+                          "actions": {
+                            "items": {
+                              "properties": {
+                                "actionType": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "customAction": {
+                                  "properties": {
+                                    "maskChar": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "percent": {
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "regex": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "regexActions": {
+                                      "items": {
+                                        "properties": {
+                                          "regex": {
+                                            "type": "string"
+                                          },
+                                          "subgroup": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "keyValueAction": {
+                                  "properties": {
+                                    "keyToMask": {
+                                      "type": "string"
+                                    },
+                                    "maskChar": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "percent": {
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "shadow": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matcher": {
+                            "properties": {
+                              "caseSensitive": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "exact": {
+                                "type": "string"
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "invertMatch": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "methods": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "prefix": {
+                                "type": "string"
+                              },
+                              "queryParameters": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "enabledFor": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dynamicForwardProxy": {
+                  "properties": {
+                    "dnsCacheConfig": {
+                      "properties": {
+                        "appleDns": {
+                          "type": "object"
+                        },
+                        "caresDns": {
+                          "properties": {
+                            "dnsResolverOptions": {
+                              "properties": {
+                                "noDefaultSearchDomain": {
+                                  "type": "boolean"
+                                },
+                                "useTcpForDnsLookups": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "resolvers": {
+                              "items": {
+                                "properties": {
+                                  "pipe": {
+                                    "properties": {
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "socketAddress": {
+                                    "properties": {
+                                      "address": {
+                                        "type": "string"
+                                      },
+                                      "ipv4Compat": {
+                                        "type": "boolean"
+                                      },
+                                      "namedPort": {
+                                        "type": "string"
+                                      },
+                                      "portValue": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resolverName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dnsCacheCircuitBreaker": {
+                          "properties": {
+                            "maxPendingRequests": {
+                              "maximum": 4294967295,
+                              "minimum": 0,
+                              "nullable": true,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dnsFailureRefreshRate": {
+                          "properties": {
+                            "baseInterval": {
+                              "type": "string"
+                            },
+                            "maxInterval": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dnsLookupFamily": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "dnsQueryTimeout": {
+                          "type": "string"
+                        },
+                        "dnsRefreshRate": {
+                          "type": "string"
+                        },
+                        "hostTtl": {
+                          "type": "string"
+                        },
+                        "maxHosts": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "preresolveHostnames": {
+                          "items": {
+                            "properties": {
+                              "address": {
+                                "type": "string"
+                              },
+                              "ipv4Compat": {
+                                "type": "boolean"
+                              },
+                              "namedPort": {
+                                "type": "string"
+                              },
+                              "portValue": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resolverName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "saveUpstreamAddress": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "extauth": {
+                  "properties": {
+                    "clearRouteCache": {
+                      "type": "boolean"
+                    },
+                    "extauthzServerRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureModeAllow": {
+                      "type": "boolean"
+                    },
+                    "grpcService": {
+                      "properties": {
+                        "authority": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpService": {
+                      "properties": {
+                        "pathPrefix": {
+                          "type": "string"
+                        },
+                        "request": {
+                          "properties": {
+                            "allowedHeaders": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "allowedHeadersRegex": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "headersToAdd": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "response": {
+                          "properties": {
+                            "allowedClientHeaders": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "allowedUpstreamHeaders": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "allowedUpstreamHeadersToAppend": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "requestBody": {
+                      "properties": {
+                        "allowPartialMessage": {
+                          "type": "boolean"
+                        },
+                        "maxRequestBytes": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "packAsBytes": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "requestTimeout": {
+                      "type": "string"
+                    },
+                    "statPrefix": {
+                      "type": "string"
+                    },
+                    "statusOnError": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "transportApiVersion": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "userIdHeader": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "extensions": {
+                  "properties": {
+                    "configs": {
+                      "additionalProperties": {
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "grpcJsonTranscoder": {
+                  "properties": {
+                    "autoMapping": {
+                      "type": "boolean"
+                    },
+                    "convertGrpcStatus": {
+                      "type": "boolean"
+                    },
+                    "ignoreUnknownQueryParameters": {
+                      "type": "boolean"
+                    },
+                    "ignoredQueryParameters": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "matchIncomingRequestRoute": {
+                      "type": "boolean"
+                    },
+                    "printOptions": {
+                      "properties": {
+                        "addWhitespace": {
+                          "type": "boolean"
+                        },
+                        "alwaysPrintEnumsAsInts": {
+                          "type": "boolean"
+                        },
+                        "alwaysPrintPrimitiveFields": {
+                          "type": "boolean"
+                        },
+                        "preserveProtoFieldNames": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "protoDescriptor": {
+                      "type": "string"
+                    },
+                    "protoDescriptorBin": {
+                      "format": "byte",
+                      "type": "string"
+                    },
+                    "protoDescriptorConfigMap": {
+                      "properties": {
+                        "configMapRef": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "key": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "services": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "grpcWeb": {
+                  "properties": {
+                    "disable": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "gzip": {
+                  "properties": {
+                    "compressionLevel": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "compressionStrategy": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "contentLength": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "contentType": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "disableOnEtagHeader": {
+                      "type": "boolean"
+                    },
+                    "memoryLevel": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "removeAcceptEncodingHeader": {
+                      "type": "boolean"
+                    },
+                    "windowBits": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "healthCheck": {
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpConnectionManagerSettings": {
+                  "properties": {
+                    "acceptHttp10": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "allowChunkedLength": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "codecType": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "defaultHostForHttp10": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "delayedCloseTimeout": {
+                      "type": "string"
+                    },
+                    "drainTimeout": {
+                      "type": "string"
+                    },
+                    "enableTrailers": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "forwardClientCertDetails": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "generateRequestId": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "headersWithUnderscoresAction": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "http2ProtocolOptions": {
+                      "properties": {
+                        "initialConnectionWindowSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "initialStreamWindowSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "maxConcurrentStreams": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "overrideStreamErrorOnInvalidHttpMessage": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "idleTimeout": {
+                      "type": "string"
+                    },
+                    "internalAddressConfig": {
+                      "properties": {
+                        "cidrRanges": {
+                          "items": {
+                            "properties": {
+                              "addressPrefix": {
+                                "type": "string"
+                              },
+                              "prefixLen": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "unixSockets": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "maxConnectionDuration": {
+                      "type": "string"
+                    },
+                    "maxHeadersCount": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "maxRequestHeadersKb": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "maxRequestsPerConnection": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "maxStreamDuration": {
+                      "type": "string"
+                    },
+                    "mergeSlashes": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "normalizePath": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "pathWithEscapedSlashesAction": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "preserveCaseHeaderKeyFormat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "preserveExternalRequestId": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "properCaseHeaderKeyFormat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "proxy100Continue": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "requestHeadersTimeout": {
+                      "type": "string"
+                    },
+                    "requestTimeout": {
+                      "type": "string"
+                    },
+                    "serverHeaderTransformation": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "serverName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "setCurrentClientCertDetails": {
+                      "properties": {
+                        "cert": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "chain": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "dns": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "subject": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "uri": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "skipXffAppend": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "streamIdleTimeout": {
+                      "type": "string"
+                    },
+                    "stripAnyHostPort": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "tracing": {
+                      "properties": {
+                        "datadogConfig": {
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "collectorUpstreamRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceName": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "environmentVariablesForTags": {
+                          "items": {
+                            "properties": {
+                              "defaultValue": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "name": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "tag": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "literalsForTags": {
+                          "items": {
+                            "properties": {
+                              "tag": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "value": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "openCensusConfig": {
+                          "properties": {
+                            "grpcAddress": {
+                              "properties": {
+                                "statPrefix": {
+                                  "type": "string"
+                                },
+                                "targetUri": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "httpAddress": {
+                              "type": "string"
+                            },
+                            "incomingTraceContext": {
+                              "items": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "array"
+                            },
+                            "ocagentExporterEnabled": {
+                              "type": "boolean"
+                            },
+                            "outgoingTraceContext": {
+                              "items": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "array"
+                            },
+                            "traceConfig": {
+                              "properties": {
+                                "constantSampler": {
+                                  "properties": {
+                                    "decision": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "maxNumberOfAnnotations": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "maxNumberOfAttributes": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "maxNumberOfLinks": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "maxNumberOfMessageEvents": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "probabilitySampler": {
+                                  "properties": {
+                                    "samplingProbability": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "rateLimitingSampler": {
+                                  "properties": {
+                                    "qps": {
+                                      "format": "int64",
+                                      "type": "integer",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "openTelemetryConfig": {
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "collectorUpstreamRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "requestHeadersForTags": {
+                          "items": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "tracePercentages": {
+                          "properties": {
+                            "clientSamplePercentage": {
+                              "nullable": true,
+                              "type": "number"
+                            },
+                            "overallSamplePercentage": {
+                              "nullable": true,
+                              "type": "number"
+                            },
+                            "randomSamplePercentage": {
+                              "nullable": true,
+                              "type": "number"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "verbose": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "zipkinConfig": {
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "collectorEndpoint": {
+                              "type": "string"
+                            },
+                            "collectorEndpointVersion": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "collectorUpstreamRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sharedSpanContext": {
+                              "nullable": true,
+                              "type": "boolean"
+                            },
+                            "traceId128bit": {
+                              "nullable": true,
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "upgrades": {
+                      "items": {
+                        "properties": {
+                          "websocket": {
+                            "properties": {
+                              "enabled": {
+                                "nullable": true,
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "useRemoteAddress": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "uuidRequestIdConfig": {
+                      "properties": {
+                        "packTraceReason": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "useRequestIdForTraceSampling": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "via": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "xffNumTrustedHops": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "leftmostXffAddress": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "proxyLatency": {
+                  "properties": {
+                    "chargeClusterStat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "chargeListenerStat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "emitDynamicMetadata": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "measureRequestInternally": {
+                      "type": "boolean"
+                    },
+                    "request": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "response": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ratelimitServer": {
+                  "properties": {
+                    "denyOnFail": {
+                      "type": "boolean"
+                    },
+                    "enableXRatelimitHeaders": {
+                      "type": "boolean"
+                    },
+                    "rateLimitBeforeAuth": {
+                      "type": "boolean"
+                    },
+                    "ratelimitServerRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "requestTimeout": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sanitizeClusterHeader": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "waf": {
+                  "properties": {
+                    "auditLogging": {
+                      "properties": {
+                        "action": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "location": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "configMapRuleSets": {
+                      "items": {
+                        "properties": {
+                          "configMapRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "dataMapKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "coreRuleSet": {
+                      "properties": {
+                        "customSettingsFile": {
+                          "type": "string"
+                        },
+                        "customSettingsString": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "customInterventionMessage": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "requestHeadersOnly": {
+                      "type": "boolean"
+                    },
+                    "responseHeadersOnly": {
+                      "type": "boolean"
+                    },
+                    "ruleSets": {
+                      "items": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "files": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ruleStr": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "wasm": {
+                  "properties": {
+                    "filters": {
+                      "items": {
+                        "properties": {
+                          "config": {
+                            "type": "object",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "failOpen": {
+                            "type": "boolean"
+                          },
+                          "filePath": {
+                            "type": "string"
+                          },
+                          "filterStage": {
+                            "properties": {
+                              "predicate": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "stage": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "rootId": {
+                            "type": "string"
+                          },
+                          "vmType": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "virtualServiceExpressions": {
+              "properties": {
+                "expressions": {
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "values": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "virtualServiceNamespaces": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "virtualServiceSelector": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "virtualServices": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "hybridGateway": {
+          "properties": {
+            "delegatedHttpGateways": {
+              "properties": {
+                "httpConnectionManagerSettings": {
+                  "properties": {
+                    "acceptHttp10": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "allowChunkedLength": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "codecType": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "defaultHostForHttp10": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "delayedCloseTimeout": {
+                      "type": "string"
+                    },
+                    "drainTimeout": {
+                      "type": "string"
+                    },
+                    "enableTrailers": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "forwardClientCertDetails": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "generateRequestId": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "headersWithUnderscoresAction": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "http2ProtocolOptions": {
+                      "properties": {
+                        "initialConnectionWindowSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "initialStreamWindowSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "maxConcurrentStreams": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "overrideStreamErrorOnInvalidHttpMessage": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "idleTimeout": {
+                      "type": "string"
+                    },
+                    "internalAddressConfig": {
+                      "properties": {
+                        "cidrRanges": {
+                          "items": {
+                            "properties": {
+                              "addressPrefix": {
+                                "type": "string"
+                              },
+                              "prefixLen": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "unixSockets": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "maxConnectionDuration": {
+                      "type": "string"
+                    },
+                    "maxHeadersCount": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "maxRequestHeadersKb": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "maxRequestsPerConnection": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "maxStreamDuration": {
+                      "type": "string"
+                    },
+                    "mergeSlashes": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "normalizePath": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "pathWithEscapedSlashesAction": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "preserveCaseHeaderKeyFormat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "preserveExternalRequestId": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "properCaseHeaderKeyFormat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "proxy100Continue": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "requestHeadersTimeout": {
+                      "type": "string"
+                    },
+                    "requestTimeout": {
+                      "type": "string"
+                    },
+                    "serverHeaderTransformation": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "serverName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "setCurrentClientCertDetails": {
+                      "properties": {
+                        "cert": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "chain": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "dns": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "subject": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "uri": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "skipXffAppend": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "streamIdleTimeout": {
+                      "type": "string"
+                    },
+                    "stripAnyHostPort": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "tracing": {
+                      "properties": {
+                        "datadogConfig": {
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "collectorUpstreamRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceName": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "environmentVariablesForTags": {
+                          "items": {
+                            "properties": {
+                              "defaultValue": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "name": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "tag": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "literalsForTags": {
+                          "items": {
+                            "properties": {
+                              "tag": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "value": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "openCensusConfig": {
+                          "properties": {
+                            "grpcAddress": {
+                              "properties": {
+                                "statPrefix": {
+                                  "type": "string"
+                                },
+                                "targetUri": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "httpAddress": {
+                              "type": "string"
+                            },
+                            "incomingTraceContext": {
+                              "items": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "array"
+                            },
+                            "ocagentExporterEnabled": {
+                              "type": "boolean"
+                            },
+                            "outgoingTraceContext": {
+                              "items": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "array"
+                            },
+                            "traceConfig": {
+                              "properties": {
+                                "constantSampler": {
+                                  "properties": {
+                                    "decision": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "maxNumberOfAnnotations": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "maxNumberOfAttributes": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "maxNumberOfLinks": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "maxNumberOfMessageEvents": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "probabilitySampler": {
+                                  "properties": {
+                                    "samplingProbability": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "rateLimitingSampler": {
+                                  "properties": {
+                                    "qps": {
+                                      "format": "int64",
+                                      "type": "integer",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "openTelemetryConfig": {
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "collectorUpstreamRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "requestHeadersForTags": {
+                          "items": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "tracePercentages": {
+                          "properties": {
+                            "clientSamplePercentage": {
+                              "nullable": true,
+                              "type": "number"
+                            },
+                            "overallSamplePercentage": {
+                              "nullable": true,
+                              "type": "number"
+                            },
+                            "randomSamplePercentage": {
+                              "nullable": true,
+                              "type": "number"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "verbose": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "zipkinConfig": {
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "collectorEndpoint": {
+                              "type": "string"
+                            },
+                            "collectorEndpointVersion": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "collectorUpstreamRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sharedSpanContext": {
+                              "nullable": true,
+                              "type": "boolean"
+                            },
+                            "traceId128bit": {
+                              "nullable": true,
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "upgrades": {
+                      "items": {
+                        "properties": {
+                          "websocket": {
+                            "properties": {
+                              "enabled": {
+                                "nullable": true,
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "useRemoteAddress": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "uuidRequestIdConfig": {
+                      "properties": {
+                        "packTraceReason": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "useRequestIdForTraceSampling": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "via": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "xffNumTrustedHops": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "preventChildOverrides": {
+                  "type": "boolean"
+                },
+                "ref": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "selector": {
+                  "properties": {
+                    "expressions": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "values": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "namespaces": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sslConfig": {
+                  "properties": {
+                    "alpnProtocols": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "disableTlsSessionResumption": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "oneWayTls": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "parameters": {
+                      "properties": {
+                        "cipherSuites": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "ecdhCurves": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "maximumProtocolVersion": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "minimumProtocolVersion": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sds": {
+                      "properties": {
+                        "callCredentials": {
+                          "properties": {
+                            "fileCredentialSource": {
+                              "properties": {
+                                "header": {
+                                  "type": "string"
+                                },
+                                "tokenFileName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "certificatesSecretName": {
+                          "type": "string"
+                        },
+                        "clusterName": {
+                          "type": "string"
+                        },
+                        "targetUri": {
+                          "type": "string"
+                        },
+                        "validationContextName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sniDomains": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "sslFiles": {
+                      "properties": {
+                        "rootCa": {
+                          "type": "string"
+                        },
+                        "tlsCert": {
+                          "type": "string"
+                        },
+                        "tlsKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transportSocketConnectTimeout": {
+                      "type": "string"
+                    },
+                    "verifySubjectAltName": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "matchedGateways": {
+              "items": {
+                "properties": {
+                  "httpGateway": {
+                    "properties": {
+                      "options": {
+                        "properties": {
+                          "buffer": {
+                            "properties": {
+                              "maxRequestBytes": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "caching": {
+                            "properties": {
+                              "allowedVaryHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "exact": {
+                                      "type": "string"
+                                    },
+                                    "ignoreCase": {
+                                      "type": "boolean"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "safeRegex": {
+                                      "properties": {
+                                        "googleRe2": {
+                                          "properties": {
+                                            "maxProgramSize": {
+                                              "maximum": 4294967295,
+                                              "minimum": 0,
+                                              "nullable": true,
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "suffix": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "cachingServiceRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "maxPayloadSize": {
+                                "properties": {
+                                  "value": {
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "timeout": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "csrf": {
+                            "properties": {
+                              "additionalOrigins": {
+                                "items": {
+                                  "properties": {
+                                    "exact": {
+                                      "type": "string"
+                                    },
+                                    "ignoreCase": {
+                                      "type": "boolean"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "safeRegex": {
+                                      "properties": {
+                                        "googleRe2": {
+                                          "properties": {
+                                            "maxProgramSize": {
+                                              "maximum": 4294967295,
+                                              "minimum": 0,
+                                              "nullable": true,
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "suffix": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "filterEnabled": {
+                                "properties": {
+                                  "defaultValue": {
+                                    "properties": {
+                                      "denominator": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "numerator": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "runtimeKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "shadowEnabled": {
+                                "properties": {
+                                  "defaultValue": {
+                                    "properties": {
+                                      "denominator": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "numerator": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "runtimeKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "dlp": {
+                            "properties": {
+                              "dlpRules": {
+                                "items": {
+                                  "properties": {
+                                    "actions": {
+                                      "items": {
+                                        "properties": {
+                                          "actionType": {
+                                            "type": "string",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "customAction": {
+                                            "properties": {
+                                              "maskChar": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "percent": {
+                                                "properties": {
+                                                  "value": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "regex": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "regexActions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "regex": {
+                                                      "type": "string"
+                                                    },
+                                                    "subgroup": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "keyValueAction": {
+                                            "properties": {
+                                              "keyToMask": {
+                                                "type": "string"
+                                              },
+                                              "maskChar": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "percent": {
+                                                "properties": {
+                                                  "value": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "shadow": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "matcher": {
+                                      "properties": {
+                                        "caseSensitive": {
+                                          "nullable": true,
+                                          "type": "boolean"
+                                        },
+                                        "exact": {
+                                          "type": "string"
+                                        },
+                                        "headers": {
+                                          "items": {
+                                            "properties": {
+                                              "invertMatch": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "boolean"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "methods": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "queryParameters": {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "boolean"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "enabledFor": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "dynamicForwardProxy": {
+                            "properties": {
+                              "dnsCacheConfig": {
+                                "properties": {
+                                  "appleDns": {
+                                    "type": "object"
+                                  },
+                                  "caresDns": {
+                                    "properties": {
+                                      "dnsResolverOptions": {
+                                        "properties": {
+                                          "noDefaultSearchDomain": {
+                                            "type": "boolean"
+                                          },
+                                          "useTcpForDnsLookups": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "resolvers": {
+                                        "items": {
+                                          "properties": {
+                                            "pipe": {
+                                              "properties": {
+                                                "mode": {
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "socketAddress": {
+                                              "properties": {
+                                                "address": {
+                                                  "type": "string"
+                                                },
+                                                "ipv4Compat": {
+                                                  "type": "boolean"
+                                                },
+                                                "namedPort": {
+                                                  "type": "string"
+                                                },
+                                                "portValue": {
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                },
+                                                "protocol": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resolverName": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dnsCacheCircuitBreaker": {
+                                    "properties": {
+                                      "maxPendingRequests": {
+                                        "maximum": 4294967295,
+                                        "minimum": 0,
+                                        "nullable": true,
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dnsFailureRefreshRate": {
+                                    "properties": {
+                                      "baseInterval": {
+                                        "type": "string"
+                                      },
+                                      "maxInterval": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dnsLookupFamily": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "dnsQueryTimeout": {
+                                    "type": "string"
+                                  },
+                                  "dnsRefreshRate": {
+                                    "type": "string"
+                                  },
+                                  "hostTtl": {
+                                    "type": "string"
+                                  },
+                                  "maxHosts": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  },
+                                  "preresolveHostnames": {
+                                    "items": {
+                                      "properties": {
+                                        "address": {
+                                          "type": "string"
+                                        },
+                                        "ipv4Compat": {
+                                          "type": "boolean"
+                                        },
+                                        "namedPort": {
+                                          "type": "string"
+                                        },
+                                        "portValue": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "protocol": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resolverName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "saveUpstreamAddress": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "extauth": {
+                            "properties": {
+                              "clearRouteCache": {
+                                "type": "boolean"
+                              },
+                              "extauthzServerRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureModeAllow": {
+                                "type": "boolean"
+                              },
+                              "grpcService": {
+                                "properties": {
+                                  "authority": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpService": {
+                                "properties": {
+                                  "pathPrefix": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "properties": {
+                                      "allowedHeaders": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "allowedHeadersRegex": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "headersToAdd": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "response": {
+                                    "properties": {
+                                      "allowedClientHeaders": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "allowedUpstreamHeaders": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "allowedUpstreamHeadersToAppend": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "requestBody": {
+                                "properties": {
+                                  "allowPartialMessage": {
+                                    "type": "boolean"
+                                  },
+                                  "maxRequestBytes": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "packAsBytes": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "requestTimeout": {
+                                "type": "string"
+                              },
+                              "statPrefix": {
+                                "type": "string"
+                              },
+                              "statusOnError": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "transportApiVersion": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "userIdHeader": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "extensions": {
+                            "properties": {
+                              "configs": {
+                                "additionalProperties": {
+                                  "type": "object",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "grpcJsonTranscoder": {
+                            "properties": {
+                              "autoMapping": {
+                                "type": "boolean"
+                              },
+                              "convertGrpcStatus": {
+                                "type": "boolean"
+                              },
+                              "ignoreUnknownQueryParameters": {
+                                "type": "boolean"
+                              },
+                              "ignoredQueryParameters": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matchIncomingRequestRoute": {
+                                "type": "boolean"
+                              },
+                              "printOptions": {
+                                "properties": {
+                                  "addWhitespace": {
+                                    "type": "boolean"
+                                  },
+                                  "alwaysPrintEnumsAsInts": {
+                                    "type": "boolean"
+                                  },
+                                  "alwaysPrintPrimitiveFields": {
+                                    "type": "boolean"
+                                  },
+                                  "preserveProtoFieldNames": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "protoDescriptor": {
+                                "type": "string"
+                              },
+                              "protoDescriptorBin": {
+                                "format": "byte",
+                                "type": "string"
+                              },
+                              "protoDescriptorConfigMap": {
+                                "properties": {
+                                  "configMapRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "services": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "grpcWeb": {
+                            "properties": {
+                              "disable": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gzip": {
+                            "properties": {
+                              "compressionLevel": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "compressionStrategy": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "contentLength": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "contentType": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "disableOnEtagHeader": {
+                                "type": "boolean"
+                              },
+                              "memoryLevel": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "removeAcceptEncodingHeader": {
+                                "type": "boolean"
+                              },
+                              "windowBits": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "healthCheck": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpConnectionManagerSettings": {
+                            "properties": {
+                              "acceptHttp10": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "allowChunkedLength": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "codecType": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "defaultHostForHttp10": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "delayedCloseTimeout": {
+                                "type": "string"
+                              },
+                              "drainTimeout": {
+                                "type": "string"
+                              },
+                              "enableTrailers": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "forwardClientCertDetails": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "generateRequestId": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "headersWithUnderscoresAction": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "http2ProtocolOptions": {
+                                "properties": {
+                                  "initialConnectionWindowSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  },
+                                  "initialStreamWindowSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  },
+                                  "maxConcurrentStreams": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  },
+                                  "overrideStreamErrorOnInvalidHttpMessage": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "idleTimeout": {
+                                "type": "string"
+                              },
+                              "internalAddressConfig": {
+                                "properties": {
+                                  "cidrRanges": {
+                                    "items": {
+                                      "properties": {
+                                        "addressPrefix": {
+                                          "type": "string"
+                                        },
+                                        "prefixLen": {
+                                          "maximum": 4294967295,
+                                          "minimum": 0,
+                                          "nullable": true,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "unixSockets": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "maxConnectionDuration": {
+                                "type": "string"
+                              },
+                              "maxHeadersCount": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "maxRequestHeadersKb": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "maxRequestsPerConnection": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "maxStreamDuration": {
+                                "type": "string"
+                              },
+                              "mergeSlashes": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "normalizePath": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "pathWithEscapedSlashesAction": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "preserveCaseHeaderKeyFormat": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "preserveExternalRequestId": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "properCaseHeaderKeyFormat": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "proxy100Continue": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "requestHeadersTimeout": {
+                                "type": "string"
+                              },
+                              "requestTimeout": {
+                                "type": "string"
+                              },
+                              "serverHeaderTransformation": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "serverName": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "setCurrentClientCertDetails": {
+                                "properties": {
+                                  "cert": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  },
+                                  "chain": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  },
+                                  "dns": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  },
+                                  "subject": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  },
+                                  "uri": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "skipXffAppend": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "streamIdleTimeout": {
+                                "type": "string"
+                              },
+                              "stripAnyHostPort": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "tracing": {
+                                "properties": {
+                                  "datadogConfig": {
+                                    "properties": {
+                                      "clusterName": {
+                                        "type": "string"
+                                      },
+                                      "collectorUpstreamRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceName": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "environmentVariablesForTags": {
+                                    "items": {
+                                      "properties": {
+                                        "defaultValue": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "tag": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "literalsForTags": {
+                                    "items": {
+                                      "properties": {
+                                        "tag": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "nullable": true,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "openCensusConfig": {
+                                    "properties": {
+                                      "grpcAddress": {
+                                        "properties": {
+                                          "statPrefix": {
+                                            "type": "string"
+                                          },
+                                          "targetUri": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpAddress": {
+                                        "type": "string"
+                                      },
+                                      "incomingTraceContext": {
+                                        "items": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ocagentExporterEnabled": {
+                                        "type": "boolean"
+                                      },
+                                      "outgoingTraceContext": {
+                                        "items": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "array"
+                                      },
+                                      "traceConfig": {
+                                        "properties": {
+                                          "constantSampler": {
+                                            "properties": {
+                                              "decision": {
+                                                "type": "string",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "maxNumberOfAnnotations": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "maxNumberOfAttributes": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "maxNumberOfLinks": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "maxNumberOfMessageEvents": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "probabilitySampler": {
+                                            "properties": {
+                                              "samplingProbability": {
+                                                "type": "number"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "rateLimitingSampler": {
+                                            "properties": {
+                                              "qps": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "openTelemetryConfig": {
+                                    "properties": {
+                                      "clusterName": {
+                                        "type": "string"
+                                      },
+                                      "collectorUpstreamRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "requestHeadersForTags": {
+                                    "items": {
+                                      "nullable": true,
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tracePercentages": {
+                                    "properties": {
+                                      "clientSamplePercentage": {
+                                        "nullable": true,
+                                        "type": "number"
+                                      },
+                                      "overallSamplePercentage": {
+                                        "nullable": true,
+                                        "type": "number"
+                                      },
+                                      "randomSamplePercentage": {
+                                        "nullable": true,
+                                        "type": "number"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "verbose": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  },
+                                  "zipkinConfig": {
+                                    "properties": {
+                                      "clusterName": {
+                                        "type": "string"
+                                      },
+                                      "collectorEndpoint": {
+                                        "type": "string"
+                                      },
+                                      "collectorEndpointVersion": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "collectorUpstreamRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sharedSpanContext": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      },
+                                      "traceId128bit": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "upgrades": {
+                                "items": {
+                                  "properties": {
+                                    "websocket": {
+                                      "properties": {
+                                        "enabled": {
+                                          "nullable": true,
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "useRemoteAddress": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "uuidRequestIdConfig": {
+                                "properties": {
+                                  "packTraceReason": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  },
+                                  "useRequestIdForTraceSampling": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "via": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "xffNumTrustedHops": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "leftmostXffAddress": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "proxyLatency": {
+                            "properties": {
+                              "chargeClusterStat": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "chargeListenerStat": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "emitDynamicMetadata": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "measureRequestInternally": {
+                                "type": "boolean"
+                              },
+                              "request": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "response": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ratelimitServer": {
+                            "properties": {
+                              "denyOnFail": {
+                                "type": "boolean"
+                              },
+                              "enableXRatelimitHeaders": {
+                                "type": "boolean"
+                              },
+                              "rateLimitBeforeAuth": {
+                                "type": "boolean"
+                              },
+                              "ratelimitServerRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "requestTimeout": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sanitizeClusterHeader": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "waf": {
+                            "properties": {
+                              "auditLogging": {
+                                "properties": {
+                                  "action": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "location": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMapRuleSets": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "dataMapKeys": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "coreRuleSet": {
+                                "properties": {
+                                  "customSettingsFile": {
+                                    "type": "string"
+                                  },
+                                  "customSettingsString": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "customInterventionMessage": {
+                                "type": "string"
+                              },
+                              "disabled": {
+                                "type": "boolean"
+                              },
+                              "requestHeadersOnly": {
+                                "type": "boolean"
+                              },
+                              "responseHeadersOnly": {
+                                "type": "boolean"
+                              },
+                              "ruleSets": {
+                                "items": {
+                                  "properties": {
+                                    "directory": {
+                                      "type": "string"
+                                    },
+                                    "files": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ruleStr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "wasm": {
+                            "properties": {
+                              "filters": {
+                                "items": {
+                                  "properties": {
+                                    "config": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
+                                    "failOpen": {
+                                      "type": "boolean"
+                                    },
+                                    "filePath": {
+                                      "type": "string"
+                                    },
+                                    "filterStage": {
+                                      "properties": {
+                                        "predicate": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "stage": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "image": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "rootId": {
+                                      "type": "string"
+                                    },
+                                    "vmType": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "virtualServiceExpressions": {
+                        "properties": {
+                          "expressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "virtualServiceNamespaces": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "virtualServiceSelector": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "virtualServices": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "matcher": {
+                    "properties": {
+                      "sourcePrefixRanges": {
+                        "items": {
+                          "properties": {
+                            "addressPrefix": {
+                              "type": "string"
+                            },
+                            "prefixLen": {
+                              "maximum": 4294967295,
+                              "minimum": 0,
+                              "nullable": true,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "sslConfig": {
+                        "properties": {
+                          "alpnProtocols": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "disableTlsSessionResumption": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "oneWayTls": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "parameters": {
+                            "properties": {
+                              "cipherSuites": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ecdhCurves": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "maximumProtocolVersion": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "minimumProtocolVersion": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sds": {
+                            "properties": {
+                              "callCredentials": {
+                                "properties": {
+                                  "fileCredentialSource": {
+                                    "properties": {
+                                      "header": {
+                                        "type": "string"
+                                      },
+                                      "tokenFileName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "certificatesSecretName": {
+                                "type": "string"
+                              },
+                              "clusterName": {
+                                "type": "string"
+                              },
+                              "targetUri": {
+                                "type": "string"
+                              },
+                              "validationContextName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sniDomains": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "sslFiles": {
+                            "properties": {
+                              "rootCa": {
+                                "type": "string"
+                              },
+                              "tlsCert": {
+                                "type": "string"
+                              },
+                              "tlsKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "transportSocketConnectTimeout": {
+                            "type": "string"
+                          },
+                          "verifySubjectAltName": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tcpGateway": {
+                    "properties": {
+                      "options": {
+                        "properties": {
+                          "tcpProxySettings": {
+                            "properties": {
+                              "idleTimeout": {
+                                "type": "string"
+                              },
+                              "maxConnectAttempts": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "tunnelingConfig": {
+                                "properties": {
+                                  "headersToAdd": {
+                                    "items": {
+                                      "properties": {
+                                        "append": {
+                                          "nullable": true,
+                                          "type": "boolean"
+                                        },
+                                        "header": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "hostname": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpHosts": {
+                        "items": {
+                          "properties": {
+                            "destination": {
+                              "properties": {
+                                "forwardSniClusterName": {
+                                  "maxProperties": 0,
+                                  "type": "object"
+                                },
+                                "multi": {
+                                  "properties": {
+                                    "destinations": {
+                                      "items": {
+                                        "properties": {
+                                          "destination": {
+                                            "properties": {
+                                              "consul": {
+                                                "properties": {
+                                                  "dataCenters": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "serviceName": {
+                                                    "type": "string"
+                                                  },
+                                                  "tags": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "destinationSpec": {
+                                                "properties": {
+                                                  "aws": {
+                                                    "properties": {
+                                                      "invocationStyle": {
+                                                        "type": "string",
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "logicalName": {
+                                                        "type": "string"
+                                                      },
+                                                      "requestTransformation": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "responseTransformation": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "unwrapAsAlb": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "unwrapAsApiGateway": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "wrapAsApiGateway": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "azure": {
+                                                    "properties": {
+                                                      "functionName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "grpc": {
+                                                    "properties": {
+                                                      "function": {
+                                                        "type": "string"
+                                                      },
+                                                      "package": {
+                                                        "type": "string"
+                                                      },
+                                                      "parameters": {
+                                                        "properties": {
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "path": {
+                                                            "nullable": true,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "service": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "rest": {
+                                                    "properties": {
+                                                      "functionName": {
+                                                        "type": "string"
+                                                      },
+                                                      "parameters": {
+                                                        "properties": {
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "path": {
+                                                            "nullable": true,
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "responseTransformation": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "kube": {
+                                                "properties": {
+                                                  "port": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  },
+                                                  "ref": {
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "subset": {
+                                                "properties": {
+                                                  "values": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "upstream": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "options": {
+                                            "properties": {
+                                              "bufferPerRoute": {
+                                                "properties": {
+                                                  "buffer": {
+                                                    "properties": {
+                                                      "maxRequestBytes": {
+                                                        "maximum": 4294967295,
+                                                        "minimum": 0,
+                                                        "nullable": true,
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "disabled": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "csrf": {
+                                                "properties": {
+                                                  "additionalOrigins": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "exact": {
+                                                          "type": "string"
+                                                        },
+                                                        "ignoreCase": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "prefix": {
+                                                          "type": "string"
+                                                        },
+                                                        "safeRegex": {
+                                                          "properties": {
+                                                            "googleRe2": {
+                                                              "properties": {
+                                                                "maxProgramSize": {
+                                                                  "maximum": 4294967295,
+                                                                  "minimum": 0,
+                                                                  "nullable": true,
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "regex": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "suffix": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "filterEnabled": {
+                                                    "properties": {
+                                                      "defaultValue": {
+                                                        "properties": {
+                                                          "denominator": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "numerator": {
+                                                            "format": "int32",
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "runtimeKey": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "shadowEnabled": {
+                                                    "properties": {
+                                                      "defaultValue": {
+                                                        "properties": {
+                                                          "denominator": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "numerator": {
+                                                            "format": "int32",
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "runtimeKey": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "extauth": {
+                                                "properties": {
+                                                  "configRef": {
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "customAuth": {
+                                                    "properties": {
+                                                      "contextExtensions": {
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "disable": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "extensions": {
+                                                "properties": {
+                                                  "configs": {
+                                                    "additionalProperties": {
+                                                      "type": "object",
+                                                      "x-kubernetes-preserve-unknown-fields": true
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "headerManipulation": {
+                                                "properties": {
+                                                  "requestHeadersToAdd": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "append": {
+                                                          "nullable": true,
+                                                          "type": "boolean"
+                                                        },
+                                                        "header": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "headerSecretRef": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "namespace": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "requestHeadersToRemove": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "responseHeadersToAdd": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "append": {
+                                                          "nullable": true,
+                                                          "type": "boolean"
+                                                        },
+                                                        "header": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "responseHeadersToRemove": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "stagedTransformations": {
+                                                "properties": {
+                                                  "early": {
+                                                    "properties": {
+                                                      "requestTransforms": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "clearRouteCache": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "matcher": {
+                                                              "properties": {
+                                                                "caseSensitive": {
+                                                                  "nullable": true,
+                                                                  "type": "boolean"
+                                                                },
+                                                                "exact": {
+                                                                  "type": "string"
+                                                                },
+                                                                "headers": {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "invertMatch": {
+                                                                        "type": "boolean"
+                                                                      },
+                                                                      "name": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "regex": {
+                                                                        "type": "boolean"
+                                                                      },
+                                                                      "value": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "methods": {
+                                                                  "items": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "prefix": {
+                                                                  "type": "string"
+                                                                },
+                                                                "queryParameters": {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "name": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "regex": {
+                                                                        "type": "boolean"
+                                                                      },
+                                                                      "value": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "requestTransformation": {
+                                                              "properties": {
+                                                                "headerBodyTransform": {
+                                                                  "properties": {
+                                                                    "addRequestMetadata": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "transformationTemplate": {
+                                                                  "properties": {
+                                                                    "advancedTemplates": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "body": {
+                                                                      "properties": {
+                                                                        "text": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    "dynamicMetadataValues": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "metadataNamespace": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "extractors": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "body": {
+                                                                            "maxProperties": 0,
+                                                                            "type": "object"
+                                                                          },
+                                                                          "header": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "regex": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "subgroup": {
+                                                                            "format": "int32",
+                                                                            "type": "integer"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headers": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "text": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headersToAppend": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "headersToRemove": {
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "ignoreErrorOnParse": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "mergeExtractorsToBody": {
+                                                                      "type": "object"
+                                                                    },
+                                                                    "parseBodyBehavior": {
+                                                                      "type": "string",
+                                                                      "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "passthrough": {
+                                                                      "type": "object"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "xsltTransformation": {
+                                                                  "properties": {
+                                                                    "nonXmlTransform": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "setContentType": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "xslt": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "responseTransformation": {
+                                                              "properties": {
+                                                                "headerBodyTransform": {
+                                                                  "properties": {
+                                                                    "addRequestMetadata": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "transformationTemplate": {
+                                                                  "properties": {
+                                                                    "advancedTemplates": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "body": {
+                                                                      "properties": {
+                                                                        "text": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    "dynamicMetadataValues": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "metadataNamespace": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "extractors": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "body": {
+                                                                            "maxProperties": 0,
+                                                                            "type": "object"
+                                                                          },
+                                                                          "header": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "regex": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "subgroup": {
+                                                                            "format": "int32",
+                                                                            "type": "integer"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headers": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "text": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headersToAppend": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "headersToRemove": {
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "ignoreErrorOnParse": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "mergeExtractorsToBody": {
+                                                                      "type": "object"
+                                                                    },
+                                                                    "parseBodyBehavior": {
+                                                                      "type": "string",
+                                                                      "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "passthrough": {
+                                                                      "type": "object"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "xsltTransformation": {
+                                                                  "properties": {
+                                                                    "nonXmlTransform": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "setContentType": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "xslt": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "responseTransforms": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "matchers": {
+                                                              "items": {
+                                                                "properties": {
+                                                                  "invertMatch": {
+                                                                    "type": "boolean"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "regex": {
+                                                                    "type": "boolean"
+                                                                  },
+                                                                  "value": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "responseCodeDetails": {
+                                                              "type": "string"
+                                                            },
+                                                            "responseTransformation": {
+                                                              "properties": {
+                                                                "headerBodyTransform": {
+                                                                  "properties": {
+                                                                    "addRequestMetadata": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "transformationTemplate": {
+                                                                  "properties": {
+                                                                    "advancedTemplates": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "body": {
+                                                                      "properties": {
+                                                                        "text": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    "dynamicMetadataValues": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "metadataNamespace": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "extractors": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "body": {
+                                                                            "maxProperties": 0,
+                                                                            "type": "object"
+                                                                          },
+                                                                          "header": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "regex": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "subgroup": {
+                                                                            "format": "int32",
+                                                                            "type": "integer"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headers": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "text": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headersToAppend": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "headersToRemove": {
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "ignoreErrorOnParse": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "mergeExtractorsToBody": {
+                                                                      "type": "object"
+                                                                    },
+                                                                    "parseBodyBehavior": {
+                                                                      "type": "string",
+                                                                      "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "passthrough": {
+                                                                      "type": "object"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "xsltTransformation": {
+                                                                  "properties": {
+                                                                    "nonXmlTransform": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "setContentType": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "xslt": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "inheritTransformation": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "regular": {
+                                                    "properties": {
+                                                      "requestTransforms": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "clearRouteCache": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "matcher": {
+                                                              "properties": {
+                                                                "caseSensitive": {
+                                                                  "nullable": true,
+                                                                  "type": "boolean"
+                                                                },
+                                                                "exact": {
+                                                                  "type": "string"
+                                                                },
+                                                                "headers": {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "invertMatch": {
+                                                                        "type": "boolean"
+                                                                      },
+                                                                      "name": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "regex": {
+                                                                        "type": "boolean"
+                                                                      },
+                                                                      "value": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "methods": {
+                                                                  "items": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "prefix": {
+                                                                  "type": "string"
+                                                                },
+                                                                "queryParameters": {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "name": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "regex": {
+                                                                        "type": "boolean"
+                                                                      },
+                                                                      "value": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "requestTransformation": {
+                                                              "properties": {
+                                                                "headerBodyTransform": {
+                                                                  "properties": {
+                                                                    "addRequestMetadata": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "transformationTemplate": {
+                                                                  "properties": {
+                                                                    "advancedTemplates": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "body": {
+                                                                      "properties": {
+                                                                        "text": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    "dynamicMetadataValues": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "metadataNamespace": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "extractors": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "body": {
+                                                                            "maxProperties": 0,
+                                                                            "type": "object"
+                                                                          },
+                                                                          "header": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "regex": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "subgroup": {
+                                                                            "format": "int32",
+                                                                            "type": "integer"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headers": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "text": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headersToAppend": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "headersToRemove": {
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "ignoreErrorOnParse": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "mergeExtractorsToBody": {
+                                                                      "type": "object"
+                                                                    },
+                                                                    "parseBodyBehavior": {
+                                                                      "type": "string",
+                                                                      "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "passthrough": {
+                                                                      "type": "object"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "xsltTransformation": {
+                                                                  "properties": {
+                                                                    "nonXmlTransform": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "setContentType": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "xslt": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "responseTransformation": {
+                                                              "properties": {
+                                                                "headerBodyTransform": {
+                                                                  "properties": {
+                                                                    "addRequestMetadata": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "transformationTemplate": {
+                                                                  "properties": {
+                                                                    "advancedTemplates": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "body": {
+                                                                      "properties": {
+                                                                        "text": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    "dynamicMetadataValues": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "metadataNamespace": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "extractors": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "body": {
+                                                                            "maxProperties": 0,
+                                                                            "type": "object"
+                                                                          },
+                                                                          "header": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "regex": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "subgroup": {
+                                                                            "format": "int32",
+                                                                            "type": "integer"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headers": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "text": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headersToAppend": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "headersToRemove": {
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "ignoreErrorOnParse": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "mergeExtractorsToBody": {
+                                                                      "type": "object"
+                                                                    },
+                                                                    "parseBodyBehavior": {
+                                                                      "type": "string",
+                                                                      "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "passthrough": {
+                                                                      "type": "object"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "xsltTransformation": {
+                                                                  "properties": {
+                                                                    "nonXmlTransform": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "setContentType": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "xslt": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "responseTransforms": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "matchers": {
+                                                              "items": {
+                                                                "properties": {
+                                                                  "invertMatch": {
+                                                                    "type": "boolean"
+                                                                  },
+                                                                  "name": {
+                                                                    "type": "string"
+                                                                  },
+                                                                  "regex": {
+                                                                    "type": "boolean"
+                                                                  },
+                                                                  "value": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            "responseCodeDetails": {
+                                                              "type": "string"
+                                                            },
+                                                            "responseTransformation": {
+                                                              "properties": {
+                                                                "headerBodyTransform": {
+                                                                  "properties": {
+                                                                    "addRequestMetadata": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "transformationTemplate": {
+                                                                  "properties": {
+                                                                    "advancedTemplates": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "body": {
+                                                                      "properties": {
+                                                                        "text": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object",
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    "dynamicMetadataValues": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "metadataNamespace": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "extractors": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "body": {
+                                                                            "maxProperties": 0,
+                                                                            "type": "object"
+                                                                          },
+                                                                          "header": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "regex": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "subgroup": {
+                                                                            "format": "int32",
+                                                                            "type": "integer"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headers": {
+                                                                      "additionalProperties": {
+                                                                        "properties": {
+                                                                          "text": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "headersToAppend": {
+                                                                      "items": {
+                                                                        "properties": {
+                                                                          "key": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "value": {
+                                                                            "properties": {
+                                                                              "text": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                          }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "headersToRemove": {
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "type": "array"
+                                                                    },
+                                                                    "ignoreErrorOnParse": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "mergeExtractorsToBody": {
+                                                                      "type": "object"
+                                                                    },
+                                                                    "parseBodyBehavior": {
+                                                                      "type": "string",
+                                                                      "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "passthrough": {
+                                                                      "type": "object"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                },
+                                                                "xsltTransformation": {
+                                                                  "properties": {
+                                                                    "nonXmlTransform": {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    "setContentType": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "xslt": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "transformations": {
+                                                "properties": {
+                                                  "clearRouteCache": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "requestTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "responseTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "maximum": 4294967295,
+                                            "minimum": 0,
+                                            "nullable": true,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "single": {
+                                  "properties": {
+                                    "consul": {
+                                      "properties": {
+                                        "dataCenters": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "serviceName": {
+                                          "type": "string"
+                                        },
+                                        "tags": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "destinationSpec": {
+                                      "properties": {
+                                        "aws": {
+                                          "properties": {
+                                            "invocationStyle": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "logicalName": {
+                                              "type": "string"
+                                            },
+                                            "requestTransformation": {
+                                              "type": "boolean"
+                                            },
+                                            "responseTransformation": {
+                                              "type": "boolean"
+                                            },
+                                            "unwrapAsAlb": {
+                                              "type": "boolean"
+                                            },
+                                            "unwrapAsApiGateway": {
+                                              "type": "boolean"
+                                            },
+                                            "wrapAsApiGateway": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "azure": {
+                                          "properties": {
+                                            "functionName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "grpc": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "properties": {
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "path": {
+                                                  "nullable": true,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "service": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "rest": {
+                                          "properties": {
+                                            "functionName": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "properties": {
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "path": {
+                                                  "nullable": true,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "responseTransformation": {
+                                              "properties": {
+                                                "advancedTemplates": {
+                                                  "type": "boolean"
+                                                },
+                                                "body": {
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "dynamicMetadataValues": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "metadataNamespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "extractors": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "body": {
+                                                        "maxProperties": 0,
+                                                        "type": "object"
+                                                      },
+                                                      "header": {
+                                                        "type": "string"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      },
+                                                      "subgroup": {
+                                                        "format": "int32",
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headersToAppend": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "headersToRemove": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "ignoreErrorOnParse": {
+                                                  "type": "boolean"
+                                                },
+                                                "mergeExtractorsToBody": {
+                                                  "type": "object"
+                                                },
+                                                "parseBodyBehavior": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "passthrough": {
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "kube": {
+                                      "properties": {
+                                        "port": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "ref": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "subset": {
+                                      "properties": {
+                                        "values": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "upstream": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "upstreamGroup": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "sslConfig": {
+                              "properties": {
+                                "alpnProtocols": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "disableTlsSessionResumption": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "oneWayTls": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "parameters": {
+                                  "properties": {
+                                    "cipherSuites": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ecdhCurves": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "maximumProtocolVersion": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "minimumProtocolVersion": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "sds": {
+                                  "properties": {
+                                    "callCredentials": {
+                                      "properties": {
+                                        "fileCredentialSource": {
+                                          "properties": {
+                                            "header": {
+                                              "type": "string"
+                                            },
+                                            "tokenFileName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "certificatesSecretName": {
+                                      "type": "string"
+                                    },
+                                    "clusterName": {
+                                      "type": "string"
+                                    },
+                                    "targetUri": {
+                                      "type": "string"
+                                    },
+                                    "validationContextName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "sniDomains": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "sslFiles": {
+                                  "properties": {
+                                    "rootCa": {
+                                      "type": "string"
+                                    },
+                                    "tlsCert": {
+                                      "type": "string"
+                                    },
+                                    "tlsKey": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "transportSocketConnectTimeout": {
+                                  "type": "string"
+                                },
+                                "verifySubjectAltName": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "options": {
+          "properties": {
+            "accessLoggingService": {
+              "properties": {
+                "accessLog": {
+                  "items": {
+                    "properties": {
+                      "fileSink": {
+                        "properties": {
+                          "jsonFormat": {
+                            "type": "object",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "stringFormat": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "grpcService": {
+                        "properties": {
+                          "additionalRequestHeadersToLog": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "additionalResponseHeadersToLog": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "additionalResponseTrailersToLog": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "logName": {
+                            "type": "string"
+                          },
+                          "staticClusterName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "extensions": {
+              "properties": {
+                "configs": {
+                  "additionalProperties": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "perConnectionBufferLimitBytes": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "proxyProtocol": {
+              "properties": {
+                "allowRequestsWithoutProxyProtocol": {
+                  "type": "boolean"
+                },
+                "rules": {
+                  "items": {
+                    "properties": {
+                      "onTlvPresent": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "metadataNamespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tlvType": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "socketOptions": {
+              "items": {
+                "properties": {
+                  "bufValue": {
+                    "format": "byte",
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "intValue": {
+                    "format": "int64",
+                    "type": "integer",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "level": {
+                    "format": "int64",
+                    "type": "integer",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "name": {
+                    "format": "int64",
+                    "type": "integer",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "state": {
+                    "type": "string",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "proxyNames": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "routeOptions": {
+          "properties": {
+            "maxDirectResponseBodySizeBytes": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ssl": {
+          "type": "boolean"
+        },
+        "tcpGateway": {
+          "properties": {
+            "options": {
+              "properties": {
+                "tcpProxySettings": {
+                  "properties": {
+                    "idleTimeout": {
+                      "type": "string"
+                    },
+                    "maxConnectAttempts": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "tunnelingConfig": {
+                      "properties": {
+                        "headersToAdd": {
+                          "items": {
+                            "properties": {
+                              "append": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "header": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "hostname": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tcpHosts": {
+              "items": {
+                "properties": {
+                  "destination": {
+                    "properties": {
+                      "forwardSniClusterName": {
+                        "maxProperties": 0,
+                        "type": "object"
+                      },
+                      "multi": {
+                        "properties": {
+                          "destinations": {
+                            "items": {
+                              "properties": {
+                                "destination": {
+                                  "properties": {
+                                    "consul": {
+                                      "properties": {
+                                        "dataCenters": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "serviceName": {
+                                          "type": "string"
+                                        },
+                                        "tags": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "destinationSpec": {
+                                      "properties": {
+                                        "aws": {
+                                          "properties": {
+                                            "invocationStyle": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "logicalName": {
+                                              "type": "string"
+                                            },
+                                            "requestTransformation": {
+                                              "type": "boolean"
+                                            },
+                                            "responseTransformation": {
+                                              "type": "boolean"
+                                            },
+                                            "unwrapAsAlb": {
+                                              "type": "boolean"
+                                            },
+                                            "unwrapAsApiGateway": {
+                                              "type": "boolean"
+                                            },
+                                            "wrapAsApiGateway": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "azure": {
+                                          "properties": {
+                                            "functionName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "grpc": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "properties": {
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "path": {
+                                                  "nullable": true,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "service": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "rest": {
+                                          "properties": {
+                                            "functionName": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "properties": {
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "path": {
+                                                  "nullable": true,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "responseTransformation": {
+                                              "properties": {
+                                                "advancedTemplates": {
+                                                  "type": "boolean"
+                                                },
+                                                "body": {
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "dynamicMetadataValues": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "metadataNamespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "extractors": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "body": {
+                                                        "maxProperties": 0,
+                                                        "type": "object"
+                                                      },
+                                                      "header": {
+                                                        "type": "string"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      },
+                                                      "subgroup": {
+                                                        "format": "int32",
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headersToAppend": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "headersToRemove": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "ignoreErrorOnParse": {
+                                                  "type": "boolean"
+                                                },
+                                                "mergeExtractorsToBody": {
+                                                  "type": "object"
+                                                },
+                                                "parseBodyBehavior": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "passthrough": {
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "kube": {
+                                      "properties": {
+                                        "port": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "ref": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "subset": {
+                                      "properties": {
+                                        "values": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "upstream": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "options": {
+                                  "properties": {
+                                    "bufferPerRoute": {
+                                      "properties": {
+                                        "buffer": {
+                                          "properties": {
+                                            "maxRequestBytes": {
+                                              "maximum": 4294967295,
+                                              "minimum": 0,
+                                              "nullable": true,
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "disabled": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "csrf": {
+                                      "properties": {
+                                        "additionalOrigins": {
+                                          "items": {
+                                            "properties": {
+                                              "exact": {
+                                                "type": "string"
+                                              },
+                                              "ignoreCase": {
+                                                "type": "boolean"
+                                              },
+                                              "prefix": {
+                                                "type": "string"
+                                              },
+                                              "safeRegex": {
+                                                "properties": {
+                                                  "googleRe2": {
+                                                    "properties": {
+                                                      "maxProgramSize": {
+                                                        "maximum": 4294967295,
+                                                        "minimum": 0,
+                                                        "nullable": true,
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "suffix": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "filterEnabled": {
+                                          "properties": {
+                                            "defaultValue": {
+                                              "properties": {
+                                                "denominator": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "numerator": {
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "runtimeKey": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "shadowEnabled": {
+                                          "properties": {
+                                            "defaultValue": {
+                                              "properties": {
+                                                "denominator": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "numerator": {
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "runtimeKey": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "extauth": {
+                                      "properties": {
+                                        "configRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "customAuth": {
+                                          "properties": {
+                                            "contextExtensions": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "disable": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "extensions": {
+                                      "properties": {
+                                        "configs": {
+                                          "additionalProperties": {
+                                            "type": "object",
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "headerManipulation": {
+                                      "properties": {
+                                        "requestHeadersToAdd": {
+                                          "items": {
+                                            "properties": {
+                                              "append": {
+                                                "nullable": true,
+                                                "type": "boolean"
+                                              },
+                                              "header": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "headerSecretRef": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "requestHeadersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "responseHeadersToAdd": {
+                                          "items": {
+                                            "properties": {
+                                              "append": {
+                                                "nullable": true,
+                                                "type": "boolean"
+                                              },
+                                              "header": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "responseHeadersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "stagedTransformations": {
+                                      "properties": {
+                                        "early": {
+                                          "properties": {
+                                            "requestTransforms": {
+                                              "items": {
+                                                "properties": {
+                                                  "clearRouteCache": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "matcher": {
+                                                    "properties": {
+                                                      "caseSensitive": {
+                                                        "nullable": true,
+                                                        "type": "boolean"
+                                                      },
+                                                      "exact": {
+                                                        "type": "string"
+                                                      },
+                                                      "headers": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "invertMatch": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "methods": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "prefix": {
+                                                        "type": "string"
+                                                      },
+                                                      "queryParameters": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "requestTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "responseTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "responseTransforms": {
+                                              "items": {
+                                                "properties": {
+                                                  "matchers": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "invertMatch": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "regex": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "responseCodeDetails": {
+                                                    "type": "string"
+                                                  },
+                                                  "responseTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "inheritTransformation": {
+                                          "type": "boolean"
+                                        },
+                                        "regular": {
+                                          "properties": {
+                                            "requestTransforms": {
+                                              "items": {
+                                                "properties": {
+                                                  "clearRouteCache": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "matcher": {
+                                                    "properties": {
+                                                      "caseSensitive": {
+                                                        "nullable": true,
+                                                        "type": "boolean"
+                                                      },
+                                                      "exact": {
+                                                        "type": "string"
+                                                      },
+                                                      "headers": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "invertMatch": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "methods": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "prefix": {
+                                                        "type": "string"
+                                                      },
+                                                      "queryParameters": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "requestTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "responseTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "responseTransforms": {
+                                              "items": {
+                                                "properties": {
+                                                  "matchers": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "invertMatch": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "regex": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "responseCodeDetails": {
+                                                    "type": "string"
+                                                  },
+                                                  "responseTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformations": {
+                                      "properties": {
+                                        "clearRouteCache": {
+                                          "type": "boolean"
+                                        },
+                                        "requestTransformation": {
+                                          "properties": {
+                                            "headerBodyTransform": {
+                                              "properties": {
+                                                "addRequestMetadata": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "transformationTemplate": {
+                                              "properties": {
+                                                "advancedTemplates": {
+                                                  "type": "boolean"
+                                                },
+                                                "body": {
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "dynamicMetadataValues": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "metadataNamespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "extractors": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "body": {
+                                                        "maxProperties": 0,
+                                                        "type": "object"
+                                                      },
+                                                      "header": {
+                                                        "type": "string"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      },
+                                                      "subgroup": {
+                                                        "format": "int32",
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headersToAppend": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "headersToRemove": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "ignoreErrorOnParse": {
+                                                  "type": "boolean"
+                                                },
+                                                "mergeExtractorsToBody": {
+                                                  "type": "object"
+                                                },
+                                                "parseBodyBehavior": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "passthrough": {
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "xsltTransformation": {
+                                              "properties": {
+                                                "nonXmlTransform": {
+                                                  "type": "boolean"
+                                                },
+                                                "setContentType": {
+                                                  "type": "string"
+                                                },
+                                                "xslt": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "responseTransformation": {
+                                          "properties": {
+                                            "headerBodyTransform": {
+                                              "properties": {
+                                                "addRequestMetadata": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "transformationTemplate": {
+                                              "properties": {
+                                                "advancedTemplates": {
+                                                  "type": "boolean"
+                                                },
+                                                "body": {
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "dynamicMetadataValues": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "metadataNamespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "extractors": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "body": {
+                                                        "maxProperties": 0,
+                                                        "type": "object"
+                                                      },
+                                                      "header": {
+                                                        "type": "string"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      },
+                                                      "subgroup": {
+                                                        "format": "int32",
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headersToAppend": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "headersToRemove": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "ignoreErrorOnParse": {
+                                                  "type": "boolean"
+                                                },
+                                                "mergeExtractorsToBody": {
+                                                  "type": "object"
+                                                },
+                                                "parseBodyBehavior": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "passthrough": {
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "xsltTransformation": {
+                                              "properties": {
+                                                "nonXmlTransform": {
+                                                  "type": "boolean"
+                                                },
+                                                "setContentType": {
+                                                  "type": "string"
+                                                },
+                                                "xslt": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "weight": {
+                                  "maximum": 4294967295,
+                                  "minimum": 0,
+                                  "nullable": true,
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "single": {
+                        "properties": {
+                          "consul": {
+                            "properties": {
+                              "dataCenters": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "serviceName": {
+                                "type": "string"
+                              },
+                              "tags": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "destinationSpec": {
+                            "properties": {
+                              "aws": {
+                                "properties": {
+                                  "invocationStyle": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "logicalName": {
+                                    "type": "string"
+                                  },
+                                  "requestTransformation": {
+                                    "type": "boolean"
+                                  },
+                                  "responseTransformation": {
+                                    "type": "boolean"
+                                  },
+                                  "unwrapAsAlb": {
+                                    "type": "boolean"
+                                  },
+                                  "unwrapAsApiGateway": {
+                                    "type": "boolean"
+                                  },
+                                  "wrapAsApiGateway": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azure": {
+                                "properties": {
+                                  "functionName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "function": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "properties": {
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "path": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "rest": {
+                                "properties": {
+                                  "functionName": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "properties": {
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "path": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "responseTransformation": {
+                                    "properties": {
+                                      "advancedTemplates": {
+                                        "type": "boolean"
+                                      },
+                                      "body": {
+                                        "properties": {
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dynamicMetadataValues": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "metadataNamespace": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "extractors": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "body": {
+                                              "maxProperties": 0,
+                                              "type": "object"
+                                            },
+                                            "header": {
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "type": "string"
+                                            },
+                                            "subgroup": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headersToAppend": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "headersToRemove": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ignoreErrorOnParse": {
+                                        "type": "boolean"
+                                      },
+                                      "mergeExtractorsToBody": {
+                                        "type": "object"
+                                      },
+                                      "parseBodyBehavior": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "passthrough": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "kube": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "ref": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subset": {
+                            "properties": {
+                              "values": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "upstream": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "upstreamGroup": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "sslConfig": {
+                    "properties": {
+                      "alpnProtocols": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "disableTlsSessionResumption": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "oneWayTls": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "parameters": {
+                        "properties": {
+                          "cipherSuites": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ecdhCurves": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maximumProtocolVersion": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "minimumProtocolVersion": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "sds": {
+                        "properties": {
+                          "callCredentials": {
+                            "properties": {
+                              "fileCredentialSource": {
+                                "properties": {
+                                  "header": {
+                                    "type": "string"
+                                  },
+                                  "tokenFileName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "certificatesSecretName": {
+                            "type": "string"
+                          },
+                          "clusterName": {
+                            "type": "string"
+                          },
+                          "targetUri": {
+                            "type": "string"
+                          },
+                          "validationContextName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "sniDomains": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "sslFiles": {
+                        "properties": {
+                          "rootCa": {
+                            "type": "string"
+                          },
+                          "tlsCert": {
+                            "type": "string"
+                          },
+                          "tlsKey": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "transportSocketConnectTimeout": {
+                        "type": "string"
+                      },
+                      "verifySubjectAltName": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "useProxyProto": {
+          "nullable": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gateway.solo.io/matchablehttpgateway_v1.json
+++ b/gateway.solo.io/matchablehttpgateway_v1.json
@@ -1,0 +1,1741 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "httpGateway": {
+          "properties": {
+            "options": {
+              "properties": {
+                "buffer": {
+                  "properties": {
+                    "maxRequestBytes": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "caching": {
+                  "properties": {
+                    "allowedVaryHeaders": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "cachingServiceRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "maxPayloadSize": {
+                      "properties": {
+                        "value": {
+                          "format": "int64",
+                          "type": "integer",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "timeout": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "csrf": {
+                  "properties": {
+                    "additionalOrigins": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "filterEnabled": {
+                      "properties": {
+                        "defaultValue": {
+                          "properties": {
+                            "denominator": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "numerator": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "runtimeKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "shadowEnabled": {
+                      "properties": {
+                        "defaultValue": {
+                          "properties": {
+                            "denominator": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "numerator": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "runtimeKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dlp": {
+                  "properties": {
+                    "dlpRules": {
+                      "items": {
+                        "properties": {
+                          "actions": {
+                            "items": {
+                              "properties": {
+                                "actionType": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "customAction": {
+                                  "properties": {
+                                    "maskChar": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "percent": {
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "regex": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "regexActions": {
+                                      "items": {
+                                        "properties": {
+                                          "regex": {
+                                            "type": "string"
+                                          },
+                                          "subgroup": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "keyValueAction": {
+                                  "properties": {
+                                    "keyToMask": {
+                                      "type": "string"
+                                    },
+                                    "maskChar": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "percent": {
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "shadow": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matcher": {
+                            "properties": {
+                              "caseSensitive": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "exact": {
+                                "type": "string"
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "invertMatch": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "methods": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "prefix": {
+                                "type": "string"
+                              },
+                              "queryParameters": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "enabledFor": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dynamicForwardProxy": {
+                  "properties": {
+                    "dnsCacheConfig": {
+                      "properties": {
+                        "appleDns": {
+                          "type": "object"
+                        },
+                        "caresDns": {
+                          "properties": {
+                            "dnsResolverOptions": {
+                              "properties": {
+                                "noDefaultSearchDomain": {
+                                  "type": "boolean"
+                                },
+                                "useTcpForDnsLookups": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "resolvers": {
+                              "items": {
+                                "properties": {
+                                  "pipe": {
+                                    "properties": {
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "socketAddress": {
+                                    "properties": {
+                                      "address": {
+                                        "type": "string"
+                                      },
+                                      "ipv4Compat": {
+                                        "type": "boolean"
+                                      },
+                                      "namedPort": {
+                                        "type": "string"
+                                      },
+                                      "portValue": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "protocol": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resolverName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dnsCacheCircuitBreaker": {
+                          "properties": {
+                            "maxPendingRequests": {
+                              "maximum": 4294967295,
+                              "minimum": 0,
+                              "nullable": true,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dnsFailureRefreshRate": {
+                          "properties": {
+                            "baseInterval": {
+                              "type": "string"
+                            },
+                            "maxInterval": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dnsLookupFamily": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "dnsQueryTimeout": {
+                          "type": "string"
+                        },
+                        "dnsRefreshRate": {
+                          "type": "string"
+                        },
+                        "hostTtl": {
+                          "type": "string"
+                        },
+                        "maxHosts": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "preresolveHostnames": {
+                          "items": {
+                            "properties": {
+                              "address": {
+                                "type": "string"
+                              },
+                              "ipv4Compat": {
+                                "type": "boolean"
+                              },
+                              "namedPort": {
+                                "type": "string"
+                              },
+                              "portValue": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resolverName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "saveUpstreamAddress": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "extauth": {
+                  "properties": {
+                    "clearRouteCache": {
+                      "type": "boolean"
+                    },
+                    "extauthzServerRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureModeAllow": {
+                      "type": "boolean"
+                    },
+                    "grpcService": {
+                      "properties": {
+                        "authority": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpService": {
+                      "properties": {
+                        "pathPrefix": {
+                          "type": "string"
+                        },
+                        "request": {
+                          "properties": {
+                            "allowedHeaders": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "allowedHeadersRegex": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "headersToAdd": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "response": {
+                          "properties": {
+                            "allowedClientHeaders": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "allowedUpstreamHeaders": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "allowedUpstreamHeadersToAppend": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "requestBody": {
+                      "properties": {
+                        "allowPartialMessage": {
+                          "type": "boolean"
+                        },
+                        "maxRequestBytes": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "packAsBytes": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "requestTimeout": {
+                      "type": "string"
+                    },
+                    "statPrefix": {
+                      "type": "string"
+                    },
+                    "statusOnError": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "transportApiVersion": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "userIdHeader": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "extensions": {
+                  "properties": {
+                    "configs": {
+                      "additionalProperties": {
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "grpcJsonTranscoder": {
+                  "properties": {
+                    "autoMapping": {
+                      "type": "boolean"
+                    },
+                    "convertGrpcStatus": {
+                      "type": "boolean"
+                    },
+                    "ignoreUnknownQueryParameters": {
+                      "type": "boolean"
+                    },
+                    "ignoredQueryParameters": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "matchIncomingRequestRoute": {
+                      "type": "boolean"
+                    },
+                    "printOptions": {
+                      "properties": {
+                        "addWhitespace": {
+                          "type": "boolean"
+                        },
+                        "alwaysPrintEnumsAsInts": {
+                          "type": "boolean"
+                        },
+                        "alwaysPrintPrimitiveFields": {
+                          "type": "boolean"
+                        },
+                        "preserveProtoFieldNames": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "protoDescriptor": {
+                      "type": "string"
+                    },
+                    "protoDescriptorBin": {
+                      "format": "byte",
+                      "type": "string"
+                    },
+                    "protoDescriptorConfigMap": {
+                      "properties": {
+                        "configMapRef": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "key": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "services": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "grpcWeb": {
+                  "properties": {
+                    "disable": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "gzip": {
+                  "properties": {
+                    "compressionLevel": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "compressionStrategy": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "contentLength": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "contentType": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "disableOnEtagHeader": {
+                      "type": "boolean"
+                    },
+                    "memoryLevel": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "removeAcceptEncodingHeader": {
+                      "type": "boolean"
+                    },
+                    "windowBits": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "healthCheck": {
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpConnectionManagerSettings": {
+                  "properties": {
+                    "acceptHttp10": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "allowChunkedLength": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "codecType": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "defaultHostForHttp10": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "delayedCloseTimeout": {
+                      "type": "string"
+                    },
+                    "drainTimeout": {
+                      "type": "string"
+                    },
+                    "enableTrailers": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "forwardClientCertDetails": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "generateRequestId": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "headersWithUnderscoresAction": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "http2ProtocolOptions": {
+                      "properties": {
+                        "initialConnectionWindowSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "initialStreamWindowSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "maxConcurrentStreams": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "overrideStreamErrorOnInvalidHttpMessage": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "idleTimeout": {
+                      "type": "string"
+                    },
+                    "internalAddressConfig": {
+                      "properties": {
+                        "cidrRanges": {
+                          "items": {
+                            "properties": {
+                              "addressPrefix": {
+                                "type": "string"
+                              },
+                              "prefixLen": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "unixSockets": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "maxConnectionDuration": {
+                      "type": "string"
+                    },
+                    "maxHeadersCount": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "maxRequestHeadersKb": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "maxRequestsPerConnection": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "maxStreamDuration": {
+                      "type": "string"
+                    },
+                    "mergeSlashes": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "normalizePath": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "pathWithEscapedSlashesAction": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "preserveCaseHeaderKeyFormat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "preserveExternalRequestId": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "properCaseHeaderKeyFormat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "proxy100Continue": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "requestHeadersTimeout": {
+                      "type": "string"
+                    },
+                    "requestTimeout": {
+                      "type": "string"
+                    },
+                    "serverHeaderTransformation": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "serverName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "setCurrentClientCertDetails": {
+                      "properties": {
+                        "cert": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "chain": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "dns": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "subject": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "uri": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "skipXffAppend": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "streamIdleTimeout": {
+                      "type": "string"
+                    },
+                    "stripAnyHostPort": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "tracing": {
+                      "properties": {
+                        "datadogConfig": {
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "collectorUpstreamRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceName": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "environmentVariablesForTags": {
+                          "items": {
+                            "properties": {
+                              "defaultValue": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "name": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "tag": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "literalsForTags": {
+                          "items": {
+                            "properties": {
+                              "tag": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "value": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "openCensusConfig": {
+                          "properties": {
+                            "grpcAddress": {
+                              "properties": {
+                                "statPrefix": {
+                                  "type": "string"
+                                },
+                                "targetUri": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "httpAddress": {
+                              "type": "string"
+                            },
+                            "incomingTraceContext": {
+                              "items": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "array"
+                            },
+                            "ocagentExporterEnabled": {
+                              "type": "boolean"
+                            },
+                            "outgoingTraceContext": {
+                              "items": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "array"
+                            },
+                            "traceConfig": {
+                              "properties": {
+                                "constantSampler": {
+                                  "properties": {
+                                    "decision": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "maxNumberOfAnnotations": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "maxNumberOfAttributes": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "maxNumberOfLinks": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "maxNumberOfMessageEvents": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "probabilitySampler": {
+                                  "properties": {
+                                    "samplingProbability": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "rateLimitingSampler": {
+                                  "properties": {
+                                    "qps": {
+                                      "format": "int64",
+                                      "type": "integer",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "openTelemetryConfig": {
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "collectorUpstreamRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "requestHeadersForTags": {
+                          "items": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "tracePercentages": {
+                          "properties": {
+                            "clientSamplePercentage": {
+                              "nullable": true,
+                              "type": "number"
+                            },
+                            "overallSamplePercentage": {
+                              "nullable": true,
+                              "type": "number"
+                            },
+                            "randomSamplePercentage": {
+                              "nullable": true,
+                              "type": "number"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "verbose": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "zipkinConfig": {
+                          "properties": {
+                            "clusterName": {
+                              "type": "string"
+                            },
+                            "collectorEndpoint": {
+                              "type": "string"
+                            },
+                            "collectorEndpointVersion": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "collectorUpstreamRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sharedSpanContext": {
+                              "nullable": true,
+                              "type": "boolean"
+                            },
+                            "traceId128bit": {
+                              "nullable": true,
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "upgrades": {
+                      "items": {
+                        "properties": {
+                          "websocket": {
+                            "properties": {
+                              "enabled": {
+                                "nullable": true,
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "useRemoteAddress": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "uuidRequestIdConfig": {
+                      "properties": {
+                        "packTraceReason": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "useRequestIdForTraceSampling": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "via": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "xffNumTrustedHops": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "leftmostXffAddress": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "proxyLatency": {
+                  "properties": {
+                    "chargeClusterStat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "chargeListenerStat": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "emitDynamicMetadata": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "measureRequestInternally": {
+                      "type": "boolean"
+                    },
+                    "request": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "response": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ratelimitServer": {
+                  "properties": {
+                    "denyOnFail": {
+                      "type": "boolean"
+                    },
+                    "enableXRatelimitHeaders": {
+                      "type": "boolean"
+                    },
+                    "rateLimitBeforeAuth": {
+                      "type": "boolean"
+                    },
+                    "ratelimitServerRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "requestTimeout": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sanitizeClusterHeader": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "waf": {
+                  "properties": {
+                    "auditLogging": {
+                      "properties": {
+                        "action": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "location": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "configMapRuleSets": {
+                      "items": {
+                        "properties": {
+                          "configMapRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "dataMapKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "coreRuleSet": {
+                      "properties": {
+                        "customSettingsFile": {
+                          "type": "string"
+                        },
+                        "customSettingsString": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "customInterventionMessage": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "requestHeadersOnly": {
+                      "type": "boolean"
+                    },
+                    "responseHeadersOnly": {
+                      "type": "boolean"
+                    },
+                    "ruleSets": {
+                      "items": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "files": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ruleStr": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "wasm": {
+                  "properties": {
+                    "filters": {
+                      "items": {
+                        "properties": {
+                          "config": {
+                            "type": "object",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "failOpen": {
+                            "type": "boolean"
+                          },
+                          "filePath": {
+                            "type": "string"
+                          },
+                          "filterStage": {
+                            "properties": {
+                              "predicate": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "stage": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "rootId": {
+                            "type": "string"
+                          },
+                          "vmType": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "virtualServiceExpressions": {
+              "properties": {
+                "expressions": {
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "values": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "virtualServiceNamespaces": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "virtualServiceSelector": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "virtualServices": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "matcher": {
+          "properties": {
+            "sourcePrefixRanges": {
+              "items": {
+                "properties": {
+                  "addressPrefix": {
+                    "type": "string"
+                  },
+                  "prefixLen": {
+                    "maximum": 4294967295,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "sslConfig": {
+              "properties": {
+                "alpnProtocols": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "disableTlsSessionResumption": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "oneWayTls": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "parameters": {
+                  "properties": {
+                    "cipherSuites": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "ecdhCurves": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "maximumProtocolVersion": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "minimumProtocolVersion": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sds": {
+                  "properties": {
+                    "callCredentials": {
+                      "properties": {
+                        "fileCredentialSource": {
+                          "properties": {
+                            "header": {
+                              "type": "string"
+                            },
+                            "tokenFileName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "certificatesSecretName": {
+                      "type": "string"
+                    },
+                    "clusterName": {
+                      "type": "string"
+                    },
+                    "targetUri": {
+                      "type": "string"
+                    },
+                    "validationContextName": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sniDomains": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "sslFiles": {
+                  "properties": {
+                    "rootCa": {
+                      "type": "string"
+                    },
+                    "tlsCert": {
+                      "type": "string"
+                    },
+                    "tlsKey": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "transportSocketConnectTimeout": {
+                  "type": "string"
+                },
+                "verifySubjectAltName": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gateway.solo.io/routeoption_v1.json
+++ b/gateway.solo.io/routeoption_v1.json
@@ -1,0 +1,3234 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "options": {
+          "properties": {
+            "autoHostRewrite": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "bufferPerRoute": {
+              "properties": {
+                "buffer": {
+                  "properties": {
+                    "maxRequestBytes": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disabled": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cors": {
+              "properties": {
+                "allowCredentials": {
+                  "type": "boolean"
+                },
+                "allowHeaders": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowMethods": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowOrigin": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowOriginRegex": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "disableForRoute": {
+                  "type": "boolean"
+                },
+                "exposeHeaders": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maxAge": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "csrf": {
+              "properties": {
+                "additionalOrigins": {
+                  "items": {
+                    "properties": {
+                      "exact": {
+                        "type": "string"
+                      },
+                      "ignoreCase": {
+                        "type": "boolean"
+                      },
+                      "prefix": {
+                        "type": "string"
+                      },
+                      "safeRegex": {
+                        "properties": {
+                          "googleRe2": {
+                            "properties": {
+                              "maxProgramSize": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "suffix": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "filterEnabled": {
+                  "properties": {
+                    "defaultValue": {
+                      "properties": {
+                        "denominator": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "numerator": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "runtimeKey": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "shadowEnabled": {
+                  "properties": {
+                    "defaultValue": {
+                      "properties": {
+                        "denominator": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "numerator": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "runtimeKey": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dlp": {
+              "properties": {
+                "actions": {
+                  "items": {
+                    "properties": {
+                      "actionType": {
+                        "type": "string",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "customAction": {
+                        "properties": {
+                          "maskChar": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "percent": {
+                            "properties": {
+                              "value": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "regexActions": {
+                            "items": {
+                              "properties": {
+                                "regex": {
+                                  "type": "string"
+                                },
+                                "subgroup": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "keyValueAction": {
+                        "properties": {
+                          "keyToMask": {
+                            "type": "string"
+                          },
+                          "maskChar": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "percent": {
+                            "properties": {
+                              "value": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "shadow": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "enabledFor": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "envoyMetadata": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            },
+            "extauth": {
+              "properties": {
+                "configRef": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "customAuth": {
+                  "properties": {
+                    "contextExtensions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disable": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "extensions": {
+              "properties": {
+                "configs": {
+                  "additionalProperties": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "faults": {
+              "properties": {
+                "abort": {
+                  "properties": {
+                    "httpStatus": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "percentage": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "delay": {
+                  "properties": {
+                    "fixedDelay": {
+                      "type": "string"
+                    },
+                    "percentage": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "headerManipulation": {
+              "properties": {
+                "requestHeadersToAdd": {
+                  "items": {
+                    "properties": {
+                      "append": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "header": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "headerSecretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "requestHeadersToRemove": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "responseHeadersToAdd": {
+                  "items": {
+                    "properties": {
+                      "append": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "header": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "responseHeadersToRemove": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "hostRewrite": {
+              "type": "string"
+            },
+            "jwt": {
+              "properties": {
+                "disable": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jwtStaged": {
+              "properties": {
+                "afterExtAuth": {
+                  "properties": {
+                    "disable": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "beforeExtAuth": {
+                  "properties": {
+                    "disable": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "lbHash": {
+              "properties": {
+                "hashPolicies": {
+                  "items": {
+                    "properties": {
+                      "cookie": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "ttl": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "header": {
+                        "type": "string"
+                      },
+                      "sourceIp": {
+                        "type": "boolean"
+                      },
+                      "terminal": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "maxStreamDuration": {
+              "properties": {
+                "grpcTimeoutHeaderMax": {
+                  "type": "string"
+                },
+                "grpcTimeoutHeaderOffset": {
+                  "type": "string"
+                },
+                "maxStreamDuration": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prefixRewrite": {
+              "nullable": true,
+              "type": "string"
+            },
+            "rateLimitConfigs": {
+              "properties": {
+                "refs": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rateLimitEarlyConfigs": {
+              "properties": {
+                "refs": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rateLimitRegularConfigs": {
+              "properties": {
+                "refs": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ratelimit": {
+              "properties": {
+                "includeVhRateLimits": {
+                  "type": "boolean"
+                },
+                "rateLimits": {
+                  "items": {
+                    "properties": {
+                      "actions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "setActions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ratelimitBasic": {
+              "properties": {
+                "anonymousLimits": {
+                  "properties": {
+                    "requestsPerUnit": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "unit": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "authorizedLimits": {
+                  "properties": {
+                    "requestsPerUnit": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "unit": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ratelimitEarly": {
+              "properties": {
+                "includeVhRateLimits": {
+                  "type": "boolean"
+                },
+                "rateLimits": {
+                  "items": {
+                    "properties": {
+                      "actions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "setActions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ratelimitRegular": {
+              "properties": {
+                "includeVhRateLimits": {
+                  "type": "boolean"
+                },
+                "rateLimits": {
+                  "items": {
+                    "properties": {
+                      "actions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "setActions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rbac": {
+              "properties": {
+                "disable": {
+                  "type": "boolean"
+                },
+                "policies": {
+                  "additionalProperties": {
+                    "properties": {
+                      "nestedClaimDelimiter": {
+                        "type": "string"
+                      },
+                      "permissions": {
+                        "properties": {
+                          "methods": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "pathPrefix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "principals": {
+                        "items": {
+                          "properties": {
+                            "jwtPrincipal": {
+                              "properties": {
+                                "claims": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "matcher": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "provider": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "regexRewrite": {
+              "properties": {
+                "pattern": {
+                  "properties": {
+                    "googleRe2": {
+                      "properties": {
+                        "maxProgramSize": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "regex": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "substitution": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "retries": {
+              "properties": {
+                "numRetries": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "perTryTimeout": {
+                  "type": "string"
+                },
+                "retryBackOff": {
+                  "properties": {
+                    "baseInterval": {
+                      "type": "string"
+                    },
+                    "maxInterval": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "retryOn": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "shadowing": {
+              "properties": {
+                "percentage": {
+                  "type": "number"
+                },
+                "upstream": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "stagedTransformations": {
+              "properties": {
+                "early": {
+                  "properties": {
+                    "requestTransforms": {
+                      "items": {
+                        "properties": {
+                          "clearRouteCache": {
+                            "type": "boolean"
+                          },
+                          "matcher": {
+                            "properties": {
+                              "caseSensitive": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "exact": {
+                                "type": "string"
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "invertMatch": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "methods": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "prefix": {
+                                "type": "string"
+                              },
+                              "queryParameters": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "requestTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "responseTransforms": {
+                      "items": {
+                        "properties": {
+                          "matchers": {
+                            "items": {
+                              "properties": {
+                                "invertMatch": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "regex": {
+                                  "type": "boolean"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "responseCodeDetails": {
+                            "type": "string"
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "inheritTransformation": {
+                  "type": "boolean"
+                },
+                "regular": {
+                  "properties": {
+                    "requestTransforms": {
+                      "items": {
+                        "properties": {
+                          "clearRouteCache": {
+                            "type": "boolean"
+                          },
+                          "matcher": {
+                            "properties": {
+                              "caseSensitive": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "exact": {
+                                "type": "string"
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "invertMatch": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "methods": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "prefix": {
+                                "type": "string"
+                              },
+                              "queryParameters": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "requestTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "responseTransforms": {
+                      "items": {
+                        "properties": {
+                          "matchers": {
+                            "items": {
+                              "properties": {
+                                "invertMatch": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "regex": {
+                                  "type": "boolean"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "responseCodeDetails": {
+                            "type": "string"
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "timeout": {
+              "type": "string"
+            },
+            "tracing": {
+              "properties": {
+                "propagate": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "routeDescriptor": {
+                  "type": "string"
+                },
+                "tracePercentages": {
+                  "properties": {
+                    "clientSamplePercentage": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "overallSamplePercentage": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "randomSamplePercentage": {
+                      "nullable": true,
+                      "type": "number"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "transformations": {
+              "properties": {
+                "clearRouteCache": {
+                  "type": "boolean"
+                },
+                "requestTransformation": {
+                  "properties": {
+                    "headerBodyTransform": {
+                      "properties": {
+                        "addRequestMetadata": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transformationTemplate": {
+                      "properties": {
+                        "advancedTemplates": {
+                          "type": "boolean"
+                        },
+                        "body": {
+                          "properties": {
+                            "text": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dynamicMetadataValues": {
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "metadataNamespace": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "extractors": {
+                          "additionalProperties": {
+                            "properties": {
+                              "body": {
+                                "maxProperties": 0,
+                                "type": "object"
+                              },
+                              "header": {
+                                "type": "string"
+                              },
+                              "regex": {
+                                "type": "string"
+                              },
+                              "subgroup": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        },
+                        "headers": {
+                          "additionalProperties": {
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        },
+                        "headersToAppend": {
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "headersToRemove": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "ignoreErrorOnParse": {
+                          "type": "boolean"
+                        },
+                        "mergeExtractorsToBody": {
+                          "type": "object"
+                        },
+                        "parseBodyBehavior": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "passthrough": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "xsltTransformation": {
+                      "properties": {
+                        "nonXmlTransform": {
+                          "type": "boolean"
+                        },
+                        "setContentType": {
+                          "type": "string"
+                        },
+                        "xslt": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "responseTransformation": {
+                  "properties": {
+                    "headerBodyTransform": {
+                      "properties": {
+                        "addRequestMetadata": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transformationTemplate": {
+                      "properties": {
+                        "advancedTemplates": {
+                          "type": "boolean"
+                        },
+                        "body": {
+                          "properties": {
+                            "text": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dynamicMetadataValues": {
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "metadataNamespace": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "extractors": {
+                          "additionalProperties": {
+                            "properties": {
+                              "body": {
+                                "maxProperties": 0,
+                                "type": "object"
+                              },
+                              "header": {
+                                "type": "string"
+                              },
+                              "regex": {
+                                "type": "string"
+                              },
+                              "subgroup": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        },
+                        "headers": {
+                          "additionalProperties": {
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        },
+                        "headersToAppend": {
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "headersToRemove": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "ignoreErrorOnParse": {
+                          "type": "boolean"
+                        },
+                        "mergeExtractorsToBody": {
+                          "type": "object"
+                        },
+                        "parseBodyBehavior": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "passthrough": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "xsltTransformation": {
+                      "properties": {
+                        "nonXmlTransform": {
+                          "type": "boolean"
+                        },
+                        "setContentType": {
+                          "type": "string"
+                        },
+                        "xslt": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "upgrades": {
+              "items": {
+                "properties": {
+                  "websocket": {
+                    "properties": {
+                      "enabled": {
+                        "nullable": true,
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "waf": {
+              "properties": {
+                "auditLogging": {
+                  "properties": {
+                    "action": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "location": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "configMapRuleSets": {
+                  "items": {
+                    "properties": {
+                      "configMapRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "dataMapKeys": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "coreRuleSet": {
+                  "properties": {
+                    "customSettingsFile": {
+                      "type": "string"
+                    },
+                    "customSettingsString": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "customInterventionMessage": {
+                  "type": "string"
+                },
+                "disabled": {
+                  "type": "boolean"
+                },
+                "requestHeadersOnly": {
+                  "type": "boolean"
+                },
+                "responseHeadersOnly": {
+                  "type": "boolean"
+                },
+                "ruleSets": {
+                  "items": {
+                    "properties": {
+                      "directory": {
+                        "type": "string"
+                      },
+                      "files": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "ruleStr": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gateway.solo.io/routetable_v1.json
+++ b/gateway.solo.io/routetable_v1.json
@@ -1,0 +1,5798 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "routes": {
+          "items": {
+            "properties": {
+              "delegateAction": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "ref": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "selector": {
+                    "properties": {
+                      "expressions": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "namespaces": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "directResponseAction": {
+                "properties": {
+                  "body": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "graphqlApiRef": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "inheritableMatchers": {
+                "nullable": true,
+                "type": "boolean"
+              },
+              "inheritablePathMatchers": {
+                "nullable": true,
+                "type": "boolean"
+              },
+              "matchers": {
+                "items": {
+                  "properties": {
+                    "caseSensitive": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "exact": {
+                      "type": "string"
+                    },
+                    "headers": {
+                      "items": {
+                        "properties": {
+                          "invertMatch": {
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "regex": {
+                            "type": "boolean"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "methods": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "queryParameters": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "regex": {
+                            "type": "boolean"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "regex": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "options": {
+                "properties": {
+                  "autoHostRewrite": {
+                    "nullable": true,
+                    "type": "boolean"
+                  },
+                  "bufferPerRoute": {
+                    "properties": {
+                      "buffer": {
+                        "properties": {
+                          "maxRequestBytes": {
+                            "maximum": 4294967295,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "disabled": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cors": {
+                    "properties": {
+                      "allowCredentials": {
+                        "type": "boolean"
+                      },
+                      "allowHeaders": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "allowMethods": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "allowOrigin": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "allowOriginRegex": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "disableForRoute": {
+                        "type": "boolean"
+                      },
+                      "exposeHeaders": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "maxAge": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "csrf": {
+                    "properties": {
+                      "additionalOrigins": {
+                        "items": {
+                          "properties": {
+                            "exact": {
+                              "type": "string"
+                            },
+                            "ignoreCase": {
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "safeRegex": {
+                              "properties": {
+                                "googleRe2": {
+                                  "properties": {
+                                    "maxProgramSize": {
+                                      "maximum": 4294967295,
+                                      "minimum": 0,
+                                      "nullable": true,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "regex": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "suffix": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "filterEnabled": {
+                        "properties": {
+                          "defaultValue": {
+                            "properties": {
+                              "denominator": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "numerator": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "runtimeKey": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "shadowEnabled": {
+                        "properties": {
+                          "defaultValue": {
+                            "properties": {
+                              "denominator": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "numerator": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "runtimeKey": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "dlp": {
+                    "properties": {
+                      "actions": {
+                        "items": {
+                          "properties": {
+                            "actionType": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "customAction": {
+                              "properties": {
+                                "maskChar": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "percent": {
+                                  "properties": {
+                                    "value": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "regex": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "regexActions": {
+                                  "items": {
+                                    "properties": {
+                                      "regex": {
+                                        "type": "string"
+                                      },
+                                      "subgroup": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "keyValueAction": {
+                              "properties": {
+                                "keyToMask": {
+                                  "type": "string"
+                                },
+                                "maskChar": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "percent": {
+                                  "properties": {
+                                    "value": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "shadow": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "enabledFor": {
+                        "type": "string",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "envoyMetadata": {
+                    "additionalProperties": {
+                      "type": "object",
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "type": "object"
+                  },
+                  "extauth": {
+                    "properties": {
+                      "configRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "customAuth": {
+                        "properties": {
+                          "contextExtensions": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "disable": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "extensions": {
+                    "properties": {
+                      "configs": {
+                        "additionalProperties": {
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "faults": {
+                    "properties": {
+                      "abort": {
+                        "properties": {
+                          "httpStatus": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "percentage": {
+                            "type": "number"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "delay": {
+                        "properties": {
+                          "fixedDelay": {
+                            "type": "string"
+                          },
+                          "percentage": {
+                            "type": "number"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "headerManipulation": {
+                    "properties": {
+                      "requestHeadersToAdd": {
+                        "items": {
+                          "properties": {
+                            "append": {
+                              "nullable": true,
+                              "type": "boolean"
+                            },
+                            "header": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerSecretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "requestHeadersToRemove": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "responseHeadersToAdd": {
+                        "items": {
+                          "properties": {
+                            "append": {
+                              "nullable": true,
+                              "type": "boolean"
+                            },
+                            "header": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "responseHeadersToRemove": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostRewrite": {
+                    "type": "string"
+                  },
+                  "jwt": {
+                    "properties": {
+                      "disable": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "jwtStaged": {
+                    "properties": {
+                      "afterExtAuth": {
+                        "properties": {
+                          "disable": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "beforeExtAuth": {
+                        "properties": {
+                          "disable": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "lbHash": {
+                    "properties": {
+                      "hashPolicies": {
+                        "items": {
+                          "properties": {
+                            "cookie": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "ttl": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "header": {
+                              "type": "string"
+                            },
+                            "sourceIp": {
+                              "type": "boolean"
+                            },
+                            "terminal": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxStreamDuration": {
+                    "properties": {
+                      "grpcTimeoutHeaderMax": {
+                        "type": "string"
+                      },
+                      "grpcTimeoutHeaderOffset": {
+                        "type": "string"
+                      },
+                      "maxStreamDuration": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "prefixRewrite": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "rateLimitConfigs": {
+                    "properties": {
+                      "refs": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rateLimitEarlyConfigs": {
+                    "properties": {
+                      "refs": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rateLimitRegularConfigs": {
+                    "properties": {
+                      "refs": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ratelimit": {
+                    "properties": {
+                      "includeVhRateLimits": {
+                        "type": "boolean"
+                      },
+                      "rateLimits": {
+                        "items": {
+                          "properties": {
+                            "actions": {
+                              "items": {
+                                "properties": {
+                                  "destinationCluster": {
+                                    "type": "object"
+                                  },
+                                  "genericKey": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headerValueMatch": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      },
+                                      "expectMatch": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      },
+                                      "headers": {
+                                        "items": {
+                                          "properties": {
+                                            "exactMatch": {
+                                              "type": "string"
+                                            },
+                                            "invertMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "prefixMatch": {
+                                              "type": "string"
+                                            },
+                                            "presentMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "rangeMatch": {
+                                              "properties": {
+                                                "end": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "start": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "regexMatch": {
+                                              "type": "string"
+                                            },
+                                            "suffixMatch": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "metadata": {
+                                    "properties": {
+                                      "defaultValue": {
+                                        "type": "string"
+                                      },
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "metadataKey": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "source": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "remoteAddress": {
+                                    "type": "object"
+                                  },
+                                  "requestHeaders": {
+                                    "properties": {
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "headerName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sourceCluster": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "setActions": {
+                              "items": {
+                                "properties": {
+                                  "destinationCluster": {
+                                    "type": "object"
+                                  },
+                                  "genericKey": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headerValueMatch": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      },
+                                      "expectMatch": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      },
+                                      "headers": {
+                                        "items": {
+                                          "properties": {
+                                            "exactMatch": {
+                                              "type": "string"
+                                            },
+                                            "invertMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "prefixMatch": {
+                                              "type": "string"
+                                            },
+                                            "presentMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "rangeMatch": {
+                                              "properties": {
+                                                "end": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "start": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "regexMatch": {
+                                              "type": "string"
+                                            },
+                                            "suffixMatch": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "metadata": {
+                                    "properties": {
+                                      "defaultValue": {
+                                        "type": "string"
+                                      },
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "metadataKey": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "source": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "remoteAddress": {
+                                    "type": "object"
+                                  },
+                                  "requestHeaders": {
+                                    "properties": {
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "headerName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sourceCluster": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ratelimitBasic": {
+                    "properties": {
+                      "anonymousLimits": {
+                        "properties": {
+                          "requestsPerUnit": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "authorizedLimits": {
+                        "properties": {
+                          "requestsPerUnit": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ratelimitEarly": {
+                    "properties": {
+                      "includeVhRateLimits": {
+                        "type": "boolean"
+                      },
+                      "rateLimits": {
+                        "items": {
+                          "properties": {
+                            "actions": {
+                              "items": {
+                                "properties": {
+                                  "destinationCluster": {
+                                    "type": "object"
+                                  },
+                                  "genericKey": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headerValueMatch": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      },
+                                      "expectMatch": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      },
+                                      "headers": {
+                                        "items": {
+                                          "properties": {
+                                            "exactMatch": {
+                                              "type": "string"
+                                            },
+                                            "invertMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "prefixMatch": {
+                                              "type": "string"
+                                            },
+                                            "presentMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "rangeMatch": {
+                                              "properties": {
+                                                "end": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "start": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "regexMatch": {
+                                              "type": "string"
+                                            },
+                                            "suffixMatch": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "metadata": {
+                                    "properties": {
+                                      "defaultValue": {
+                                        "type": "string"
+                                      },
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "metadataKey": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "source": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "remoteAddress": {
+                                    "type": "object"
+                                  },
+                                  "requestHeaders": {
+                                    "properties": {
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "headerName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sourceCluster": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "setActions": {
+                              "items": {
+                                "properties": {
+                                  "destinationCluster": {
+                                    "type": "object"
+                                  },
+                                  "genericKey": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headerValueMatch": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      },
+                                      "expectMatch": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      },
+                                      "headers": {
+                                        "items": {
+                                          "properties": {
+                                            "exactMatch": {
+                                              "type": "string"
+                                            },
+                                            "invertMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "prefixMatch": {
+                                              "type": "string"
+                                            },
+                                            "presentMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "rangeMatch": {
+                                              "properties": {
+                                                "end": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "start": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "regexMatch": {
+                                              "type": "string"
+                                            },
+                                            "suffixMatch": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "metadata": {
+                                    "properties": {
+                                      "defaultValue": {
+                                        "type": "string"
+                                      },
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "metadataKey": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "source": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "remoteAddress": {
+                                    "type": "object"
+                                  },
+                                  "requestHeaders": {
+                                    "properties": {
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "headerName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sourceCluster": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ratelimitRegular": {
+                    "properties": {
+                      "includeVhRateLimits": {
+                        "type": "boolean"
+                      },
+                      "rateLimits": {
+                        "items": {
+                          "properties": {
+                            "actions": {
+                              "items": {
+                                "properties": {
+                                  "destinationCluster": {
+                                    "type": "object"
+                                  },
+                                  "genericKey": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headerValueMatch": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      },
+                                      "expectMatch": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      },
+                                      "headers": {
+                                        "items": {
+                                          "properties": {
+                                            "exactMatch": {
+                                              "type": "string"
+                                            },
+                                            "invertMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "prefixMatch": {
+                                              "type": "string"
+                                            },
+                                            "presentMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "rangeMatch": {
+                                              "properties": {
+                                                "end": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "start": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "regexMatch": {
+                                              "type": "string"
+                                            },
+                                            "suffixMatch": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "metadata": {
+                                    "properties": {
+                                      "defaultValue": {
+                                        "type": "string"
+                                      },
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "metadataKey": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "source": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "remoteAddress": {
+                                    "type": "object"
+                                  },
+                                  "requestHeaders": {
+                                    "properties": {
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "headerName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sourceCluster": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "setActions": {
+                              "items": {
+                                "properties": {
+                                  "destinationCluster": {
+                                    "type": "object"
+                                  },
+                                  "genericKey": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headerValueMatch": {
+                                    "properties": {
+                                      "descriptorValue": {
+                                        "type": "string"
+                                      },
+                                      "expectMatch": {
+                                        "nullable": true,
+                                        "type": "boolean"
+                                      },
+                                      "headers": {
+                                        "items": {
+                                          "properties": {
+                                            "exactMatch": {
+                                              "type": "string"
+                                            },
+                                            "invertMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "prefixMatch": {
+                                              "type": "string"
+                                            },
+                                            "presentMatch": {
+                                              "type": "boolean"
+                                            },
+                                            "rangeMatch": {
+                                              "properties": {
+                                                "end": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "start": {
+                                                  "format": "int64",
+                                                  "type": "integer",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "regexMatch": {
+                                              "type": "string"
+                                            },
+                                            "suffixMatch": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "metadata": {
+                                    "properties": {
+                                      "defaultValue": {
+                                        "type": "string"
+                                      },
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "metadataKey": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "source": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "remoteAddress": {
+                                    "type": "object"
+                                  },
+                                  "requestHeaders": {
+                                    "properties": {
+                                      "descriptorKey": {
+                                        "type": "string"
+                                      },
+                                      "headerName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sourceCluster": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbac": {
+                    "properties": {
+                      "disable": {
+                        "type": "boolean"
+                      },
+                      "policies": {
+                        "additionalProperties": {
+                          "properties": {
+                            "nestedClaimDelimiter": {
+                              "type": "string"
+                            },
+                            "permissions": {
+                              "properties": {
+                                "methods": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "pathPrefix": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "principals": {
+                              "items": {
+                                "properties": {
+                                  "jwtPrincipal": {
+                                    "properties": {
+                                      "claims": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "matcher": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "provider": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "regexRewrite": {
+                    "properties": {
+                      "pattern": {
+                        "properties": {
+                          "googleRe2": {
+                            "properties": {
+                              "maxProgramSize": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "substitution": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "retries": {
+                    "properties": {
+                      "numRetries": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "perTryTimeout": {
+                        "type": "string"
+                      },
+                      "retryBackOff": {
+                        "properties": {
+                          "baseInterval": {
+                            "type": "string"
+                          },
+                          "maxInterval": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "retryOn": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "shadowing": {
+                    "properties": {
+                      "percentage": {
+                        "type": "number"
+                      },
+                      "upstream": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "stagedTransformations": {
+                    "properties": {
+                      "early": {
+                        "properties": {
+                          "requestTransforms": {
+                            "items": {
+                              "properties": {
+                                "clearRouteCache": {
+                                  "type": "boolean"
+                                },
+                                "matcher": {
+                                  "properties": {
+                                    "caseSensitive": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "exact": {
+                                      "type": "string"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "methods": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "queryParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "requestTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "responseTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "responseTransforms": {
+                            "items": {
+                              "properties": {
+                                "matchers": {
+                                  "items": {
+                                    "properties": {
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "regex": {
+                                        "type": "boolean"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "responseCodeDetails": {
+                                  "type": "string"
+                                },
+                                "responseTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "inheritTransformation": {
+                        "type": "boolean"
+                      },
+                      "regular": {
+                        "properties": {
+                          "requestTransforms": {
+                            "items": {
+                              "properties": {
+                                "clearRouteCache": {
+                                  "type": "boolean"
+                                },
+                                "matcher": {
+                                  "properties": {
+                                    "caseSensitive": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "exact": {
+                                      "type": "string"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "methods": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "queryParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "requestTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "responseTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "responseTransforms": {
+                            "items": {
+                              "properties": {
+                                "matchers": {
+                                  "items": {
+                                    "properties": {
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "regex": {
+                                        "type": "boolean"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "responseCodeDetails": {
+                                  "type": "string"
+                                },
+                                "responseTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "timeout": {
+                    "type": "string"
+                  },
+                  "tracing": {
+                    "properties": {
+                      "propagate": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "routeDescriptor": {
+                        "type": "string"
+                      },
+                      "tracePercentages": {
+                        "properties": {
+                          "clientSamplePercentage": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "overallSamplePercentage": {
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "randomSamplePercentage": {
+                            "nullable": true,
+                            "type": "number"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "transformations": {
+                    "properties": {
+                      "clearRouteCache": {
+                        "type": "boolean"
+                      },
+                      "requestTransformation": {
+                        "properties": {
+                          "headerBodyTransform": {
+                            "properties": {
+                              "addRequestMetadata": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "transformationTemplate": {
+                            "properties": {
+                              "advancedTemplates": {
+                                "type": "boolean"
+                              },
+                              "body": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "dynamicMetadataValues": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "metadataNamespace": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "extractors": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "body": {
+                                      "maxProperties": 0,
+                                      "type": "object"
+                                    },
+                                    "header": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    },
+                                    "subgroup": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headers": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headersToAppend": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "headersToRemove": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ignoreErrorOnParse": {
+                                "type": "boolean"
+                              },
+                              "mergeExtractorsToBody": {
+                                "type": "object"
+                              },
+                              "parseBodyBehavior": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "passthrough": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "xsltTransformation": {
+                            "properties": {
+                              "nonXmlTransform": {
+                                "type": "boolean"
+                              },
+                              "setContentType": {
+                                "type": "string"
+                              },
+                              "xslt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "responseTransformation": {
+                        "properties": {
+                          "headerBodyTransform": {
+                            "properties": {
+                              "addRequestMetadata": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "transformationTemplate": {
+                            "properties": {
+                              "advancedTemplates": {
+                                "type": "boolean"
+                              },
+                              "body": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "dynamicMetadataValues": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "metadataNamespace": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "extractors": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "body": {
+                                      "maxProperties": 0,
+                                      "type": "object"
+                                    },
+                                    "header": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    },
+                                    "subgroup": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headers": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headersToAppend": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "headersToRemove": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ignoreErrorOnParse": {
+                                "type": "boolean"
+                              },
+                              "mergeExtractorsToBody": {
+                                "type": "object"
+                              },
+                              "parseBodyBehavior": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "passthrough": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "xsltTransformation": {
+                            "properties": {
+                              "nonXmlTransform": {
+                                "type": "boolean"
+                              },
+                              "setContentType": {
+                                "type": "string"
+                              },
+                              "xslt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "upgrades": {
+                    "items": {
+                      "properties": {
+                        "websocket": {
+                          "properties": {
+                            "enabled": {
+                              "nullable": true,
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "waf": {
+                    "properties": {
+                      "auditLogging": {
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "location": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMapRuleSets": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "dataMapKeys": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "coreRuleSet": {
+                        "properties": {
+                          "customSettingsFile": {
+                            "type": "string"
+                          },
+                          "customSettingsString": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "customInterventionMessage": {
+                        "type": "string"
+                      },
+                      "disabled": {
+                        "type": "boolean"
+                      },
+                      "requestHeadersOnly": {
+                        "type": "boolean"
+                      },
+                      "responseHeadersOnly": {
+                        "type": "boolean"
+                      },
+                      "ruleSets": {
+                        "items": {
+                          "properties": {
+                            "directory": {
+                              "type": "string"
+                            },
+                            "files": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "ruleStr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "optionsConfigRefs": {
+                "properties": {
+                  "delegateOptions": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "redirectAction": {
+                "properties": {
+                  "hostRedirect": {
+                    "type": "string"
+                  },
+                  "httpsRedirect": {
+                    "type": "boolean"
+                  },
+                  "pathRedirect": {
+                    "type": "string"
+                  },
+                  "prefixRewrite": {
+                    "type": "string"
+                  },
+                  "regexRewrite": {
+                    "properties": {
+                      "pattern": {
+                        "properties": {
+                          "googleRe2": {
+                            "properties": {
+                              "maxProgramSize": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "substitution": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "responseCode": {
+                    "type": "string",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "stripQuery": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "routeAction": {
+                "properties": {
+                  "clusterHeader": {
+                    "type": "string"
+                  },
+                  "dynamicForwardProxy": {
+                    "properties": {
+                      "autoHostRewriteHeader": {
+                        "type": "string"
+                      },
+                      "hostRewrite": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "multi": {
+                    "properties": {
+                      "destinations": {
+                        "items": {
+                          "properties": {
+                            "destination": {
+                              "properties": {
+                                "consul": {
+                                  "properties": {
+                                    "dataCenters": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "serviceName": {
+                                      "type": "string"
+                                    },
+                                    "tags": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "destinationSpec": {
+                                  "properties": {
+                                    "aws": {
+                                      "properties": {
+                                        "invocationStyle": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "logicalName": {
+                                          "type": "string"
+                                        },
+                                        "requestTransformation": {
+                                          "type": "boolean"
+                                        },
+                                        "responseTransformation": {
+                                          "type": "boolean"
+                                        },
+                                        "unwrapAsAlb": {
+                                          "type": "boolean"
+                                        },
+                                        "unwrapAsApiGateway": {
+                                          "type": "boolean"
+                                        },
+                                        "wrapAsApiGateway": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "azure": {
+                                      "properties": {
+                                        "functionName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "grpc": {
+                                      "properties": {
+                                        "function": {
+                                          "type": "string"
+                                        },
+                                        "package": {
+                                          "type": "string"
+                                        },
+                                        "parameters": {
+                                          "properties": {
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "path": {
+                                              "nullable": true,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "service": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "rest": {
+                                      "properties": {
+                                        "functionName": {
+                                          "type": "string"
+                                        },
+                                        "parameters": {
+                                          "properties": {
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "path": {
+                                              "nullable": true,
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "responseTransformation": {
+                                          "properties": {
+                                            "advancedTemplates": {
+                                              "type": "boolean"
+                                            },
+                                            "body": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "dynamicMetadataValues": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "metadataNamespace": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "extractors": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "body": {
+                                                    "maxProperties": 0,
+                                                    "type": "object"
+                                                  },
+                                                  "header": {
+                                                    "type": "string"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  },
+                                                  "subgroup": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headersToAppend": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "headersToRemove": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreErrorOnParse": {
+                                              "type": "boolean"
+                                            },
+                                            "mergeExtractorsToBody": {
+                                              "type": "object"
+                                            },
+                                            "parseBodyBehavior": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "passthrough": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kube": {
+                                  "properties": {
+                                    "port": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "ref": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "subset": {
+                                  "properties": {
+                                    "values": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "upstream": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "options": {
+                              "properties": {
+                                "bufferPerRoute": {
+                                  "properties": {
+                                    "buffer": {
+                                      "properties": {
+                                        "maxRequestBytes": {
+                                          "maximum": 4294967295,
+                                          "minimum": 0,
+                                          "nullable": true,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "disabled": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "csrf": {
+                                  "properties": {
+                                    "additionalOrigins": {
+                                      "items": {
+                                        "properties": {
+                                          "exact": {
+                                            "type": "string"
+                                          },
+                                          "ignoreCase": {
+                                            "type": "boolean"
+                                          },
+                                          "prefix": {
+                                            "type": "string"
+                                          },
+                                          "safeRegex": {
+                                            "properties": {
+                                              "googleRe2": {
+                                                "properties": {
+                                                  "maxProgramSize": {
+                                                    "maximum": 4294967295,
+                                                    "minimum": 0,
+                                                    "nullable": true,
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "suffix": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "filterEnabled": {
+                                      "properties": {
+                                        "defaultValue": {
+                                          "properties": {
+                                            "denominator": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "numerator": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "runtimeKey": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "shadowEnabled": {
+                                      "properties": {
+                                        "defaultValue": {
+                                          "properties": {
+                                            "denominator": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "numerator": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "runtimeKey": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "extauth": {
+                                  "properties": {
+                                    "configRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "customAuth": {
+                                      "properties": {
+                                        "contextExtensions": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "disable": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "extensions": {
+                                  "properties": {
+                                    "configs": {
+                                      "additionalProperties": {
+                                        "type": "object",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headerManipulation": {
+                                  "properties": {
+                                    "requestHeadersToAdd": {
+                                      "items": {
+                                        "properties": {
+                                          "append": {
+                                            "nullable": true,
+                                            "type": "boolean"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "headerSecretRef": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requestHeadersToRemove": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "responseHeadersToAdd": {
+                                      "items": {
+                                        "properties": {
+                                          "append": {
+                                            "nullable": true,
+                                            "type": "boolean"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "responseHeadersToRemove": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "stagedTransformations": {
+                                  "properties": {
+                                    "early": {
+                                      "properties": {
+                                        "requestTransforms": {
+                                          "items": {
+                                            "properties": {
+                                              "clearRouteCache": {
+                                                "type": "boolean"
+                                              },
+                                              "matcher": {
+                                                "properties": {
+                                                  "caseSensitive": {
+                                                    "nullable": true,
+                                                    "type": "boolean"
+                                                  },
+                                                  "exact": {
+                                                    "type": "string"
+                                                  },
+                                                  "headers": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "invertMatch": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "regex": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "methods": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "prefix": {
+                                                    "type": "string"
+                                                  },
+                                                  "queryParameters": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "regex": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "requestTransformation": {
+                                                "properties": {
+                                                  "headerBodyTransform": {
+                                                    "properties": {
+                                                      "addRequestMetadata": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "transformationTemplate": {
+                                                    "properties": {
+                                                      "advancedTemplates": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "body": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "dynamicMetadataValues": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "metadataNamespace": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "extractors": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "body": {
+                                                              "maxProperties": 0,
+                                                              "type": "object"
+                                                            },
+                                                            "header": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "string"
+                                                            },
+                                                            "subgroup": {
+                                                              "format": "int32",
+                                                              "type": "integer"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headers": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headersToAppend": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "headersToRemove": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "ignoreErrorOnParse": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "mergeExtractorsToBody": {
+                                                        "type": "object"
+                                                      },
+                                                      "parseBodyBehavior": {
+                                                        "type": "string",
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "passthrough": {
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "xsltTransformation": {
+                                                    "properties": {
+                                                      "nonXmlTransform": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "setContentType": {
+                                                        "type": "string"
+                                                      },
+                                                      "xslt": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "responseTransformation": {
+                                                "properties": {
+                                                  "headerBodyTransform": {
+                                                    "properties": {
+                                                      "addRequestMetadata": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "transformationTemplate": {
+                                                    "properties": {
+                                                      "advancedTemplates": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "body": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "dynamicMetadataValues": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "metadataNamespace": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "extractors": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "body": {
+                                                              "maxProperties": 0,
+                                                              "type": "object"
+                                                            },
+                                                            "header": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "string"
+                                                            },
+                                                            "subgroup": {
+                                                              "format": "int32",
+                                                              "type": "integer"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headers": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headersToAppend": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "headersToRemove": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "ignoreErrorOnParse": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "mergeExtractorsToBody": {
+                                                        "type": "object"
+                                                      },
+                                                      "parseBodyBehavior": {
+                                                        "type": "string",
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "passthrough": {
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "xsltTransformation": {
+                                                    "properties": {
+                                                      "nonXmlTransform": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "setContentType": {
+                                                        "type": "string"
+                                                      },
+                                                      "xslt": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "responseTransforms": {
+                                          "items": {
+                                            "properties": {
+                                              "matchers": {
+                                                "items": {
+                                                  "properties": {
+                                                    "invertMatch": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "regex": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "responseCodeDetails": {
+                                                "type": "string"
+                                              },
+                                              "responseTransformation": {
+                                                "properties": {
+                                                  "headerBodyTransform": {
+                                                    "properties": {
+                                                      "addRequestMetadata": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "transformationTemplate": {
+                                                    "properties": {
+                                                      "advancedTemplates": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "body": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "dynamicMetadataValues": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "metadataNamespace": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "extractors": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "body": {
+                                                              "maxProperties": 0,
+                                                              "type": "object"
+                                                            },
+                                                            "header": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "string"
+                                                            },
+                                                            "subgroup": {
+                                                              "format": "int32",
+                                                              "type": "integer"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headers": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headersToAppend": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "headersToRemove": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "ignoreErrorOnParse": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "mergeExtractorsToBody": {
+                                                        "type": "object"
+                                                      },
+                                                      "parseBodyBehavior": {
+                                                        "type": "string",
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "passthrough": {
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "xsltTransformation": {
+                                                    "properties": {
+                                                      "nonXmlTransform": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "setContentType": {
+                                                        "type": "string"
+                                                      },
+                                                      "xslt": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "inheritTransformation": {
+                                      "type": "boolean"
+                                    },
+                                    "regular": {
+                                      "properties": {
+                                        "requestTransforms": {
+                                          "items": {
+                                            "properties": {
+                                              "clearRouteCache": {
+                                                "type": "boolean"
+                                              },
+                                              "matcher": {
+                                                "properties": {
+                                                  "caseSensitive": {
+                                                    "nullable": true,
+                                                    "type": "boolean"
+                                                  },
+                                                  "exact": {
+                                                    "type": "string"
+                                                  },
+                                                  "headers": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "invertMatch": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "regex": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "methods": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "prefix": {
+                                                    "type": "string"
+                                                  },
+                                                  "queryParameters": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "regex": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "requestTransformation": {
+                                                "properties": {
+                                                  "headerBodyTransform": {
+                                                    "properties": {
+                                                      "addRequestMetadata": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "transformationTemplate": {
+                                                    "properties": {
+                                                      "advancedTemplates": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "body": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "dynamicMetadataValues": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "metadataNamespace": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "extractors": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "body": {
+                                                              "maxProperties": 0,
+                                                              "type": "object"
+                                                            },
+                                                            "header": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "string"
+                                                            },
+                                                            "subgroup": {
+                                                              "format": "int32",
+                                                              "type": "integer"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headers": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headersToAppend": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "headersToRemove": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "ignoreErrorOnParse": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "mergeExtractorsToBody": {
+                                                        "type": "object"
+                                                      },
+                                                      "parseBodyBehavior": {
+                                                        "type": "string",
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "passthrough": {
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "xsltTransformation": {
+                                                    "properties": {
+                                                      "nonXmlTransform": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "setContentType": {
+                                                        "type": "string"
+                                                      },
+                                                      "xslt": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "responseTransformation": {
+                                                "properties": {
+                                                  "headerBodyTransform": {
+                                                    "properties": {
+                                                      "addRequestMetadata": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "transformationTemplate": {
+                                                    "properties": {
+                                                      "advancedTemplates": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "body": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "dynamicMetadataValues": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "metadataNamespace": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "extractors": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "body": {
+                                                              "maxProperties": 0,
+                                                              "type": "object"
+                                                            },
+                                                            "header": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "string"
+                                                            },
+                                                            "subgroup": {
+                                                              "format": "int32",
+                                                              "type": "integer"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headers": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headersToAppend": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "headersToRemove": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "ignoreErrorOnParse": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "mergeExtractorsToBody": {
+                                                        "type": "object"
+                                                      },
+                                                      "parseBodyBehavior": {
+                                                        "type": "string",
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "passthrough": {
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "xsltTransformation": {
+                                                    "properties": {
+                                                      "nonXmlTransform": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "setContentType": {
+                                                        "type": "string"
+                                                      },
+                                                      "xslt": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "responseTransforms": {
+                                          "items": {
+                                            "properties": {
+                                              "matchers": {
+                                                "items": {
+                                                  "properties": {
+                                                    "invertMatch": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "regex": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "responseCodeDetails": {
+                                                "type": "string"
+                                              },
+                                              "responseTransformation": {
+                                                "properties": {
+                                                  "headerBodyTransform": {
+                                                    "properties": {
+                                                      "addRequestMetadata": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "transformationTemplate": {
+                                                    "properties": {
+                                                      "advancedTemplates": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "body": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "dynamicMetadataValues": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "metadataNamespace": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "extractors": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "body": {
+                                                              "maxProperties": 0,
+                                                              "type": "object"
+                                                            },
+                                                            "header": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "string"
+                                                            },
+                                                            "subgroup": {
+                                                              "format": "int32",
+                                                              "type": "integer"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headers": {
+                                                        "additionalProperties": {
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "headersToAppend": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "headersToRemove": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "ignoreErrorOnParse": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "mergeExtractorsToBody": {
+                                                        "type": "object"
+                                                      },
+                                                      "parseBodyBehavior": {
+                                                        "type": "string",
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "passthrough": {
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "xsltTransformation": {
+                                                    "properties": {
+                                                      "nonXmlTransform": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "setContentType": {
+                                                        "type": "string"
+                                                      },
+                                                      "xslt": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "transformations": {
+                                  "properties": {
+                                    "clearRouteCache": {
+                                      "type": "boolean"
+                                    },
+                                    "requestTransformation": {
+                                      "properties": {
+                                        "headerBodyTransform": {
+                                          "properties": {
+                                            "addRequestMetadata": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "transformationTemplate": {
+                                          "properties": {
+                                            "advancedTemplates": {
+                                              "type": "boolean"
+                                            },
+                                            "body": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "dynamicMetadataValues": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "metadataNamespace": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "extractors": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "body": {
+                                                    "maxProperties": 0,
+                                                    "type": "object"
+                                                  },
+                                                  "header": {
+                                                    "type": "string"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  },
+                                                  "subgroup": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headersToAppend": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "headersToRemove": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreErrorOnParse": {
+                                              "type": "boolean"
+                                            },
+                                            "mergeExtractorsToBody": {
+                                              "type": "object"
+                                            },
+                                            "parseBodyBehavior": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "passthrough": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "xsltTransformation": {
+                                          "properties": {
+                                            "nonXmlTransform": {
+                                              "type": "boolean"
+                                            },
+                                            "setContentType": {
+                                              "type": "string"
+                                            },
+                                            "xslt": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "responseTransformation": {
+                                      "properties": {
+                                        "headerBodyTransform": {
+                                          "properties": {
+                                            "addRequestMetadata": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "transformationTemplate": {
+                                          "properties": {
+                                            "advancedTemplates": {
+                                              "type": "boolean"
+                                            },
+                                            "body": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "dynamicMetadataValues": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "metadataNamespace": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "extractors": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "body": {
+                                                    "maxProperties": 0,
+                                                    "type": "object"
+                                                  },
+                                                  "header": {
+                                                    "type": "string"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  },
+                                                  "subgroup": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headersToAppend": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "headersToRemove": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreErrorOnParse": {
+                                              "type": "boolean"
+                                            },
+                                            "mergeExtractorsToBody": {
+                                              "type": "object"
+                                            },
+                                            "parseBodyBehavior": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "passthrough": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "xsltTransformation": {
+                                          "properties": {
+                                            "nonXmlTransform": {
+                                              "type": "boolean"
+                                            },
+                                            "setContentType": {
+                                              "type": "string"
+                                            },
+                                            "xslt": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "weight": {
+                              "maximum": 4294967295,
+                              "minimum": 0,
+                              "nullable": true,
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "single": {
+                    "properties": {
+                      "consul": {
+                        "properties": {
+                          "dataCenters": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "serviceName": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "destinationSpec": {
+                        "properties": {
+                          "aws": {
+                            "properties": {
+                              "invocationStyle": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "logicalName": {
+                                "type": "string"
+                              },
+                              "requestTransformation": {
+                                "type": "boolean"
+                              },
+                              "responseTransformation": {
+                                "type": "boolean"
+                              },
+                              "unwrapAsAlb": {
+                                "type": "boolean"
+                              },
+                              "unwrapAsApiGateway": {
+                                "type": "boolean"
+                              },
+                              "wrapAsApiGateway": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "functionName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "grpc": {
+                            "properties": {
+                              "function": {
+                                "type": "string"
+                              },
+                              "package": {
+                                "type": "string"
+                              },
+                              "parameters": {
+                                "properties": {
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "path": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "rest": {
+                            "properties": {
+                              "functionName": {
+                                "type": "string"
+                              },
+                              "parameters": {
+                                "properties": {
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "path": {
+                                    "nullable": true,
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "responseTransformation": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "kube": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "ref": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "subset": {
+                        "properties": {
+                          "values": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "upstream": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "upstreamGroup": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "weight": {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "nullable": true,
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gateway.solo.io/virtualhostoption_v1.json
+++ b/gateway.solo.io/virtualhostoption_v1.json
@@ -1,0 +1,3392 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "options": {
+          "properties": {
+            "bufferPerRoute": {
+              "properties": {
+                "buffer": {
+                  "properties": {
+                    "maxRequestBytes": {
+                      "maximum": 4294967295,
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disabled": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cors": {
+              "properties": {
+                "allowCredentials": {
+                  "type": "boolean"
+                },
+                "allowHeaders": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowMethods": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowOrigin": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowOriginRegex": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "disableForRoute": {
+                  "type": "boolean"
+                },
+                "exposeHeaders": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maxAge": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "csrf": {
+              "properties": {
+                "additionalOrigins": {
+                  "items": {
+                    "properties": {
+                      "exact": {
+                        "type": "string"
+                      },
+                      "ignoreCase": {
+                        "type": "boolean"
+                      },
+                      "prefix": {
+                        "type": "string"
+                      },
+                      "safeRegex": {
+                        "properties": {
+                          "googleRe2": {
+                            "properties": {
+                              "maxProgramSize": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "suffix": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "filterEnabled": {
+                  "properties": {
+                    "defaultValue": {
+                      "properties": {
+                        "denominator": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "numerator": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "runtimeKey": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "shadowEnabled": {
+                  "properties": {
+                    "defaultValue": {
+                      "properties": {
+                        "denominator": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "numerator": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "runtimeKey": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dlp": {
+              "properties": {
+                "actions": {
+                  "items": {
+                    "properties": {
+                      "actionType": {
+                        "type": "string",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "customAction": {
+                        "properties": {
+                          "maskChar": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "percent": {
+                            "properties": {
+                              "value": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "regex": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "regexActions": {
+                            "items": {
+                              "properties": {
+                                "regex": {
+                                  "type": "string"
+                                },
+                                "subgroup": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "keyValueAction": {
+                        "properties": {
+                          "keyToMask": {
+                            "type": "string"
+                          },
+                          "maskChar": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "percent": {
+                            "properties": {
+                              "value": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "shadow": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "enabledFor": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "extauth": {
+              "properties": {
+                "configRef": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "customAuth": {
+                  "properties": {
+                    "contextExtensions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "disable": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "extensions": {
+              "properties": {
+                "configs": {
+                  "additionalProperties": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "headerManipulation": {
+              "properties": {
+                "requestHeadersToAdd": {
+                  "items": {
+                    "properties": {
+                      "append": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "header": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "headerSecretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "requestHeadersToRemove": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "responseHeadersToAdd": {
+                  "items": {
+                    "properties": {
+                      "append": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "header": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "responseHeadersToRemove": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "includeAttemptCountInResponse": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "includeRequestAttemptCount": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "jwt": {
+              "properties": {
+                "allowMissingOrFailedJwt": {
+                  "type": "boolean"
+                },
+                "providers": {
+                  "additionalProperties": {
+                    "properties": {
+                      "audiences": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "claimsToHeaders": {
+                        "items": {
+                          "properties": {
+                            "append": {
+                              "type": "boolean"
+                            },
+                            "claim": {
+                              "type": "string"
+                            },
+                            "header": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "issuer": {
+                        "type": "string"
+                      },
+                      "jwks": {
+                        "properties": {
+                          "local": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "remote": {
+                            "properties": {
+                              "asyncFetch": {
+                                "properties": {
+                                  "fastListener": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "cacheDuration": {
+                                "type": "string"
+                              },
+                              "upstreamRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "keepToken": {
+                        "type": "boolean"
+                      },
+                      "tokenSource": {
+                        "properties": {
+                          "headers": {
+                            "items": {
+                              "properties": {
+                                "header": {
+                                  "type": "string"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "queryParams": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jwtStaged": {
+              "properties": {
+                "afterExtAuth": {
+                  "properties": {
+                    "allowMissingOrFailedJwt": {
+                      "type": "boolean"
+                    },
+                    "providers": {
+                      "additionalProperties": {
+                        "properties": {
+                          "audiences": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "claimsToHeaders": {
+                            "items": {
+                              "properties": {
+                                "append": {
+                                  "type": "boolean"
+                                },
+                                "claim": {
+                                  "type": "string"
+                                },
+                                "header": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "issuer": {
+                            "type": "string"
+                          },
+                          "jwks": {
+                            "properties": {
+                              "local": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "remote": {
+                                "properties": {
+                                  "asyncFetch": {
+                                    "properties": {
+                                      "fastListener": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cacheDuration": {
+                                    "type": "string"
+                                  },
+                                  "upstreamRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "keepToken": {
+                            "type": "boolean"
+                          },
+                          "tokenSource": {
+                            "properties": {
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "header": {
+                                      "type": "string"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "queryParams": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "beforeExtAuth": {
+                  "properties": {
+                    "allowMissingOrFailedJwt": {
+                      "type": "boolean"
+                    },
+                    "providers": {
+                      "additionalProperties": {
+                        "properties": {
+                          "audiences": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "claimsToHeaders": {
+                            "items": {
+                              "properties": {
+                                "append": {
+                                  "type": "boolean"
+                                },
+                                "claim": {
+                                  "type": "string"
+                                },
+                                "header": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "issuer": {
+                            "type": "string"
+                          },
+                          "jwks": {
+                            "properties": {
+                              "local": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "remote": {
+                                "properties": {
+                                  "asyncFetch": {
+                                    "properties": {
+                                      "fastListener": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cacheDuration": {
+                                    "type": "string"
+                                  },
+                                  "upstreamRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "keepToken": {
+                            "type": "boolean"
+                          },
+                          "tokenSource": {
+                            "properties": {
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "header": {
+                                      "type": "string"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "queryParams": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rateLimitConfigs": {
+              "properties": {
+                "refs": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rateLimitEarlyConfigs": {
+              "properties": {
+                "refs": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rateLimitRegularConfigs": {
+              "properties": {
+                "refs": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ratelimit": {
+              "properties": {
+                "rateLimits": {
+                  "items": {
+                    "properties": {
+                      "actions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "setActions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ratelimitBasic": {
+              "properties": {
+                "anonymousLimits": {
+                  "properties": {
+                    "requestsPerUnit": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "unit": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "authorizedLimits": {
+                  "properties": {
+                    "requestsPerUnit": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "unit": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ratelimitEarly": {
+              "properties": {
+                "rateLimits": {
+                  "items": {
+                    "properties": {
+                      "actions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "setActions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ratelimitRegular": {
+              "properties": {
+                "rateLimits": {
+                  "items": {
+                    "properties": {
+                      "actions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "setActions": {
+                        "items": {
+                          "properties": {
+                            "destinationCluster": {
+                              "type": "object"
+                            },
+                            "genericKey": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerValueMatch": {
+                              "properties": {
+                                "descriptorValue": {
+                                  "type": "string"
+                                },
+                                "expectMatch": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "exactMatch": {
+                                        "type": "string"
+                                      },
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "prefixMatch": {
+                                        "type": "string"
+                                      },
+                                      "presentMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "rangeMatch": {
+                                        "properties": {
+                                          "end": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "start": {
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "regexMatch": {
+                                        "type": "string"
+                                      },
+                                      "suffixMatch": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "metadata": {
+                              "properties": {
+                                "defaultValue": {
+                                  "type": "string"
+                                },
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "metadataKey": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "source": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "remoteAddress": {
+                              "type": "object"
+                            },
+                            "requestHeaders": {
+                              "properties": {
+                                "descriptorKey": {
+                                  "type": "string"
+                                },
+                                "headerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "sourceCluster": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rbac": {
+              "properties": {
+                "disable": {
+                  "type": "boolean"
+                },
+                "policies": {
+                  "additionalProperties": {
+                    "properties": {
+                      "nestedClaimDelimiter": {
+                        "type": "string"
+                      },
+                      "permissions": {
+                        "properties": {
+                          "methods": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "pathPrefix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "principals": {
+                        "items": {
+                          "properties": {
+                            "jwtPrincipal": {
+                              "properties": {
+                                "claims": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "matcher": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "provider": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "retries": {
+              "properties": {
+                "numRetries": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "perTryTimeout": {
+                  "type": "string"
+                },
+                "retryBackOff": {
+                  "properties": {
+                    "baseInterval": {
+                      "type": "string"
+                    },
+                    "maxInterval": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "retryOn": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "stagedTransformations": {
+              "properties": {
+                "early": {
+                  "properties": {
+                    "requestTransforms": {
+                      "items": {
+                        "properties": {
+                          "clearRouteCache": {
+                            "type": "boolean"
+                          },
+                          "matcher": {
+                            "properties": {
+                              "caseSensitive": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "exact": {
+                                "type": "string"
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "invertMatch": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "methods": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "prefix": {
+                                "type": "string"
+                              },
+                              "queryParameters": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "requestTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "responseTransforms": {
+                      "items": {
+                        "properties": {
+                          "matchers": {
+                            "items": {
+                              "properties": {
+                                "invertMatch": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "regex": {
+                                  "type": "boolean"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "responseCodeDetails": {
+                            "type": "string"
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "inheritTransformation": {
+                  "type": "boolean"
+                },
+                "regular": {
+                  "properties": {
+                    "requestTransforms": {
+                      "items": {
+                        "properties": {
+                          "clearRouteCache": {
+                            "type": "boolean"
+                          },
+                          "matcher": {
+                            "properties": {
+                              "caseSensitive": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "exact": {
+                                "type": "string"
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "invertMatch": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "methods": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "prefix": {
+                                "type": "string"
+                              },
+                              "queryParameters": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "requestTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "responseTransforms": {
+                      "items": {
+                        "properties": {
+                          "matchers": {
+                            "items": {
+                              "properties": {
+                                "invertMatch": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "regex": {
+                                  "type": "boolean"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "responseCodeDetails": {
+                            "type": "string"
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "stats": {
+              "properties": {
+                "virtualClusters": {
+                  "items": {
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "transformations": {
+              "properties": {
+                "clearRouteCache": {
+                  "type": "boolean"
+                },
+                "requestTransformation": {
+                  "properties": {
+                    "headerBodyTransform": {
+                      "properties": {
+                        "addRequestMetadata": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transformationTemplate": {
+                      "properties": {
+                        "advancedTemplates": {
+                          "type": "boolean"
+                        },
+                        "body": {
+                          "properties": {
+                            "text": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dynamicMetadataValues": {
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "metadataNamespace": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "extractors": {
+                          "additionalProperties": {
+                            "properties": {
+                              "body": {
+                                "maxProperties": 0,
+                                "type": "object"
+                              },
+                              "header": {
+                                "type": "string"
+                              },
+                              "regex": {
+                                "type": "string"
+                              },
+                              "subgroup": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        },
+                        "headers": {
+                          "additionalProperties": {
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        },
+                        "headersToAppend": {
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "headersToRemove": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "ignoreErrorOnParse": {
+                          "type": "boolean"
+                        },
+                        "mergeExtractorsToBody": {
+                          "type": "object"
+                        },
+                        "parseBodyBehavior": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "passthrough": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "xsltTransformation": {
+                      "properties": {
+                        "nonXmlTransform": {
+                          "type": "boolean"
+                        },
+                        "setContentType": {
+                          "type": "string"
+                        },
+                        "xslt": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "responseTransformation": {
+                  "properties": {
+                    "headerBodyTransform": {
+                      "properties": {
+                        "addRequestMetadata": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transformationTemplate": {
+                      "properties": {
+                        "advancedTemplates": {
+                          "type": "boolean"
+                        },
+                        "body": {
+                          "properties": {
+                            "text": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dynamicMetadataValues": {
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "metadataNamespace": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "extractors": {
+                          "additionalProperties": {
+                            "properties": {
+                              "body": {
+                                "maxProperties": 0,
+                                "type": "object"
+                              },
+                              "header": {
+                                "type": "string"
+                              },
+                              "regex": {
+                                "type": "string"
+                              },
+                              "subgroup": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        },
+                        "headers": {
+                          "additionalProperties": {
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        },
+                        "headersToAppend": {
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "headersToRemove": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "ignoreErrorOnParse": {
+                          "type": "boolean"
+                        },
+                        "mergeExtractorsToBody": {
+                          "type": "object"
+                        },
+                        "parseBodyBehavior": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "passthrough": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "xsltTransformation": {
+                      "properties": {
+                        "nonXmlTransform": {
+                          "type": "boolean"
+                        },
+                        "setContentType": {
+                          "type": "string"
+                        },
+                        "xslt": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "waf": {
+              "properties": {
+                "auditLogging": {
+                  "properties": {
+                    "action": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "location": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "configMapRuleSets": {
+                  "items": {
+                    "properties": {
+                      "configMapRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "dataMapKeys": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "coreRuleSet": {
+                  "properties": {
+                    "customSettingsFile": {
+                      "type": "string"
+                    },
+                    "customSettingsString": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "customInterventionMessage": {
+                  "type": "string"
+                },
+                "disabled": {
+                  "type": "boolean"
+                },
+                "requestHeadersOnly": {
+                  "type": "boolean"
+                },
+                "responseHeadersOnly": {
+                  "type": "boolean"
+                },
+                "ruleSets": {
+                  "items": {
+                    "properties": {
+                      "directory": {
+                        "type": "string"
+                      },
+                      "files": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "ruleStr": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gateway.solo.io/virtualservice_v1.json
+++ b/gateway.solo.io/virtualservice_v1.json
@@ -1,0 +1,9307 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "displayName": {
+          "type": "string"
+        },
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sslConfig": {
+          "properties": {
+            "alpnProtocols": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "disableTlsSessionResumption": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "oneWayTls": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "parameters": {
+              "properties": {
+                "cipherSuites": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ecdhCurves": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maximumProtocolVersion": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "minimumProtocolVersion": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sds": {
+              "properties": {
+                "callCredentials": {
+                  "properties": {
+                    "fileCredentialSource": {
+                      "properties": {
+                        "header": {
+                          "type": "string"
+                        },
+                        "tokenFileName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "certificatesSecretName": {
+                  "type": "string"
+                },
+                "clusterName": {
+                  "type": "string"
+                },
+                "targetUri": {
+                  "type": "string"
+                },
+                "validationContextName": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sniDomains": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "sslFiles": {
+              "properties": {
+                "rootCa": {
+                  "type": "string"
+                },
+                "tlsCert": {
+                  "type": "string"
+                },
+                "tlsKey": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "transportSocketConnectTimeout": {
+              "type": "string"
+            },
+            "verifySubjectAltName": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "virtualHost": {
+          "properties": {
+            "domains": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "options": {
+              "properties": {
+                "bufferPerRoute": {
+                  "properties": {
+                    "buffer": {
+                      "properties": {
+                        "maxRequestBytes": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "cors": {
+                  "properties": {
+                    "allowCredentials": {
+                      "type": "boolean"
+                    },
+                    "allowHeaders": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "allowMethods": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "allowOrigin": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "allowOriginRegex": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "disableForRoute": {
+                      "type": "boolean"
+                    },
+                    "exposeHeaders": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "maxAge": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "csrf": {
+                  "properties": {
+                    "additionalOrigins": {
+                      "items": {
+                        "properties": {
+                          "exact": {
+                            "type": "string"
+                          },
+                          "ignoreCase": {
+                            "type": "boolean"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "safeRegex": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "filterEnabled": {
+                      "properties": {
+                        "defaultValue": {
+                          "properties": {
+                            "denominator": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "numerator": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "runtimeKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "shadowEnabled": {
+                      "properties": {
+                        "defaultValue": {
+                          "properties": {
+                            "denominator": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "numerator": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "runtimeKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dlp": {
+                  "properties": {
+                    "actions": {
+                      "items": {
+                        "properties": {
+                          "actionType": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "customAction": {
+                            "properties": {
+                              "maskChar": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "percent": {
+                                "properties": {
+                                  "value": {
+                                    "type": "number"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "regexActions": {
+                                "items": {
+                                  "properties": {
+                                    "regex": {
+                                      "type": "string"
+                                    },
+                                    "subgroup": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "keyValueAction": {
+                            "properties": {
+                              "keyToMask": {
+                                "type": "string"
+                              },
+                              "maskChar": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "percent": {
+                                "properties": {
+                                  "value": {
+                                    "type": "number"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "shadow": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "enabledFor": {
+                      "type": "string",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "extauth": {
+                  "properties": {
+                    "configRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "customAuth": {
+                      "properties": {
+                        "contextExtensions": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "disable": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "extensions": {
+                  "properties": {
+                    "configs": {
+                      "additionalProperties": {
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "headerManipulation": {
+                  "properties": {
+                    "requestHeadersToAdd": {
+                      "items": {
+                        "properties": {
+                          "append": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "header": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "headerSecretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requestHeadersToRemove": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "responseHeadersToAdd": {
+                      "items": {
+                        "properties": {
+                          "append": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "header": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "responseHeadersToRemove": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "includeAttemptCountInResponse": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "includeRequestAttemptCount": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "jwt": {
+                  "properties": {
+                    "allowMissingOrFailedJwt": {
+                      "type": "boolean"
+                    },
+                    "providers": {
+                      "additionalProperties": {
+                        "properties": {
+                          "audiences": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "claimsToHeaders": {
+                            "items": {
+                              "properties": {
+                                "append": {
+                                  "type": "boolean"
+                                },
+                                "claim": {
+                                  "type": "string"
+                                },
+                                "header": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "issuer": {
+                            "type": "string"
+                          },
+                          "jwks": {
+                            "properties": {
+                              "local": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "remote": {
+                                "properties": {
+                                  "asyncFetch": {
+                                    "properties": {
+                                      "fastListener": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cacheDuration": {
+                                    "type": "string"
+                                  },
+                                  "upstreamRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "keepToken": {
+                            "type": "boolean"
+                          },
+                          "tokenSource": {
+                            "properties": {
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "header": {
+                                      "type": "string"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "queryParams": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "jwtStaged": {
+                  "properties": {
+                    "afterExtAuth": {
+                      "properties": {
+                        "allowMissingOrFailedJwt": {
+                          "type": "boolean"
+                        },
+                        "providers": {
+                          "additionalProperties": {
+                            "properties": {
+                              "audiences": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "claimsToHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "append": {
+                                      "type": "boolean"
+                                    },
+                                    "claim": {
+                                      "type": "string"
+                                    },
+                                    "header": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "issuer": {
+                                "type": "string"
+                              },
+                              "jwks": {
+                                "properties": {
+                                  "local": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "remote": {
+                                    "properties": {
+                                      "asyncFetch": {
+                                        "properties": {
+                                          "fastListener": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "cacheDuration": {
+                                        "type": "string"
+                                      },
+                                      "upstreamRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "keepToken": {
+                                "type": "boolean"
+                              },
+                              "tokenSource": {
+                                "properties": {
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "queryParams": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "beforeExtAuth": {
+                      "properties": {
+                        "allowMissingOrFailedJwt": {
+                          "type": "boolean"
+                        },
+                        "providers": {
+                          "additionalProperties": {
+                            "properties": {
+                              "audiences": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "claimsToHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "append": {
+                                      "type": "boolean"
+                                    },
+                                    "claim": {
+                                      "type": "string"
+                                    },
+                                    "header": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "issuer": {
+                                "type": "string"
+                              },
+                              "jwks": {
+                                "properties": {
+                                  "local": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "remote": {
+                                    "properties": {
+                                      "asyncFetch": {
+                                        "properties": {
+                                          "fastListener": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "cacheDuration": {
+                                        "type": "string"
+                                      },
+                                      "upstreamRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "url": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "keepToken": {
+                                "type": "boolean"
+                              },
+                              "tokenSource": {
+                                "properties": {
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "queryParams": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rateLimitConfigs": {
+                  "properties": {
+                    "refs": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rateLimitEarlyConfigs": {
+                  "properties": {
+                    "refs": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rateLimitRegularConfigs": {
+                  "properties": {
+                    "refs": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ratelimit": {
+                  "properties": {
+                    "rateLimits": {
+                      "items": {
+                        "properties": {
+                          "actions": {
+                            "items": {
+                              "properties": {
+                                "destinationCluster": {
+                                  "type": "object"
+                                },
+                                "genericKey": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headerValueMatch": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    },
+                                    "expectMatch": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "exactMatch": {
+                                            "type": "string"
+                                          },
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "prefixMatch": {
+                                            "type": "string"
+                                          },
+                                          "presentMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "rangeMatch": {
+                                            "properties": {
+                                              "end": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "start": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "regexMatch": {
+                                            "type": "string"
+                                          },
+                                          "suffixMatch": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "metadata": {
+                                  "properties": {
+                                    "defaultValue": {
+                                      "type": "string"
+                                    },
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "metadataKey": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "source": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "remoteAddress": {
+                                  "type": "object"
+                                },
+                                "requestHeaders": {
+                                  "properties": {
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "headerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "sourceCluster": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "setActions": {
+                            "items": {
+                              "properties": {
+                                "destinationCluster": {
+                                  "type": "object"
+                                },
+                                "genericKey": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headerValueMatch": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    },
+                                    "expectMatch": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "exactMatch": {
+                                            "type": "string"
+                                          },
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "prefixMatch": {
+                                            "type": "string"
+                                          },
+                                          "presentMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "rangeMatch": {
+                                            "properties": {
+                                              "end": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "start": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "regexMatch": {
+                                            "type": "string"
+                                          },
+                                          "suffixMatch": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "metadata": {
+                                  "properties": {
+                                    "defaultValue": {
+                                      "type": "string"
+                                    },
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "metadataKey": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "source": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "remoteAddress": {
+                                  "type": "object"
+                                },
+                                "requestHeaders": {
+                                  "properties": {
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "headerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "sourceCluster": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ratelimitBasic": {
+                  "properties": {
+                    "anonymousLimits": {
+                      "properties": {
+                        "requestsPerUnit": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "unit": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "authorizedLimits": {
+                      "properties": {
+                        "requestsPerUnit": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "unit": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ratelimitEarly": {
+                  "properties": {
+                    "rateLimits": {
+                      "items": {
+                        "properties": {
+                          "actions": {
+                            "items": {
+                              "properties": {
+                                "destinationCluster": {
+                                  "type": "object"
+                                },
+                                "genericKey": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headerValueMatch": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    },
+                                    "expectMatch": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "exactMatch": {
+                                            "type": "string"
+                                          },
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "prefixMatch": {
+                                            "type": "string"
+                                          },
+                                          "presentMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "rangeMatch": {
+                                            "properties": {
+                                              "end": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "start": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "regexMatch": {
+                                            "type": "string"
+                                          },
+                                          "suffixMatch": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "metadata": {
+                                  "properties": {
+                                    "defaultValue": {
+                                      "type": "string"
+                                    },
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "metadataKey": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "source": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "remoteAddress": {
+                                  "type": "object"
+                                },
+                                "requestHeaders": {
+                                  "properties": {
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "headerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "sourceCluster": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "setActions": {
+                            "items": {
+                              "properties": {
+                                "destinationCluster": {
+                                  "type": "object"
+                                },
+                                "genericKey": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headerValueMatch": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    },
+                                    "expectMatch": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "exactMatch": {
+                                            "type": "string"
+                                          },
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "prefixMatch": {
+                                            "type": "string"
+                                          },
+                                          "presentMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "rangeMatch": {
+                                            "properties": {
+                                              "end": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "start": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "regexMatch": {
+                                            "type": "string"
+                                          },
+                                          "suffixMatch": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "metadata": {
+                                  "properties": {
+                                    "defaultValue": {
+                                      "type": "string"
+                                    },
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "metadataKey": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "source": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "remoteAddress": {
+                                  "type": "object"
+                                },
+                                "requestHeaders": {
+                                  "properties": {
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "headerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "sourceCluster": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ratelimitRegular": {
+                  "properties": {
+                    "rateLimits": {
+                      "items": {
+                        "properties": {
+                          "actions": {
+                            "items": {
+                              "properties": {
+                                "destinationCluster": {
+                                  "type": "object"
+                                },
+                                "genericKey": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headerValueMatch": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    },
+                                    "expectMatch": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "exactMatch": {
+                                            "type": "string"
+                                          },
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "prefixMatch": {
+                                            "type": "string"
+                                          },
+                                          "presentMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "rangeMatch": {
+                                            "properties": {
+                                              "end": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "start": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "regexMatch": {
+                                            "type": "string"
+                                          },
+                                          "suffixMatch": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "metadata": {
+                                  "properties": {
+                                    "defaultValue": {
+                                      "type": "string"
+                                    },
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "metadataKey": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "source": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "remoteAddress": {
+                                  "type": "object"
+                                },
+                                "requestHeaders": {
+                                  "properties": {
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "headerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "sourceCluster": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "setActions": {
+                            "items": {
+                              "properties": {
+                                "destinationCluster": {
+                                  "type": "object"
+                                },
+                                "genericKey": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headerValueMatch": {
+                                  "properties": {
+                                    "descriptorValue": {
+                                      "type": "string"
+                                    },
+                                    "expectMatch": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "exactMatch": {
+                                            "type": "string"
+                                          },
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "prefixMatch": {
+                                            "type": "string"
+                                          },
+                                          "presentMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "rangeMatch": {
+                                            "properties": {
+                                              "end": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "start": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "regexMatch": {
+                                            "type": "string"
+                                          },
+                                          "suffixMatch": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "metadata": {
+                                  "properties": {
+                                    "defaultValue": {
+                                      "type": "string"
+                                    },
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "metadataKey": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "source": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "remoteAddress": {
+                                  "type": "object"
+                                },
+                                "requestHeaders": {
+                                  "properties": {
+                                    "descriptorKey": {
+                                      "type": "string"
+                                    },
+                                    "headerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "sourceCluster": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rbac": {
+                  "properties": {
+                    "disable": {
+                      "type": "boolean"
+                    },
+                    "policies": {
+                      "additionalProperties": {
+                        "properties": {
+                          "nestedClaimDelimiter": {
+                            "type": "string"
+                          },
+                          "permissions": {
+                            "properties": {
+                              "methods": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pathPrefix": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "principals": {
+                            "items": {
+                              "properties": {
+                                "jwtPrincipal": {
+                                  "properties": {
+                                    "claims": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "matcher": {
+                                      "type": "string",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "provider": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "retries": {
+                  "properties": {
+                    "numRetries": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "perTryTimeout": {
+                      "type": "string"
+                    },
+                    "retryBackOff": {
+                      "properties": {
+                        "baseInterval": {
+                          "type": "string"
+                        },
+                        "maxInterval": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "retryOn": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "stagedTransformations": {
+                  "properties": {
+                    "early": {
+                      "properties": {
+                        "requestTransforms": {
+                          "items": {
+                            "properties": {
+                              "clearRouteCache": {
+                                "type": "boolean"
+                              },
+                              "matcher": {
+                                "properties": {
+                                  "caseSensitive": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  },
+                                  "exact": {
+                                    "type": "string"
+                                  },
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "invertMatch": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "boolean"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "methods": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "prefix": {
+                                    "type": "string"
+                                  },
+                                  "queryParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "boolean"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "regex": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "requestTransformation": {
+                                "properties": {
+                                  "headerBodyTransform": {
+                                    "properties": {
+                                      "addRequestMetadata": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "transformationTemplate": {
+                                    "properties": {
+                                      "advancedTemplates": {
+                                        "type": "boolean"
+                                      },
+                                      "body": {
+                                        "properties": {
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dynamicMetadataValues": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "metadataNamespace": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "extractors": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "body": {
+                                              "maxProperties": 0,
+                                              "type": "object"
+                                            },
+                                            "header": {
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "type": "string"
+                                            },
+                                            "subgroup": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headersToAppend": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "headersToRemove": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ignoreErrorOnParse": {
+                                        "type": "boolean"
+                                      },
+                                      "mergeExtractorsToBody": {
+                                        "type": "object"
+                                      },
+                                      "parseBodyBehavior": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "passthrough": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "xsltTransformation": {
+                                    "properties": {
+                                      "nonXmlTransform": {
+                                        "type": "boolean"
+                                      },
+                                      "setContentType": {
+                                        "type": "string"
+                                      },
+                                      "xslt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "responseTransformation": {
+                                "properties": {
+                                  "headerBodyTransform": {
+                                    "properties": {
+                                      "addRequestMetadata": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "transformationTemplate": {
+                                    "properties": {
+                                      "advancedTemplates": {
+                                        "type": "boolean"
+                                      },
+                                      "body": {
+                                        "properties": {
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dynamicMetadataValues": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "metadataNamespace": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "extractors": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "body": {
+                                              "maxProperties": 0,
+                                              "type": "object"
+                                            },
+                                            "header": {
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "type": "string"
+                                            },
+                                            "subgroup": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headersToAppend": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "headersToRemove": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ignoreErrorOnParse": {
+                                        "type": "boolean"
+                                      },
+                                      "mergeExtractorsToBody": {
+                                        "type": "object"
+                                      },
+                                      "parseBodyBehavior": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "passthrough": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "xsltTransformation": {
+                                    "properties": {
+                                      "nonXmlTransform": {
+                                        "type": "boolean"
+                                      },
+                                      "setContentType": {
+                                        "type": "string"
+                                      },
+                                      "xslt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "responseTransforms": {
+                          "items": {
+                            "properties": {
+                              "matchers": {
+                                "items": {
+                                  "properties": {
+                                    "invertMatch": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "responseCodeDetails": {
+                                "type": "string"
+                              },
+                              "responseTransformation": {
+                                "properties": {
+                                  "headerBodyTransform": {
+                                    "properties": {
+                                      "addRequestMetadata": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "transformationTemplate": {
+                                    "properties": {
+                                      "advancedTemplates": {
+                                        "type": "boolean"
+                                      },
+                                      "body": {
+                                        "properties": {
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dynamicMetadataValues": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "metadataNamespace": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "extractors": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "body": {
+                                              "maxProperties": 0,
+                                              "type": "object"
+                                            },
+                                            "header": {
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "type": "string"
+                                            },
+                                            "subgroup": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headersToAppend": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "headersToRemove": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ignoreErrorOnParse": {
+                                        "type": "boolean"
+                                      },
+                                      "mergeExtractorsToBody": {
+                                        "type": "object"
+                                      },
+                                      "parseBodyBehavior": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "passthrough": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "xsltTransformation": {
+                                    "properties": {
+                                      "nonXmlTransform": {
+                                        "type": "boolean"
+                                      },
+                                      "setContentType": {
+                                        "type": "string"
+                                      },
+                                      "xslt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "inheritTransformation": {
+                      "type": "boolean"
+                    },
+                    "regular": {
+                      "properties": {
+                        "requestTransforms": {
+                          "items": {
+                            "properties": {
+                              "clearRouteCache": {
+                                "type": "boolean"
+                              },
+                              "matcher": {
+                                "properties": {
+                                  "caseSensitive": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  },
+                                  "exact": {
+                                    "type": "string"
+                                  },
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "invertMatch": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "boolean"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "methods": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "prefix": {
+                                    "type": "string"
+                                  },
+                                  "queryParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "boolean"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "regex": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "requestTransformation": {
+                                "properties": {
+                                  "headerBodyTransform": {
+                                    "properties": {
+                                      "addRequestMetadata": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "transformationTemplate": {
+                                    "properties": {
+                                      "advancedTemplates": {
+                                        "type": "boolean"
+                                      },
+                                      "body": {
+                                        "properties": {
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dynamicMetadataValues": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "metadataNamespace": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "extractors": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "body": {
+                                              "maxProperties": 0,
+                                              "type": "object"
+                                            },
+                                            "header": {
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "type": "string"
+                                            },
+                                            "subgroup": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headersToAppend": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "headersToRemove": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ignoreErrorOnParse": {
+                                        "type": "boolean"
+                                      },
+                                      "mergeExtractorsToBody": {
+                                        "type": "object"
+                                      },
+                                      "parseBodyBehavior": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "passthrough": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "xsltTransformation": {
+                                    "properties": {
+                                      "nonXmlTransform": {
+                                        "type": "boolean"
+                                      },
+                                      "setContentType": {
+                                        "type": "string"
+                                      },
+                                      "xslt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "responseTransformation": {
+                                "properties": {
+                                  "headerBodyTransform": {
+                                    "properties": {
+                                      "addRequestMetadata": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "transformationTemplate": {
+                                    "properties": {
+                                      "advancedTemplates": {
+                                        "type": "boolean"
+                                      },
+                                      "body": {
+                                        "properties": {
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dynamicMetadataValues": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "metadataNamespace": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "extractors": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "body": {
+                                              "maxProperties": 0,
+                                              "type": "object"
+                                            },
+                                            "header": {
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "type": "string"
+                                            },
+                                            "subgroup": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headersToAppend": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "headersToRemove": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ignoreErrorOnParse": {
+                                        "type": "boolean"
+                                      },
+                                      "mergeExtractorsToBody": {
+                                        "type": "object"
+                                      },
+                                      "parseBodyBehavior": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "passthrough": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "xsltTransformation": {
+                                    "properties": {
+                                      "nonXmlTransform": {
+                                        "type": "boolean"
+                                      },
+                                      "setContentType": {
+                                        "type": "string"
+                                      },
+                                      "xslt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "responseTransforms": {
+                          "items": {
+                            "properties": {
+                              "matchers": {
+                                "items": {
+                                  "properties": {
+                                    "invertMatch": {
+                                      "type": "boolean"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "boolean"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "responseCodeDetails": {
+                                "type": "string"
+                              },
+                              "responseTransformation": {
+                                "properties": {
+                                  "headerBodyTransform": {
+                                    "properties": {
+                                      "addRequestMetadata": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "transformationTemplate": {
+                                    "properties": {
+                                      "advancedTemplates": {
+                                        "type": "boolean"
+                                      },
+                                      "body": {
+                                        "properties": {
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dynamicMetadataValues": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "metadataNamespace": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "extractors": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "body": {
+                                              "maxProperties": 0,
+                                              "type": "object"
+                                            },
+                                            "header": {
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "type": "string"
+                                            },
+                                            "subgroup": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headersToAppend": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "headersToRemove": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ignoreErrorOnParse": {
+                                        "type": "boolean"
+                                      },
+                                      "mergeExtractorsToBody": {
+                                        "type": "object"
+                                      },
+                                      "parseBodyBehavior": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "passthrough": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "xsltTransformation": {
+                                    "properties": {
+                                      "nonXmlTransform": {
+                                        "type": "boolean"
+                                      },
+                                      "setContentType": {
+                                        "type": "string"
+                                      },
+                                      "xslt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "stats": {
+                  "properties": {
+                    "virtualClusters": {
+                      "items": {
+                        "properties": {
+                          "method": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "pattern": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "transformations": {
+                  "properties": {
+                    "clearRouteCache": {
+                      "type": "boolean"
+                    },
+                    "requestTransformation": {
+                      "properties": {
+                        "headerBodyTransform": {
+                          "properties": {
+                            "addRequestMetadata": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "transformationTemplate": {
+                          "properties": {
+                            "advancedTemplates": {
+                              "type": "boolean"
+                            },
+                            "body": {
+                              "properties": {
+                                "text": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "dynamicMetadataValues": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "metadataNamespace": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "extractors": {
+                              "additionalProperties": {
+                                "properties": {
+                                  "body": {
+                                    "maxProperties": 0,
+                                    "type": "object"
+                                  },
+                                  "header": {
+                                    "type": "string"
+                                  },
+                                  "regex": {
+                                    "type": "string"
+                                  },
+                                  "subgroup": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "object"
+                            },
+                            "headers": {
+                              "additionalProperties": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "object"
+                            },
+                            "headersToAppend": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "headersToRemove": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "ignoreErrorOnParse": {
+                              "type": "boolean"
+                            },
+                            "mergeExtractorsToBody": {
+                              "type": "object"
+                            },
+                            "parseBodyBehavior": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "passthrough": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "xsltTransformation": {
+                          "properties": {
+                            "nonXmlTransform": {
+                              "type": "boolean"
+                            },
+                            "setContentType": {
+                              "type": "string"
+                            },
+                            "xslt": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "responseTransformation": {
+                      "properties": {
+                        "headerBodyTransform": {
+                          "properties": {
+                            "addRequestMetadata": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "transformationTemplate": {
+                          "properties": {
+                            "advancedTemplates": {
+                              "type": "boolean"
+                            },
+                            "body": {
+                              "properties": {
+                                "text": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "dynamicMetadataValues": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "metadataNamespace": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "extractors": {
+                              "additionalProperties": {
+                                "properties": {
+                                  "body": {
+                                    "maxProperties": 0,
+                                    "type": "object"
+                                  },
+                                  "header": {
+                                    "type": "string"
+                                  },
+                                  "regex": {
+                                    "type": "string"
+                                  },
+                                  "subgroup": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "object"
+                            },
+                            "headers": {
+                              "additionalProperties": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "object"
+                            },
+                            "headersToAppend": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "headersToRemove": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "ignoreErrorOnParse": {
+                              "type": "boolean"
+                            },
+                            "mergeExtractorsToBody": {
+                              "type": "object"
+                            },
+                            "parseBodyBehavior": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "passthrough": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "xsltTransformation": {
+                          "properties": {
+                            "nonXmlTransform": {
+                              "type": "boolean"
+                            },
+                            "setContentType": {
+                              "type": "string"
+                            },
+                            "xslt": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "waf": {
+                  "properties": {
+                    "auditLogging": {
+                      "properties": {
+                        "action": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "location": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "configMapRuleSets": {
+                      "items": {
+                        "properties": {
+                          "configMapRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "dataMapKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "coreRuleSet": {
+                      "properties": {
+                        "customSettingsFile": {
+                          "type": "string"
+                        },
+                        "customSettingsString": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "customInterventionMessage": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "requestHeadersOnly": {
+                      "type": "boolean"
+                    },
+                    "responseHeadersOnly": {
+                      "type": "boolean"
+                    },
+                    "ruleSets": {
+                      "items": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "files": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ruleStr": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "optionsConfigRefs": {
+              "properties": {
+                "delegateOptions": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "routes": {
+              "items": {
+                "properties": {
+                  "delegateAction": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "ref": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "selector": {
+                        "properties": {
+                          "expressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "namespaces": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "directResponseAction": {
+                    "properties": {
+                      "body": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "graphqlApiRef": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "inheritableMatchers": {
+                    "nullable": true,
+                    "type": "boolean"
+                  },
+                  "inheritablePathMatchers": {
+                    "nullable": true,
+                    "type": "boolean"
+                  },
+                  "matchers": {
+                    "items": {
+                      "properties": {
+                        "caseSensitive": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "exact": {
+                          "type": "string"
+                        },
+                        "headers": {
+                          "items": {
+                            "properties": {
+                              "invertMatch": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "regex": {
+                                "type": "boolean"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "methods": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "prefix": {
+                          "type": "string"
+                        },
+                        "queryParameters": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "regex": {
+                                "type": "boolean"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "regex": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "properties": {
+                      "autoHostRewrite": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "bufferPerRoute": {
+                        "properties": {
+                          "buffer": {
+                            "properties": {
+                              "maxRequestBytes": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "disabled": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cors": {
+                        "properties": {
+                          "allowCredentials": {
+                            "type": "boolean"
+                          },
+                          "allowHeaders": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allowMethods": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allowOrigin": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "allowOriginRegex": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "disableForRoute": {
+                            "type": "boolean"
+                          },
+                          "exposeHeaders": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxAge": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "csrf": {
+                        "properties": {
+                          "additionalOrigins": {
+                            "items": {
+                              "properties": {
+                                "exact": {
+                                  "type": "string"
+                                },
+                                "ignoreCase": {
+                                  "type": "boolean"
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "safeRegex": {
+                                  "properties": {
+                                    "googleRe2": {
+                                      "properties": {
+                                        "maxProgramSize": {
+                                          "maximum": 4294967295,
+                                          "minimum": 0,
+                                          "nullable": true,
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "suffix": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "filterEnabled": {
+                            "properties": {
+                              "defaultValue": {
+                                "properties": {
+                                  "denominator": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "numerator": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "runtimeKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "shadowEnabled": {
+                            "properties": {
+                              "defaultValue": {
+                                "properties": {
+                                  "denominator": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "numerator": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "runtimeKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "dlp": {
+                        "properties": {
+                          "actions": {
+                            "items": {
+                              "properties": {
+                                "actionType": {
+                                  "type": "string",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "customAction": {
+                                  "properties": {
+                                    "maskChar": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "percent": {
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "regex": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "regexActions": {
+                                      "items": {
+                                        "properties": {
+                                          "regex": {
+                                            "type": "string"
+                                          },
+                                          "subgroup": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "keyValueAction": {
+                                  "properties": {
+                                    "keyToMask": {
+                                      "type": "string"
+                                    },
+                                    "maskChar": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "percent": {
+                                      "properties": {
+                                        "value": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "shadow": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "enabledFor": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "envoyMetadata": {
+                        "additionalProperties": {
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "type": "object"
+                      },
+                      "extauth": {
+                        "properties": {
+                          "configRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "customAuth": {
+                            "properties": {
+                              "contextExtensions": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "disable": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "extensions": {
+                        "properties": {
+                          "configs": {
+                            "additionalProperties": {
+                              "type": "object",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "faults": {
+                        "properties": {
+                          "abort": {
+                            "properties": {
+                              "httpStatus": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "percentage": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "delay": {
+                            "properties": {
+                              "fixedDelay": {
+                                "type": "string"
+                              },
+                              "percentage": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "headerManipulation": {
+                        "properties": {
+                          "requestHeadersToAdd": {
+                            "items": {
+                              "properties": {
+                                "append": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "header": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headerSecretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "requestHeadersToRemove": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "responseHeadersToAdd": {
+                            "items": {
+                              "properties": {
+                                "append": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                },
+                                "header": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "responseHeadersToRemove": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hostRewrite": {
+                        "type": "string"
+                      },
+                      "jwt": {
+                        "properties": {
+                          "disable": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "jwtStaged": {
+                        "properties": {
+                          "afterExtAuth": {
+                            "properties": {
+                              "disable": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "beforeExtAuth": {
+                            "properties": {
+                              "disable": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "lbHash": {
+                        "properties": {
+                          "hashPolicies": {
+                            "items": {
+                              "properties": {
+                                "cookie": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "ttl": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "header": {
+                                  "type": "string"
+                                },
+                                "sourceIp": {
+                                  "type": "boolean"
+                                },
+                                "terminal": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxStreamDuration": {
+                        "properties": {
+                          "grpcTimeoutHeaderMax": {
+                            "type": "string"
+                          },
+                          "grpcTimeoutHeaderOffset": {
+                            "type": "string"
+                          },
+                          "maxStreamDuration": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "prefixRewrite": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "rateLimitConfigs": {
+                        "properties": {
+                          "refs": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rateLimitEarlyConfigs": {
+                        "properties": {
+                          "refs": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rateLimitRegularConfigs": {
+                        "properties": {
+                          "refs": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ratelimit": {
+                        "properties": {
+                          "includeVhRateLimits": {
+                            "type": "boolean"
+                          },
+                          "rateLimits": {
+                            "items": {
+                              "properties": {
+                                "actions": {
+                                  "items": {
+                                    "properties": {
+                                      "destinationCluster": {
+                                        "type": "object"
+                                      },
+                                      "genericKey": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "headerValueMatch": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          },
+                                          "expectMatch": {
+                                            "nullable": true,
+                                            "type": "boolean"
+                                          },
+                                          "headers": {
+                                            "items": {
+                                              "properties": {
+                                                "exactMatch": {
+                                                  "type": "string"
+                                                },
+                                                "invertMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "prefixMatch": {
+                                                  "type": "string"
+                                                },
+                                                "presentMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "rangeMatch": {
+                                                  "properties": {
+                                                    "end": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "start": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "regexMatch": {
+                                                  "type": "string"
+                                                },
+                                                "suffixMatch": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "metadata": {
+                                        "properties": {
+                                          "defaultValue": {
+                                            "type": "string"
+                                          },
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "metadataKey": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "path": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "source": {
+                                            "type": "string",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "remoteAddress": {
+                                        "type": "object"
+                                      },
+                                      "requestHeaders": {
+                                        "properties": {
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "headerName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sourceCluster": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "setActions": {
+                                  "items": {
+                                    "properties": {
+                                      "destinationCluster": {
+                                        "type": "object"
+                                      },
+                                      "genericKey": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "headerValueMatch": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          },
+                                          "expectMatch": {
+                                            "nullable": true,
+                                            "type": "boolean"
+                                          },
+                                          "headers": {
+                                            "items": {
+                                              "properties": {
+                                                "exactMatch": {
+                                                  "type": "string"
+                                                },
+                                                "invertMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "prefixMatch": {
+                                                  "type": "string"
+                                                },
+                                                "presentMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "rangeMatch": {
+                                                  "properties": {
+                                                    "end": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "start": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "regexMatch": {
+                                                  "type": "string"
+                                                },
+                                                "suffixMatch": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "metadata": {
+                                        "properties": {
+                                          "defaultValue": {
+                                            "type": "string"
+                                          },
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "metadataKey": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "path": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "source": {
+                                            "type": "string",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "remoteAddress": {
+                                        "type": "object"
+                                      },
+                                      "requestHeaders": {
+                                        "properties": {
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "headerName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sourceCluster": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ratelimitBasic": {
+                        "properties": {
+                          "anonymousLimits": {
+                            "properties": {
+                              "requestsPerUnit": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "unit": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "authorizedLimits": {
+                            "properties": {
+                              "requestsPerUnit": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "unit": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ratelimitEarly": {
+                        "properties": {
+                          "includeVhRateLimits": {
+                            "type": "boolean"
+                          },
+                          "rateLimits": {
+                            "items": {
+                              "properties": {
+                                "actions": {
+                                  "items": {
+                                    "properties": {
+                                      "destinationCluster": {
+                                        "type": "object"
+                                      },
+                                      "genericKey": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "headerValueMatch": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          },
+                                          "expectMatch": {
+                                            "nullable": true,
+                                            "type": "boolean"
+                                          },
+                                          "headers": {
+                                            "items": {
+                                              "properties": {
+                                                "exactMatch": {
+                                                  "type": "string"
+                                                },
+                                                "invertMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "prefixMatch": {
+                                                  "type": "string"
+                                                },
+                                                "presentMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "rangeMatch": {
+                                                  "properties": {
+                                                    "end": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "start": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "regexMatch": {
+                                                  "type": "string"
+                                                },
+                                                "suffixMatch": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "metadata": {
+                                        "properties": {
+                                          "defaultValue": {
+                                            "type": "string"
+                                          },
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "metadataKey": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "path": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "source": {
+                                            "type": "string",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "remoteAddress": {
+                                        "type": "object"
+                                      },
+                                      "requestHeaders": {
+                                        "properties": {
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "headerName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sourceCluster": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "setActions": {
+                                  "items": {
+                                    "properties": {
+                                      "destinationCluster": {
+                                        "type": "object"
+                                      },
+                                      "genericKey": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "headerValueMatch": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          },
+                                          "expectMatch": {
+                                            "nullable": true,
+                                            "type": "boolean"
+                                          },
+                                          "headers": {
+                                            "items": {
+                                              "properties": {
+                                                "exactMatch": {
+                                                  "type": "string"
+                                                },
+                                                "invertMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "prefixMatch": {
+                                                  "type": "string"
+                                                },
+                                                "presentMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "rangeMatch": {
+                                                  "properties": {
+                                                    "end": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "start": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "regexMatch": {
+                                                  "type": "string"
+                                                },
+                                                "suffixMatch": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "metadata": {
+                                        "properties": {
+                                          "defaultValue": {
+                                            "type": "string"
+                                          },
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "metadataKey": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "path": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "source": {
+                                            "type": "string",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "remoteAddress": {
+                                        "type": "object"
+                                      },
+                                      "requestHeaders": {
+                                        "properties": {
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "headerName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sourceCluster": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ratelimitRegular": {
+                        "properties": {
+                          "includeVhRateLimits": {
+                            "type": "boolean"
+                          },
+                          "rateLimits": {
+                            "items": {
+                              "properties": {
+                                "actions": {
+                                  "items": {
+                                    "properties": {
+                                      "destinationCluster": {
+                                        "type": "object"
+                                      },
+                                      "genericKey": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "headerValueMatch": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          },
+                                          "expectMatch": {
+                                            "nullable": true,
+                                            "type": "boolean"
+                                          },
+                                          "headers": {
+                                            "items": {
+                                              "properties": {
+                                                "exactMatch": {
+                                                  "type": "string"
+                                                },
+                                                "invertMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "prefixMatch": {
+                                                  "type": "string"
+                                                },
+                                                "presentMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "rangeMatch": {
+                                                  "properties": {
+                                                    "end": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "start": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "regexMatch": {
+                                                  "type": "string"
+                                                },
+                                                "suffixMatch": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "metadata": {
+                                        "properties": {
+                                          "defaultValue": {
+                                            "type": "string"
+                                          },
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "metadataKey": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "path": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "source": {
+                                            "type": "string",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "remoteAddress": {
+                                        "type": "object"
+                                      },
+                                      "requestHeaders": {
+                                        "properties": {
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "headerName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sourceCluster": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "setActions": {
+                                  "items": {
+                                    "properties": {
+                                      "destinationCluster": {
+                                        "type": "object"
+                                      },
+                                      "genericKey": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "headerValueMatch": {
+                                        "properties": {
+                                          "descriptorValue": {
+                                            "type": "string"
+                                          },
+                                          "expectMatch": {
+                                            "nullable": true,
+                                            "type": "boolean"
+                                          },
+                                          "headers": {
+                                            "items": {
+                                              "properties": {
+                                                "exactMatch": {
+                                                  "type": "string"
+                                                },
+                                                "invertMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "prefixMatch": {
+                                                  "type": "string"
+                                                },
+                                                "presentMatch": {
+                                                  "type": "boolean"
+                                                },
+                                                "rangeMatch": {
+                                                  "properties": {
+                                                    "end": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "start": {
+                                                      "format": "int64",
+                                                      "type": "integer",
+                                                      "x-kubernetes-int-or-string": true
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "regexMatch": {
+                                                  "type": "string"
+                                                },
+                                                "suffixMatch": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "metadata": {
+                                        "properties": {
+                                          "defaultValue": {
+                                            "type": "string"
+                                          },
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "metadataKey": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "path": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "source": {
+                                            "type": "string",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "remoteAddress": {
+                                        "type": "object"
+                                      },
+                                      "requestHeaders": {
+                                        "properties": {
+                                          "descriptorKey": {
+                                            "type": "string"
+                                          },
+                                          "headerName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sourceCluster": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rbac": {
+                        "properties": {
+                          "disable": {
+                            "type": "boolean"
+                          },
+                          "policies": {
+                            "additionalProperties": {
+                              "properties": {
+                                "nestedClaimDelimiter": {
+                                  "type": "string"
+                                },
+                                "permissions": {
+                                  "properties": {
+                                    "methods": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "pathPrefix": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "principals": {
+                                  "items": {
+                                    "properties": {
+                                      "jwtPrincipal": {
+                                        "properties": {
+                                          "claims": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "matcher": {
+                                            "type": "string",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "provider": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "regexRewrite": {
+                        "properties": {
+                          "pattern": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "substitution": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "retries": {
+                        "properties": {
+                          "numRetries": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "perTryTimeout": {
+                            "type": "string"
+                          },
+                          "retryBackOff": {
+                            "properties": {
+                              "baseInterval": {
+                                "type": "string"
+                              },
+                              "maxInterval": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "retryOn": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "shadowing": {
+                        "properties": {
+                          "percentage": {
+                            "type": "number"
+                          },
+                          "upstream": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stagedTransformations": {
+                        "properties": {
+                          "early": {
+                            "properties": {
+                              "requestTransforms": {
+                                "items": {
+                                  "properties": {
+                                    "clearRouteCache": {
+                                      "type": "boolean"
+                                    },
+                                    "matcher": {
+                                      "properties": {
+                                        "caseSensitive": {
+                                          "nullable": true,
+                                          "type": "boolean"
+                                        },
+                                        "exact": {
+                                          "type": "string"
+                                        },
+                                        "headers": {
+                                          "items": {
+                                            "properties": {
+                                              "invertMatch": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "boolean"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "methods": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "queryParameters": {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "boolean"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "requestTransformation": {
+                                      "properties": {
+                                        "headerBodyTransform": {
+                                          "properties": {
+                                            "addRequestMetadata": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "transformationTemplate": {
+                                          "properties": {
+                                            "advancedTemplates": {
+                                              "type": "boolean"
+                                            },
+                                            "body": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "dynamicMetadataValues": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "metadataNamespace": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "extractors": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "body": {
+                                                    "maxProperties": 0,
+                                                    "type": "object"
+                                                  },
+                                                  "header": {
+                                                    "type": "string"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  },
+                                                  "subgroup": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headersToAppend": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "headersToRemove": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreErrorOnParse": {
+                                              "type": "boolean"
+                                            },
+                                            "mergeExtractorsToBody": {
+                                              "type": "object"
+                                            },
+                                            "parseBodyBehavior": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "passthrough": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "xsltTransformation": {
+                                          "properties": {
+                                            "nonXmlTransform": {
+                                              "type": "boolean"
+                                            },
+                                            "setContentType": {
+                                              "type": "string"
+                                            },
+                                            "xslt": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "responseTransformation": {
+                                      "properties": {
+                                        "headerBodyTransform": {
+                                          "properties": {
+                                            "addRequestMetadata": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "transformationTemplate": {
+                                          "properties": {
+                                            "advancedTemplates": {
+                                              "type": "boolean"
+                                            },
+                                            "body": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "dynamicMetadataValues": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "metadataNamespace": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "extractors": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "body": {
+                                                    "maxProperties": 0,
+                                                    "type": "object"
+                                                  },
+                                                  "header": {
+                                                    "type": "string"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  },
+                                                  "subgroup": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headersToAppend": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "headersToRemove": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreErrorOnParse": {
+                                              "type": "boolean"
+                                            },
+                                            "mergeExtractorsToBody": {
+                                              "type": "object"
+                                            },
+                                            "parseBodyBehavior": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "passthrough": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "xsltTransformation": {
+                                          "properties": {
+                                            "nonXmlTransform": {
+                                              "type": "boolean"
+                                            },
+                                            "setContentType": {
+                                              "type": "string"
+                                            },
+                                            "xslt": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "responseTransforms": {
+                                "items": {
+                                  "properties": {
+                                    "matchers": {
+                                      "items": {
+                                        "properties": {
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "responseCodeDetails": {
+                                      "type": "string"
+                                    },
+                                    "responseTransformation": {
+                                      "properties": {
+                                        "headerBodyTransform": {
+                                          "properties": {
+                                            "addRequestMetadata": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "transformationTemplate": {
+                                          "properties": {
+                                            "advancedTemplates": {
+                                              "type": "boolean"
+                                            },
+                                            "body": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "dynamicMetadataValues": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "metadataNamespace": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "extractors": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "body": {
+                                                    "maxProperties": 0,
+                                                    "type": "object"
+                                                  },
+                                                  "header": {
+                                                    "type": "string"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  },
+                                                  "subgroup": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headersToAppend": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "headersToRemove": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreErrorOnParse": {
+                                              "type": "boolean"
+                                            },
+                                            "mergeExtractorsToBody": {
+                                              "type": "object"
+                                            },
+                                            "parseBodyBehavior": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "passthrough": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "xsltTransformation": {
+                                          "properties": {
+                                            "nonXmlTransform": {
+                                              "type": "boolean"
+                                            },
+                                            "setContentType": {
+                                              "type": "string"
+                                            },
+                                            "xslt": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "inheritTransformation": {
+                            "type": "boolean"
+                          },
+                          "regular": {
+                            "properties": {
+                              "requestTransforms": {
+                                "items": {
+                                  "properties": {
+                                    "clearRouteCache": {
+                                      "type": "boolean"
+                                    },
+                                    "matcher": {
+                                      "properties": {
+                                        "caseSensitive": {
+                                          "nullable": true,
+                                          "type": "boolean"
+                                        },
+                                        "exact": {
+                                          "type": "string"
+                                        },
+                                        "headers": {
+                                          "items": {
+                                            "properties": {
+                                              "invertMatch": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "boolean"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "methods": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "queryParameters": {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "boolean"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "requestTransformation": {
+                                      "properties": {
+                                        "headerBodyTransform": {
+                                          "properties": {
+                                            "addRequestMetadata": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "transformationTemplate": {
+                                          "properties": {
+                                            "advancedTemplates": {
+                                              "type": "boolean"
+                                            },
+                                            "body": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "dynamicMetadataValues": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "metadataNamespace": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "extractors": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "body": {
+                                                    "maxProperties": 0,
+                                                    "type": "object"
+                                                  },
+                                                  "header": {
+                                                    "type": "string"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  },
+                                                  "subgroup": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headersToAppend": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "headersToRemove": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreErrorOnParse": {
+                                              "type": "boolean"
+                                            },
+                                            "mergeExtractorsToBody": {
+                                              "type": "object"
+                                            },
+                                            "parseBodyBehavior": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "passthrough": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "xsltTransformation": {
+                                          "properties": {
+                                            "nonXmlTransform": {
+                                              "type": "boolean"
+                                            },
+                                            "setContentType": {
+                                              "type": "string"
+                                            },
+                                            "xslt": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "responseTransformation": {
+                                      "properties": {
+                                        "headerBodyTransform": {
+                                          "properties": {
+                                            "addRequestMetadata": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "transformationTemplate": {
+                                          "properties": {
+                                            "advancedTemplates": {
+                                              "type": "boolean"
+                                            },
+                                            "body": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "dynamicMetadataValues": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "metadataNamespace": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "extractors": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "body": {
+                                                    "maxProperties": 0,
+                                                    "type": "object"
+                                                  },
+                                                  "header": {
+                                                    "type": "string"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  },
+                                                  "subgroup": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headersToAppend": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "headersToRemove": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreErrorOnParse": {
+                                              "type": "boolean"
+                                            },
+                                            "mergeExtractorsToBody": {
+                                              "type": "object"
+                                            },
+                                            "parseBodyBehavior": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "passthrough": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "xsltTransformation": {
+                                          "properties": {
+                                            "nonXmlTransform": {
+                                              "type": "boolean"
+                                            },
+                                            "setContentType": {
+                                              "type": "string"
+                                            },
+                                            "xslt": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "responseTransforms": {
+                                "items": {
+                                  "properties": {
+                                    "matchers": {
+                                      "items": {
+                                        "properties": {
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "responseCodeDetails": {
+                                      "type": "string"
+                                    },
+                                    "responseTransformation": {
+                                      "properties": {
+                                        "headerBodyTransform": {
+                                          "properties": {
+                                            "addRequestMetadata": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "transformationTemplate": {
+                                          "properties": {
+                                            "advancedTemplates": {
+                                              "type": "boolean"
+                                            },
+                                            "body": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "dynamicMetadataValues": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "metadataNamespace": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "extractors": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "body": {
+                                                    "maxProperties": 0,
+                                                    "type": "object"
+                                                  },
+                                                  "header": {
+                                                    "type": "string"
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  },
+                                                  "subgroup": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headers": {
+                                              "additionalProperties": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "object"
+                                            },
+                                            "headersToAppend": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "headersToRemove": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreErrorOnParse": {
+                                              "type": "boolean"
+                                            },
+                                            "mergeExtractorsToBody": {
+                                              "type": "object"
+                                            },
+                                            "parseBodyBehavior": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "passthrough": {
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "xsltTransformation": {
+                                          "properties": {
+                                            "nonXmlTransform": {
+                                              "type": "boolean"
+                                            },
+                                            "setContentType": {
+                                              "type": "string"
+                                            },
+                                            "xslt": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "timeout": {
+                        "type": "string"
+                      },
+                      "tracing": {
+                        "properties": {
+                          "propagate": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "routeDescriptor": {
+                            "type": "string"
+                          },
+                          "tracePercentages": {
+                            "properties": {
+                              "clientSamplePercentage": {
+                                "nullable": true,
+                                "type": "number"
+                              },
+                              "overallSamplePercentage": {
+                                "nullable": true,
+                                "type": "number"
+                              },
+                              "randomSamplePercentage": {
+                                "nullable": true,
+                                "type": "number"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "transformations": {
+                        "properties": {
+                          "clearRouteCache": {
+                            "type": "boolean"
+                          },
+                          "requestTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "headerBodyTransform": {
+                                "properties": {
+                                  "addRequestMetadata": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "transformationTemplate": {
+                                "properties": {
+                                  "advancedTemplates": {
+                                    "type": "boolean"
+                                  },
+                                  "body": {
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dynamicMetadataValues": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "metadataNamespace": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "extractors": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "body": {
+                                          "maxProperties": 0,
+                                          "type": "object"
+                                        },
+                                        "header": {
+                                          "type": "string"
+                                        },
+                                        "regex": {
+                                          "type": "string"
+                                        },
+                                        "subgroup": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "object"
+                                  },
+                                  "headersToAppend": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "headersToRemove": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreErrorOnParse": {
+                                    "type": "boolean"
+                                  },
+                                  "mergeExtractorsToBody": {
+                                    "type": "object"
+                                  },
+                                  "parseBodyBehavior": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "passthrough": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "xsltTransformation": {
+                                "properties": {
+                                  "nonXmlTransform": {
+                                    "type": "boolean"
+                                  },
+                                  "setContentType": {
+                                    "type": "string"
+                                  },
+                                  "xslt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "upgrades": {
+                        "items": {
+                          "properties": {
+                            "websocket": {
+                              "properties": {
+                                "enabled": {
+                                  "nullable": true,
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "waf": {
+                        "properties": {
+                          "auditLogging": {
+                            "properties": {
+                              "action": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "location": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "configMapRuleSets": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "dataMapKeys": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "coreRuleSet": {
+                            "properties": {
+                              "customSettingsFile": {
+                                "type": "string"
+                              },
+                              "customSettingsString": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "customInterventionMessage": {
+                            "type": "string"
+                          },
+                          "disabled": {
+                            "type": "boolean"
+                          },
+                          "requestHeadersOnly": {
+                            "type": "boolean"
+                          },
+                          "responseHeadersOnly": {
+                            "type": "boolean"
+                          },
+                          "ruleSets": {
+                            "items": {
+                              "properties": {
+                                "directory": {
+                                  "type": "string"
+                                },
+                                "files": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "ruleStr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "optionsConfigRefs": {
+                    "properties": {
+                      "delegateOptions": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "redirectAction": {
+                    "properties": {
+                      "hostRedirect": {
+                        "type": "string"
+                      },
+                      "httpsRedirect": {
+                        "type": "boolean"
+                      },
+                      "pathRedirect": {
+                        "type": "string"
+                      },
+                      "prefixRewrite": {
+                        "type": "string"
+                      },
+                      "regexRewrite": {
+                        "properties": {
+                          "pattern": {
+                            "properties": {
+                              "googleRe2": {
+                                "properties": {
+                                  "maxProgramSize": {
+                                    "maximum": 4294967295,
+                                    "minimum": 0,
+                                    "nullable": true,
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "regex": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "substitution": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "responseCode": {
+                        "type": "string",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "stripQuery": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "routeAction": {
+                    "properties": {
+                      "clusterHeader": {
+                        "type": "string"
+                      },
+                      "dynamicForwardProxy": {
+                        "properties": {
+                          "autoHostRewriteHeader": {
+                            "type": "string"
+                          },
+                          "hostRewrite": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "multi": {
+                        "properties": {
+                          "destinations": {
+                            "items": {
+                              "properties": {
+                                "destination": {
+                                  "properties": {
+                                    "consul": {
+                                      "properties": {
+                                        "dataCenters": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "serviceName": {
+                                          "type": "string"
+                                        },
+                                        "tags": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "destinationSpec": {
+                                      "properties": {
+                                        "aws": {
+                                          "properties": {
+                                            "invocationStyle": {
+                                              "type": "string",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "logicalName": {
+                                              "type": "string"
+                                            },
+                                            "requestTransformation": {
+                                              "type": "boolean"
+                                            },
+                                            "responseTransformation": {
+                                              "type": "boolean"
+                                            },
+                                            "unwrapAsAlb": {
+                                              "type": "boolean"
+                                            },
+                                            "unwrapAsApiGateway": {
+                                              "type": "boolean"
+                                            },
+                                            "wrapAsApiGateway": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "azure": {
+                                          "properties": {
+                                            "functionName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "grpc": {
+                                          "properties": {
+                                            "function": {
+                                              "type": "string"
+                                            },
+                                            "package": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "properties": {
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "path": {
+                                                  "nullable": true,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "service": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "rest": {
+                                          "properties": {
+                                            "functionName": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "properties": {
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "path": {
+                                                  "nullable": true,
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "responseTransformation": {
+                                              "properties": {
+                                                "advancedTemplates": {
+                                                  "type": "boolean"
+                                                },
+                                                "body": {
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "dynamicMetadataValues": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "metadataNamespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "extractors": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "body": {
+                                                        "maxProperties": 0,
+                                                        "type": "object"
+                                                      },
+                                                      "header": {
+                                                        "type": "string"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      },
+                                                      "subgroup": {
+                                                        "format": "int32",
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headersToAppend": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "headersToRemove": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "ignoreErrorOnParse": {
+                                                  "type": "boolean"
+                                                },
+                                                "mergeExtractorsToBody": {
+                                                  "type": "object"
+                                                },
+                                                "parseBodyBehavior": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "passthrough": {
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "kube": {
+                                      "properties": {
+                                        "port": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "ref": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "subset": {
+                                      "properties": {
+                                        "values": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "upstream": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "options": {
+                                  "properties": {
+                                    "bufferPerRoute": {
+                                      "properties": {
+                                        "buffer": {
+                                          "properties": {
+                                            "maxRequestBytes": {
+                                              "maximum": 4294967295,
+                                              "minimum": 0,
+                                              "nullable": true,
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "disabled": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "csrf": {
+                                      "properties": {
+                                        "additionalOrigins": {
+                                          "items": {
+                                            "properties": {
+                                              "exact": {
+                                                "type": "string"
+                                              },
+                                              "ignoreCase": {
+                                                "type": "boolean"
+                                              },
+                                              "prefix": {
+                                                "type": "string"
+                                              },
+                                              "safeRegex": {
+                                                "properties": {
+                                                  "googleRe2": {
+                                                    "properties": {
+                                                      "maxProgramSize": {
+                                                        "maximum": 4294967295,
+                                                        "minimum": 0,
+                                                        "nullable": true,
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "regex": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "suffix": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "filterEnabled": {
+                                          "properties": {
+                                            "defaultValue": {
+                                              "properties": {
+                                                "denominator": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "numerator": {
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "runtimeKey": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "shadowEnabled": {
+                                          "properties": {
+                                            "defaultValue": {
+                                              "properties": {
+                                                "denominator": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "numerator": {
+                                                  "format": "int32",
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "runtimeKey": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "extauth": {
+                                      "properties": {
+                                        "configRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "customAuth": {
+                                          "properties": {
+                                            "contextExtensions": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "disable": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "extensions": {
+                                      "properties": {
+                                        "configs": {
+                                          "additionalProperties": {
+                                            "type": "object",
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "headerManipulation": {
+                                      "properties": {
+                                        "requestHeadersToAdd": {
+                                          "items": {
+                                            "properties": {
+                                              "append": {
+                                                "nullable": true,
+                                                "type": "boolean"
+                                              },
+                                              "header": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "headerSecretRef": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "requestHeadersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "responseHeadersToAdd": {
+                                          "items": {
+                                            "properties": {
+                                              "append": {
+                                                "nullable": true,
+                                                "type": "boolean"
+                                              },
+                                              "header": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "responseHeadersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "stagedTransformations": {
+                                      "properties": {
+                                        "early": {
+                                          "properties": {
+                                            "requestTransforms": {
+                                              "items": {
+                                                "properties": {
+                                                  "clearRouteCache": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "matcher": {
+                                                    "properties": {
+                                                      "caseSensitive": {
+                                                        "nullable": true,
+                                                        "type": "boolean"
+                                                      },
+                                                      "exact": {
+                                                        "type": "string"
+                                                      },
+                                                      "headers": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "invertMatch": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "methods": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "prefix": {
+                                                        "type": "string"
+                                                      },
+                                                      "queryParameters": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "requestTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "responseTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "responseTransforms": {
+                                              "items": {
+                                                "properties": {
+                                                  "matchers": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "invertMatch": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "regex": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "responseCodeDetails": {
+                                                    "type": "string"
+                                                  },
+                                                  "responseTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "inheritTransformation": {
+                                          "type": "boolean"
+                                        },
+                                        "regular": {
+                                          "properties": {
+                                            "requestTransforms": {
+                                              "items": {
+                                                "properties": {
+                                                  "clearRouteCache": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "matcher": {
+                                                    "properties": {
+                                                      "caseSensitive": {
+                                                        "nullable": true,
+                                                        "type": "boolean"
+                                                      },
+                                                      "exact": {
+                                                        "type": "string"
+                                                      },
+                                                      "headers": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "invertMatch": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "methods": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "prefix": {
+                                                        "type": "string"
+                                                      },
+                                                      "queryParameters": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "regex": {
+                                                              "type": "boolean"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "requestTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "responseTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "responseTransforms": {
+                                              "items": {
+                                                "properties": {
+                                                  "matchers": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "invertMatch": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "regex": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "responseCodeDetails": {
+                                                    "type": "string"
+                                                  },
+                                                  "responseTransformation": {
+                                                    "properties": {
+                                                      "headerBodyTransform": {
+                                                        "properties": {
+                                                          "addRequestMetadata": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "transformationTemplate": {
+                                                        "properties": {
+                                                          "advancedTemplates": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "body": {
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "dynamicMetadataValues": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "metadataNamespace": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "extractors": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "body": {
+                                                                  "maxProperties": 0,
+                                                                  "type": "object"
+                                                                },
+                                                                "header": {
+                                                                  "type": "string"
+                                                                },
+                                                                "regex": {
+                                                                  "type": "string"
+                                                                },
+                                                                "subgroup": {
+                                                                  "format": "int32",
+                                                                  "type": "integer"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headers": {
+                                                            "additionalProperties": {
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "headersToAppend": {
+                                                            "items": {
+                                                              "properties": {
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "value": {
+                                                                  "properties": {
+                                                                    "text": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "type": "object",
+                                                              "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "headersToRemove": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          "ignoreErrorOnParse": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "mergeExtractorsToBody": {
+                                                            "type": "object"
+                                                          },
+                                                          "parseBodyBehavior": {
+                                                            "type": "string",
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "passthrough": {
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "xsltTransformation": {
+                                                        "properties": {
+                                                          "nonXmlTransform": {
+                                                            "type": "boolean"
+                                                          },
+                                                          "setContentType": {
+                                                            "type": "string"
+                                                          },
+                                                          "xslt": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformations": {
+                                      "properties": {
+                                        "clearRouteCache": {
+                                          "type": "boolean"
+                                        },
+                                        "requestTransformation": {
+                                          "properties": {
+                                            "headerBodyTransform": {
+                                              "properties": {
+                                                "addRequestMetadata": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "transformationTemplate": {
+                                              "properties": {
+                                                "advancedTemplates": {
+                                                  "type": "boolean"
+                                                },
+                                                "body": {
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "dynamicMetadataValues": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "metadataNamespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "extractors": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "body": {
+                                                        "maxProperties": 0,
+                                                        "type": "object"
+                                                      },
+                                                      "header": {
+                                                        "type": "string"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      },
+                                                      "subgroup": {
+                                                        "format": "int32",
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headersToAppend": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "headersToRemove": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "ignoreErrorOnParse": {
+                                                  "type": "boolean"
+                                                },
+                                                "mergeExtractorsToBody": {
+                                                  "type": "object"
+                                                },
+                                                "parseBodyBehavior": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "passthrough": {
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "xsltTransformation": {
+                                              "properties": {
+                                                "nonXmlTransform": {
+                                                  "type": "boolean"
+                                                },
+                                                "setContentType": {
+                                                  "type": "string"
+                                                },
+                                                "xslt": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "responseTransformation": {
+                                          "properties": {
+                                            "headerBodyTransform": {
+                                              "properties": {
+                                                "addRequestMetadata": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "transformationTemplate": {
+                                              "properties": {
+                                                "advancedTemplates": {
+                                                  "type": "boolean"
+                                                },
+                                                "body": {
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "dynamicMetadataValues": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "metadataNamespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "extractors": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "body": {
+                                                        "maxProperties": 0,
+                                                        "type": "object"
+                                                      },
+                                                      "header": {
+                                                        "type": "string"
+                                                      },
+                                                      "regex": {
+                                                        "type": "string"
+                                                      },
+                                                      "subgroup": {
+                                                        "format": "int32",
+                                                        "type": "integer"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headers": {
+                                                  "additionalProperties": {
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "headersToAppend": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "properties": {
+                                                          "text": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "headersToRemove": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "ignoreErrorOnParse": {
+                                                  "type": "boolean"
+                                                },
+                                                "mergeExtractorsToBody": {
+                                                  "type": "object"
+                                                },
+                                                "parseBodyBehavior": {
+                                                  "type": "string",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "passthrough": {
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "xsltTransformation": {
+                                              "properties": {
+                                                "nonXmlTransform": {
+                                                  "type": "boolean"
+                                                },
+                                                "setContentType": {
+                                                  "type": "string"
+                                                },
+                                                "xslt": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "weight": {
+                                  "maximum": 4294967295,
+                                  "minimum": 0,
+                                  "nullable": true,
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "single": {
+                        "properties": {
+                          "consul": {
+                            "properties": {
+                              "dataCenters": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "serviceName": {
+                                "type": "string"
+                              },
+                              "tags": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "destinationSpec": {
+                            "properties": {
+                              "aws": {
+                                "properties": {
+                                  "invocationStyle": {
+                                    "type": "string",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "logicalName": {
+                                    "type": "string"
+                                  },
+                                  "requestTransformation": {
+                                    "type": "boolean"
+                                  },
+                                  "responseTransformation": {
+                                    "type": "boolean"
+                                  },
+                                  "unwrapAsAlb": {
+                                    "type": "boolean"
+                                  },
+                                  "unwrapAsApiGateway": {
+                                    "type": "boolean"
+                                  },
+                                  "wrapAsApiGateway": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azure": {
+                                "properties": {
+                                  "functionName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "function": {
+                                    "type": "string"
+                                  },
+                                  "package": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "properties": {
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "path": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "rest": {
+                                "properties": {
+                                  "functionName": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "properties": {
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "path": {
+                                        "nullable": true,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "responseTransformation": {
+                                    "properties": {
+                                      "advancedTemplates": {
+                                        "type": "boolean"
+                                      },
+                                      "body": {
+                                        "properties": {
+                                          "text": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dynamicMetadataValues": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "metadataNamespace": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "extractors": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "body": {
+                                              "maxProperties": 0,
+                                              "type": "object"
+                                            },
+                                            "header": {
+                                              "type": "string"
+                                            },
+                                            "regex": {
+                                              "type": "string"
+                                            },
+                                            "subgroup": {
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headers": {
+                                        "additionalProperties": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "object"
+                                      },
+                                      "headersToAppend": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "properties": {
+                                                "text": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "headersToRemove": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ignoreErrorOnParse": {
+                                        "type": "boolean"
+                                      },
+                                      "mergeExtractorsToBody": {
+                                        "type": "object"
+                                      },
+                                      "parseBodyBehavior": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "passthrough": {
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "kube": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "ref": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subset": {
+                            "properties": {
+                              "values": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "upstream": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "upstreamGroup": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gloo.solo.io/proxy_v1.json
+++ b/gloo.solo.io/proxy_v1.json
@@ -1,0 +1,412 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "compressedSpec": {
+          "type": "string"
+        },
+        "listeners": {
+          "items": {
+            "properties": {
+              "aggregateListener": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "bindAddress": {
+                "type": "string"
+              },
+              "bindPort": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "httpListener": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "hybridListener": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "metadata": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "metadataStatic": {
+                "properties": {
+                  "sources": {
+                    "items": {
+                      "properties": {
+                        "observedGeneration": {
+                          "format": "int64",
+                          "type": "integer",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "resourceKind": {
+                          "type": "string"
+                        },
+                        "resourceRef": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string"
+              },
+              "options": {
+                "properties": {
+                  "accessLoggingService": {
+                    "properties": {
+                      "accessLog": {
+                        "items": {
+                          "properties": {
+                            "fileSink": {
+                              "properties": {
+                                "jsonFormat": {
+                                  "type": "object",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "stringFormat": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "grpcService": {
+                              "properties": {
+                                "additionalRequestHeadersToLog": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "additionalResponseHeadersToLog": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "additionalResponseTrailersToLog": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "logName": {
+                                  "type": "string"
+                                },
+                                "staticClusterName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "extensions": {
+                    "properties": {
+                      "configs": {
+                        "additionalProperties": {
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "perConnectionBufferLimitBytes": {
+                    "maximum": 4294967295,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "proxyProtocol": {
+                    "properties": {
+                      "allowRequestsWithoutProxyProtocol": {
+                        "type": "boolean"
+                      },
+                      "rules": {
+                        "items": {
+                          "properties": {
+                            "onTlvPresent": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "metadataNamespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "tlvType": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "socketOptions": {
+                    "items": {
+                      "properties": {
+                        "bufValue": {
+                          "format": "byte",
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "intValue": {
+                          "format": "int64",
+                          "type": "integer",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "level": {
+                          "format": "int64",
+                          "type": "integer",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "name": {
+                          "format": "int64",
+                          "type": "integer",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "state": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "routeOptions": {
+                "properties": {
+                  "maxDirectResponseBodySizeBytes": {
+                    "maximum": 4294967295,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "sslConfigurations": {
+                "items": {
+                  "properties": {
+                    "alpnProtocols": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "disableTlsSessionResumption": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "oneWayTls": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "parameters": {
+                      "properties": {
+                        "cipherSuites": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "ecdhCurves": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "maximumProtocolVersion": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "minimumProtocolVersion": {
+                          "type": "string",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sds": {
+                      "properties": {
+                        "callCredentials": {
+                          "properties": {
+                            "fileCredentialSource": {
+                              "properties": {
+                                "header": {
+                                  "type": "string"
+                                },
+                                "tokenFileName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "certificatesSecretName": {
+                          "type": "string"
+                        },
+                        "clusterName": {
+                          "type": "string"
+                        },
+                        "targetUri": {
+                          "type": "string"
+                        },
+                        "validationContextName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sniDomains": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "sslFiles": {
+                      "properties": {
+                        "rootCa": {
+                          "type": "string"
+                        },
+                        "tlsCert": {
+                          "type": "string"
+                        },
+                        "tlsKey": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transportSocketConnectTimeout": {
+                      "type": "string"
+                    },
+                    "verifySubjectAltName": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "tcpListener": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "useProxyProto": {
+                "nullable": true,
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gloo.solo.io/settings_v1.json
+++ b/gloo.solo.io/settings_v1.json
@@ -1,0 +1,1079 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "cachingServer": {
+          "properties": {
+            "allowedVaryHeaders": {
+              "items": {
+                "properties": {
+                  "exact": {
+                    "type": "string"
+                  },
+                  "ignoreCase": {
+                    "type": "boolean"
+                  },
+                  "prefix": {
+                    "type": "string"
+                  },
+                  "safeRegex": {
+                    "properties": {
+                      "googleRe2": {
+                        "properties": {
+                          "maxProgramSize": {
+                            "maximum": 4294967295,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "regex": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "suffix": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "cachingServiceRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "maxPayloadSize": {
+              "properties": {
+                "value": {
+                  "format": "int64",
+                  "type": "integer",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "timeout": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "consoleOptions": {
+          "properties": {
+            "apiExplorerEnabled": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "readOnly": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "consul": {
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "caFile": {
+              "type": "string"
+            },
+            "caPath": {
+              "type": "string"
+            },
+            "certFile": {
+              "type": "string"
+            },
+            "datacenter": {
+              "type": "string"
+            },
+            "dnsAddress": {
+              "type": "string"
+            },
+            "dnsPollingInterval": {
+              "type": "string"
+            },
+            "httpAddress": {
+              "type": "string"
+            },
+            "insecureSkipVerify": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "keyFile": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "serviceDiscovery": {
+              "properties": {
+                "dataCenters": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "token": {
+              "type": "string"
+            },
+            "username": {
+              "type": "string"
+            },
+            "waitTime": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "consulDiscovery": {
+          "properties": {
+            "consistencyMode": {
+              "type": "string",
+              "x-kubernetes-int-or-string": true
+            },
+            "edsBlockingQueries": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "queryOptions": {
+              "properties": {
+                "useCache": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rootCa": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceTagsAllowlist": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "splitTlsServices": {
+              "type": "boolean"
+            },
+            "tlsTagName": {
+              "type": "string"
+            },
+            "useTlsTagging": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "consulKvArtifactSource": {
+          "properties": {
+            "rootKey": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "consulKvSource": {
+          "properties": {
+            "rootKey": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "devMode": {
+          "type": "boolean"
+        },
+        "directoryArtifactSource": {
+          "properties": {
+            "directory": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "directoryConfigSource": {
+          "properties": {
+            "directory": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "directorySecretSource": {
+          "properties": {
+            "directory": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "discovery": {
+          "properties": {
+            "fdsMode": {
+              "type": "string",
+              "x-kubernetes-int-or-string": true
+            },
+            "fdsOptions": {
+              "properties": {
+                "graphqlEnabled": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "udsOptions": {
+              "properties": {
+                "enabled": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "watchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "discoveryNamespace": {
+          "type": "string"
+        },
+        "extauth": {
+          "properties": {
+            "clearRouteCache": {
+              "type": "boolean"
+            },
+            "extauthzServerRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "failureModeAllow": {
+              "type": "boolean"
+            },
+            "grpcService": {
+              "properties": {
+                "authority": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpService": {
+              "properties": {
+                "pathPrefix": {
+                  "type": "string"
+                },
+                "request": {
+                  "properties": {
+                    "allowedHeaders": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "allowedHeadersRegex": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "headersToAdd": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "response": {
+                  "properties": {
+                    "allowedClientHeaders": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "allowedUpstreamHeaders": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "allowedUpstreamHeadersToAppend": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "requestBody": {
+              "properties": {
+                "allowPartialMessage": {
+                  "type": "boolean"
+                },
+                "maxRequestBytes": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "packAsBytes": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "requestTimeout": {
+              "type": "string"
+            },
+            "statPrefix": {
+              "type": "string"
+            },
+            "statusOnError": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "transportApiVersion": {
+              "type": "string",
+              "x-kubernetes-int-or-string": true
+            },
+            "userIdHeader": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "extensions": {
+          "properties": {
+            "configs": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gateway": {
+          "properties": {
+            "alwaysSortRouteTableRoutes": {
+              "type": "boolean"
+            },
+            "compressedProxySpec": {
+              "type": "boolean"
+            },
+            "enableGatewayController": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "isolateVirtualHostsBySslConfig": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "persistProxySpec": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "readGatewaysFromAllNamespaces": {
+              "type": "boolean"
+            },
+            "validation": {
+              "properties": {
+                "allowWarnings": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "alwaysAccept": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "disableTransformationValidation": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "ignoreGlooValidationFailure": {
+                  "type": "boolean"
+                },
+                "proxyValidationServerAddr": {
+                  "type": "string"
+                },
+                "serverEnabled": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "validationServerGrpcMaxSizeBytes": {
+                  "maximum": 2147483647,
+                  "minimum": -2147483648,
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "validationWebhookTlsCert": {
+                  "type": "string"
+                },
+                "validationWebhookTlsKey": {
+                  "type": "string"
+                },
+                "warnRouteShortCircuiting": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "validationServerAddr": {
+              "type": "string"
+            },
+            "virtualServiceOptions": {
+              "properties": {
+                "oneWayTls": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gloo": {
+          "properties": {
+            "awsOptions": {
+              "properties": {
+                "credentialRefreshDelay": {
+                  "type": "string"
+                },
+                "enableCredentialsDiscovey": {
+                  "type": "boolean"
+                },
+                "fallbackToFirstFunction": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "propagateOriginalRouting": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "serviceAccountCredentials": {
+                  "properties": {
+                    "cluster": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "type": "string"
+                    },
+                    "uri": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "circuitBreakers": {
+              "properties": {
+                "maxConnections": {
+                  "maximum": 4294967295,
+                  "minimum": 0,
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "maxPendingRequests": {
+                  "maximum": 4294967295,
+                  "minimum": 0,
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "maxRequests": {
+                  "maximum": 4294967295,
+                  "minimum": 0,
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "maxRetries": {
+                  "maximum": 4294967295,
+                  "minimum": 0,
+                  "nullable": true,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "disableGrpcWeb": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "disableKubernetesDestinations": {
+              "type": "boolean"
+            },
+            "disableProxyGarbageCollection": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "enableRestEds": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "endpointsWarmingTimeout": {
+              "type": "string"
+            },
+            "failoverUpstreamDnsPollingInterval": {
+              "type": "string"
+            },
+            "invalidConfigPolicy": {
+              "properties": {
+                "invalidRouteResponseBody": {
+                  "type": "string"
+                },
+                "invalidRouteResponseCode": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "replaceInvalidRoutes": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "proxyDebugBindAddr": {
+              "type": "string"
+            },
+            "regexMaxProgramSize": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "removeUnusedFilters": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "restXdsBindAddr": {
+              "type": "string"
+            },
+            "validationBindAddr": {
+              "type": "string"
+            },
+            "xdsBindAddr": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "graphqlOptions": {
+          "properties": {
+            "schemaChangeValidationOptions": {
+              "properties": {
+                "processingRules": {
+                  "items": {
+                    "type": "string",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "array"
+                },
+                "rejectBreakingChanges": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "knative": {
+          "properties": {
+            "clusterIngressProxyAddress": {
+              "type": "string"
+            },
+            "knativeExternalProxyAddress": {
+              "type": "string"
+            },
+            "knativeInternalProxyAddress": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kubernetes": {
+          "properties": {
+            "rateLimits": {
+              "properties": {
+                "QPS": {
+                  "type": "number"
+                },
+                "burst": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kubernetesArtifactSource": {
+          "type": "object"
+        },
+        "kubernetesConfigSource": {
+          "type": "object"
+        },
+        "kubernetesSecretSource": {
+          "type": "object"
+        },
+        "linkerd": {
+          "type": "boolean"
+        },
+        "namedExtauth": {
+          "additionalProperties": {
+            "properties": {
+              "clearRouteCache": {
+                "type": "boolean"
+              },
+              "extauthzServerRef": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "failureModeAllow": {
+                "type": "boolean"
+              },
+              "grpcService": {
+                "properties": {
+                  "authority": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "httpService": {
+                "properties": {
+                  "pathPrefix": {
+                    "type": "string"
+                  },
+                  "request": {
+                    "properties": {
+                      "allowedHeaders": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "allowedHeadersRegex": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "headersToAdd": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "response": {
+                    "properties": {
+                      "allowedClientHeaders": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "allowedUpstreamHeaders": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "allowedUpstreamHeadersToAppend": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "requestBody": {
+                "properties": {
+                  "allowPartialMessage": {
+                    "type": "boolean"
+                  },
+                  "maxRequestBytes": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "packAsBytes": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "requestTimeout": {
+                "type": "string"
+              },
+              "statPrefix": {
+                "type": "string"
+              },
+              "statusOnError": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "transportApiVersion": {
+                "type": "string",
+                "x-kubernetes-int-or-string": true
+              },
+              "userIdHeader": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "object"
+        },
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "observabilityOptions": {
+          "properties": {
+            "configStatusMetricLabels": {
+              "additionalProperties": {
+                "properties": {
+                  "labelToPath": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "object"
+            },
+            "grafanaIntegration": {
+              "properties": {
+                "defaultDashboardFolderId": {
+                  "maximum": 4294967295,
+                  "minimum": 0,
+                  "nullable": true,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ratelimit": {
+          "properties": {
+            "descriptors": {
+              "items": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "array"
+            },
+            "setDescriptors": {
+              "items": {
+                "properties": {
+                  "alwaysApply": {
+                    "type": "boolean"
+                  },
+                  "rateLimit": {
+                    "properties": {
+                      "requestsPerUnit": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "unit": {
+                        "type": "string",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "simpleDescriptors": {
+                    "items": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ratelimitServer": {
+          "properties": {
+            "denyOnFail": {
+              "type": "boolean"
+            },
+            "enableXRatelimitHeaders": {
+              "type": "boolean"
+            },
+            "rateLimitBeforeAuth": {
+              "type": "boolean"
+            },
+            "ratelimitServerRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "requestTimeout": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "rbac": {
+          "properties": {
+            "requireRbac": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "refreshRate": {
+          "type": "string"
+        },
+        "upstreamOptions": {
+          "properties": {
+            "globalAnnotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "sslParameters": {
+              "properties": {
+                "cipherSuites": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ecdhCurves": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maximumProtocolVersion": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "minimumProtocolVersion": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "vaultSecretSource": {
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "caCert": {
+              "type": "string"
+            },
+            "caPath": {
+              "type": "string"
+            },
+            "clientCert": {
+              "type": "string"
+            },
+            "clientKey": {
+              "type": "string"
+            },
+            "insecure": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "pathPrefix": {
+              "type": "string"
+            },
+            "rootKey": {
+              "type": "string"
+            },
+            "tlsServerName": {
+              "type": "string"
+            },
+            "token": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "watchNamespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gloo.solo.io/upstream_v1.json
+++ b/gloo.solo.io/upstream_v1.json
@@ -1,0 +1,2091 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "aws": {
+          "properties": {
+            "awsAccountId": {
+              "type": "string"
+            },
+            "destinationOverrides": {
+              "properties": {
+                "invocationStyle": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "logicalName": {
+                  "type": "string"
+                },
+                "requestTransformation": {
+                  "type": "boolean"
+                },
+                "responseTransformation": {
+                  "type": "boolean"
+                },
+                "unwrapAsAlb": {
+                  "type": "boolean"
+                },
+                "unwrapAsApiGateway": {
+                  "type": "boolean"
+                },
+                "wrapAsApiGateway": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "disableRoleChaining": {
+              "type": "boolean"
+            },
+            "lambdaFunctions": {
+              "items": {
+                "properties": {
+                  "lambdaFunctionName": {
+                    "type": "string"
+                  },
+                  "logicalName": {
+                    "type": "string"
+                  },
+                  "qualifier": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "region": {
+              "type": "string"
+            },
+            "roleArn": {
+              "type": "string"
+            },
+            "secretRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "awsEc2": {
+          "properties": {
+            "filters": {
+              "items": {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "kvPair": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "port": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "publicIp": {
+              "type": "boolean"
+            },
+            "region": {
+              "type": "string"
+            },
+            "roleArn": {
+              "type": "string"
+            },
+            "secretRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "azure": {
+          "properties": {
+            "functionAppName": {
+              "type": "string"
+            },
+            "functions": {
+              "items": {
+                "properties": {
+                  "authLevel": {
+                    "type": "string",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "functionName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "secretRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "circuitBreakers": {
+          "properties": {
+            "maxConnections": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "maxPendingRequests": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "maxRequests": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "maxRetries": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "connectionConfig": {
+          "properties": {
+            "commonHttpProtocolOptions": {
+              "properties": {
+                "headersWithUnderscoresAction": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "idleTimeout": {
+                  "type": "string"
+                },
+                "maxHeadersCount": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxStreamDuration": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "connectTimeout": {
+              "type": "string"
+            },
+            "http1ProtocolOptions": {
+              "properties": {
+                "enableTrailers": {
+                  "type": "boolean"
+                },
+                "overrideStreamErrorOnInvalidHttpMessage": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "preserveCaseHeaderKeyFormat": {
+                  "type": "boolean"
+                },
+                "properCaseHeaderKeyFormat": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "maxRequestsPerConnection": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "perConnectionBufferLimitBytes": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "tcpKeepalive": {
+              "properties": {
+                "keepaliveInterval": {
+                  "type": "string"
+                },
+                "keepaliveProbes": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveTime": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "consul": {
+          "properties": {
+            "connectEnabled": {
+              "type": "boolean"
+            },
+            "consistencyMode": {
+              "type": "string",
+              "x-kubernetes-int-or-string": true
+            },
+            "dataCenters": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "instanceBlacklistTags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "instanceTags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "queryOptions": {
+              "properties": {
+                "useCache": {
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceName": {
+              "type": "string"
+            },
+            "serviceSpec": {
+              "properties": {
+                "grpc": {
+                  "properties": {
+                    "descriptors": {
+                      "format": "byte",
+                      "type": "string"
+                    },
+                    "grpcServices": {
+                      "items": {
+                        "properties": {
+                          "functionNames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "packageName": {
+                            "type": "string"
+                          },
+                          "serviceName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rest": {
+                  "properties": {
+                    "swaggerInfo": {
+                      "properties": {
+                        "inline": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transformations": {
+                      "additionalProperties": {
+                        "properties": {
+                          "advancedTemplates": {
+                            "type": "boolean"
+                          },
+                          "body": {
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "dynamicMetadataValues": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "metadataNamespace": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "extractors": {
+                            "additionalProperties": {
+                              "properties": {
+                                "body": {
+                                  "maxProperties": 0,
+                                  "type": "object"
+                                },
+                                "header": {
+                                  "type": "string"
+                                },
+                                "regex": {
+                                  "type": "string"
+                                },
+                                "subgroup": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          },
+                          "headers": {
+                            "additionalProperties": {
+                              "properties": {
+                                "text": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          },
+                          "headersToAppend": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "headersToRemove": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ignoreErrorOnParse": {
+                            "type": "boolean"
+                          },
+                          "mergeExtractorsToBody": {
+                            "type": "object"
+                          },
+                          "parseBodyBehavior": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "passthrough": {
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceTags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "subsetTags": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "discoveryMetadata": {
+          "properties": {
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failover": {
+          "properties": {
+            "policy": {
+              "properties": {
+                "overprovisioningFactor": {
+                  "maximum": 4294967295,
+                  "minimum": 0,
+                  "nullable": true,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prioritizedLocalities": {
+              "items": {
+                "properties": {
+                  "localityEndpoints": {
+                    "items": {
+                      "properties": {
+                        "lbEndpoints": {
+                          "items": {
+                            "properties": {
+                              "address": {
+                                "type": "string"
+                              },
+                              "healthCheckConfig": {
+                                "properties": {
+                                  "hostname": {
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "portValue": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "loadBalancingWeight": {
+                                "maximum": 4294967295,
+                                "minimum": 0,
+                                "nullable": true,
+                                "type": "integer"
+                              },
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "upstreamSslConfig": {
+                                "properties": {
+                                  "allowRenegotiation": {
+                                    "nullable": true,
+                                    "type": "boolean"
+                                  },
+                                  "alpnProtocols": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "parameters": {
+                                    "properties": {
+                                      "cipherSuites": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "ecdhCurves": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "maximumProtocolVersion": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "minimumProtocolVersion": {
+                                        "type": "string",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sds": {
+                                    "properties": {
+                                      "callCredentials": {
+                                        "properties": {
+                                          "fileCredentialSource": {
+                                            "properties": {
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "tokenFileName": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "certificatesSecretName": {
+                                        "type": "string"
+                                      },
+                                      "clusterName": {
+                                        "type": "string"
+                                      },
+                                      "targetUri": {
+                                        "type": "string"
+                                      },
+                                      "validationContextName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sni": {
+                                    "type": "string"
+                                  },
+                                  "sslFiles": {
+                                    "properties": {
+                                      "rootCa": {
+                                        "type": "string"
+                                      },
+                                      "tlsCert": {
+                                        "type": "string"
+                                      },
+                                      "tlsKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "verifySubjectAltName": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "loadBalancingWeight": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "locality": {
+                          "properties": {
+                            "region": {
+                              "type": "string"
+                            },
+                            "subZone": {
+                              "type": "string"
+                            },
+                            "zone": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "healthChecks": {
+          "items": {
+            "properties": {
+              "alwaysLogHealthCheckFailures": {
+                "type": "boolean"
+              },
+              "customHealthCheck": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "typedConfig": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "eventLogPath": {
+                "type": "string"
+              },
+              "grpcHealthCheck": {
+                "properties": {
+                  "authority": {
+                    "type": "string"
+                  },
+                  "serviceName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "healthyEdgeInterval": {
+                "type": "string"
+              },
+              "healthyThreshold": {
+                "maximum": 4294967295,
+                "minimum": 0,
+                "nullable": true,
+                "type": "integer"
+              },
+              "httpHealthCheck": {
+                "properties": {
+                  "expectedStatuses": {
+                    "items": {
+                      "properties": {
+                        "end": {
+                          "format": "int64",
+                          "type": "integer",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "start": {
+                          "format": "int64",
+                          "type": "integer",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "host": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "requestHeadersToAdd": {
+                    "items": {
+                      "properties": {
+                        "append": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "header": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "headerSecretRef": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "requestHeadersToRemove": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "responseAssertions": {
+                    "properties": {
+                      "noMatchHealth": {
+                        "type": "string",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "responseMatchers": {
+                        "items": {
+                          "properties": {
+                            "matchHealth": {
+                              "type": "string",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "responseMatch": {
+                              "properties": {
+                                "body": {
+                                  "maxProperties": 0,
+                                  "type": "object"
+                                },
+                                "header": {
+                                  "type": "string"
+                                },
+                                "ignoreErrorOnParse": {
+                                  "type": "boolean"
+                                },
+                                "jsonKey": {
+                                  "properties": {
+                                    "path": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "regex": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "serviceName": {
+                    "type": "string"
+                  },
+                  "useHttp2": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "initialJitter": {
+                "type": "string"
+              },
+              "interval": {
+                "type": "string"
+              },
+              "intervalJitter": {
+                "type": "string"
+              },
+              "intervalJitterPercent": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "noTrafficInterval": {
+                "type": "string"
+              },
+              "reuseConnection": {
+                "nullable": true,
+                "type": "boolean"
+              },
+              "tcpHealthCheck": {
+                "properties": {
+                  "receive": {
+                    "items": {
+                      "properties": {
+                        "text": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "send": {
+                    "properties": {
+                      "text": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "timeout": {
+                "type": "string"
+              },
+              "unhealthyEdgeInterval": {
+                "type": "string"
+              },
+              "unhealthyInterval": {
+                "type": "string"
+              },
+              "unhealthyThreshold": {
+                "maximum": 4294967295,
+                "minimum": 0,
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "httpConnectHeaders": {
+          "items": {
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "httpConnectSslConfig": {
+          "properties": {
+            "allowRenegotiation": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "alpnProtocols": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "parameters": {
+              "properties": {
+                "cipherSuites": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ecdhCurves": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maximumProtocolVersion": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "minimumProtocolVersion": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sds": {
+              "properties": {
+                "callCredentials": {
+                  "properties": {
+                    "fileCredentialSource": {
+                      "properties": {
+                        "header": {
+                          "type": "string"
+                        },
+                        "tokenFileName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "certificatesSecretName": {
+                  "type": "string"
+                },
+                "clusterName": {
+                  "type": "string"
+                },
+                "targetUri": {
+                  "type": "string"
+                },
+                "validationContextName": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sni": {
+              "type": "string"
+            },
+            "sslFiles": {
+              "properties": {
+                "rootCa": {
+                  "type": "string"
+                },
+                "tlsCert": {
+                  "type": "string"
+                },
+                "tlsKey": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "verifySubjectAltName": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "httpProxyHostname": {
+          "nullable": true,
+          "type": "string"
+        },
+        "ignoreHealthOnHostRemoval": {
+          "nullable": true,
+          "type": "boolean"
+        },
+        "initialConnectionWindowSize": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "nullable": true,
+          "type": "integer"
+        },
+        "initialStreamWindowSize": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "nullable": true,
+          "type": "integer"
+        },
+        "kube": {
+          "properties": {
+            "selector": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "serviceName": {
+              "type": "string"
+            },
+            "serviceNamespace": {
+              "type": "string"
+            },
+            "servicePort": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "serviceSpec": {
+              "properties": {
+                "grpc": {
+                  "properties": {
+                    "descriptors": {
+                      "format": "byte",
+                      "type": "string"
+                    },
+                    "grpcServices": {
+                      "items": {
+                        "properties": {
+                          "functionNames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "packageName": {
+                            "type": "string"
+                          },
+                          "serviceName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rest": {
+                  "properties": {
+                    "swaggerInfo": {
+                      "properties": {
+                        "inline": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transformations": {
+                      "additionalProperties": {
+                        "properties": {
+                          "advancedTemplates": {
+                            "type": "boolean"
+                          },
+                          "body": {
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "dynamicMetadataValues": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "metadataNamespace": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "extractors": {
+                            "additionalProperties": {
+                              "properties": {
+                                "body": {
+                                  "maxProperties": 0,
+                                  "type": "object"
+                                },
+                                "header": {
+                                  "type": "string"
+                                },
+                                "regex": {
+                                  "type": "string"
+                                },
+                                "subgroup": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          },
+                          "headers": {
+                            "additionalProperties": {
+                              "properties": {
+                                "text": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          },
+                          "headersToAppend": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "headersToRemove": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ignoreErrorOnParse": {
+                            "type": "boolean"
+                          },
+                          "mergeExtractorsToBody": {
+                            "type": "object"
+                          },
+                          "parseBodyBehavior": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "passthrough": {
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "subsetSpec": {
+              "properties": {
+                "defaultSubset": {
+                  "properties": {
+                    "values": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "fallbackPolicy": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "selectors": {
+                  "items": {
+                    "properties": {
+                      "keys": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "singleHostPerSubset": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "loadBalancerConfig": {
+          "properties": {
+            "healthyPanicThreshold": {
+              "nullable": true,
+              "type": "number"
+            },
+            "leastRequest": {
+              "properties": {
+                "choiceCount": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "localityWeightedLbConfig": {
+              "maxProperties": 0,
+              "type": "object"
+            },
+            "maglev": {
+              "type": "object"
+            },
+            "random": {
+              "type": "object"
+            },
+            "ringHash": {
+              "properties": {
+                "ringHashConfig": {
+                  "properties": {
+                    "maximumRingSize": {
+                      "format": "int64",
+                      "type": "integer",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "minimumRingSize": {
+                      "format": "int64",
+                      "type": "integer",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "roundRobin": {
+              "type": "object"
+            },
+            "updateMergeWindow": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "maxConcurrentStreams": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "nullable": true,
+          "type": "integer"
+        },
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "outlierDetection": {
+          "properties": {
+            "baseEjectionTime": {
+              "type": "string"
+            },
+            "consecutive5xx": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "consecutiveGatewayFailure": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "consecutiveLocalOriginFailure": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "enforcingConsecutive5xx": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "enforcingConsecutiveGatewayFailure": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "enforcingConsecutiveLocalOriginFailure": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "enforcingLocalOriginSuccessRate": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "enforcingSuccessRate": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "maxEjectionPercent": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "splitExternalLocalOriginErrors": {
+              "type": "boolean"
+            },
+            "successRateMinimumHosts": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "successRateRequestVolume": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            },
+            "successRateStdevFactor": {
+              "maximum": 4294967295,
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "overrideStreamErrorOnInvalidHttpMessage": {
+          "nullable": true,
+          "type": "boolean"
+        },
+        "pipe": {
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "serviceSpec": {
+              "properties": {
+                "grpc": {
+                  "properties": {
+                    "descriptors": {
+                      "format": "byte",
+                      "type": "string"
+                    },
+                    "grpcServices": {
+                      "items": {
+                        "properties": {
+                          "functionNames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "packageName": {
+                            "type": "string"
+                          },
+                          "serviceName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rest": {
+                  "properties": {
+                    "swaggerInfo": {
+                      "properties": {
+                        "inline": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transformations": {
+                      "additionalProperties": {
+                        "properties": {
+                          "advancedTemplates": {
+                            "type": "boolean"
+                          },
+                          "body": {
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "dynamicMetadataValues": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "metadataNamespace": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "extractors": {
+                            "additionalProperties": {
+                              "properties": {
+                                "body": {
+                                  "maxProperties": 0,
+                                  "type": "object"
+                                },
+                                "header": {
+                                  "type": "string"
+                                },
+                                "regex": {
+                                  "type": "string"
+                                },
+                                "subgroup": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          },
+                          "headers": {
+                            "additionalProperties": {
+                              "properties": {
+                                "text": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          },
+                          "headersToAppend": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "headersToRemove": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ignoreErrorOnParse": {
+                            "type": "boolean"
+                          },
+                          "mergeExtractorsToBody": {
+                            "type": "object"
+                          },
+                          "parseBodyBehavior": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "passthrough": {
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "protocolSelection": {
+          "type": "string",
+          "x-kubernetes-int-or-string": true
+        },
+        "sslConfig": {
+          "properties": {
+            "allowRenegotiation": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "alpnProtocols": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "parameters": {
+              "properties": {
+                "cipherSuites": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ecdhCurves": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maximumProtocolVersion": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                },
+                "minimumProtocolVersion": {
+                  "type": "string",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sds": {
+              "properties": {
+                "callCredentials": {
+                  "properties": {
+                    "fileCredentialSource": {
+                      "properties": {
+                        "header": {
+                          "type": "string"
+                        },
+                        "tokenFileName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "certificatesSecretName": {
+                  "type": "string"
+                },
+                "clusterName": {
+                  "type": "string"
+                },
+                "targetUri": {
+                  "type": "string"
+                },
+                "validationContextName": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sni": {
+              "type": "string"
+            },
+            "sslFiles": {
+              "properties": {
+                "rootCa": {
+                  "type": "string"
+                },
+                "tlsCert": {
+                  "type": "string"
+                },
+                "tlsKey": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "verifySubjectAltName": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "static": {
+          "properties": {
+            "autoSniRewrite": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "hosts": {
+              "items": {
+                "properties": {
+                  "addr": {
+                    "type": "string"
+                  },
+                  "healthCheckConfig": {
+                    "properties": {
+                      "method": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "loadBalancingWeight": {
+                    "maximum": 4294967295,
+                    "minimum": 0,
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "port": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sniAddr": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "serviceSpec": {
+              "properties": {
+                "grpc": {
+                  "properties": {
+                    "descriptors": {
+                      "format": "byte",
+                      "type": "string"
+                    },
+                    "grpcServices": {
+                      "items": {
+                        "properties": {
+                          "functionNames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "packageName": {
+                            "type": "string"
+                          },
+                          "serviceName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rest": {
+                  "properties": {
+                    "swaggerInfo": {
+                      "properties": {
+                        "inline": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "transformations": {
+                      "additionalProperties": {
+                        "properties": {
+                          "advancedTemplates": {
+                            "type": "boolean"
+                          },
+                          "body": {
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "dynamicMetadataValues": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "metadataNamespace": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "extractors": {
+                            "additionalProperties": {
+                              "properties": {
+                                "body": {
+                                  "maxProperties": 0,
+                                  "type": "object"
+                                },
+                                "header": {
+                                  "type": "string"
+                                },
+                                "regex": {
+                                  "type": "string"
+                                },
+                                "subgroup": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          },
+                          "headers": {
+                            "additionalProperties": {
+                              "properties": {
+                                "text": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "object"
+                          },
+                          "headersToAppend": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "headersToRemove": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ignoreErrorOnParse": {
+                            "type": "boolean"
+                          },
+                          "mergeExtractorsToBody": {
+                            "type": "object"
+                          },
+                          "parseBodyBehavior": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "passthrough": {
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "useTls": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "useHttp2": {
+          "nullable": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/gloo.solo.io/upstreamgroup_v1.json
+++ b/gloo.solo.io/upstreamgroup_v1.json
@@ -1,0 +1,2015 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "destinations": {
+          "items": {
+            "properties": {
+              "destination": {
+                "properties": {
+                  "consul": {
+                    "properties": {
+                      "dataCenters": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "serviceName": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "destinationSpec": {
+                    "properties": {
+                      "aws": {
+                        "properties": {
+                          "invocationStyle": {
+                            "type": "string",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "logicalName": {
+                            "type": "string"
+                          },
+                          "requestTransformation": {
+                            "type": "boolean"
+                          },
+                          "responseTransformation": {
+                            "type": "boolean"
+                          },
+                          "unwrapAsAlb": {
+                            "type": "boolean"
+                          },
+                          "unwrapAsApiGateway": {
+                            "type": "boolean"
+                          },
+                          "wrapAsApiGateway": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azure": {
+                        "properties": {
+                          "functionName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "grpc": {
+                        "properties": {
+                          "function": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "type": "string"
+                          },
+                          "parameters": {
+                            "properties": {
+                              "headers": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "path": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rest": {
+                        "properties": {
+                          "functionName": {
+                            "type": "string"
+                          },
+                          "parameters": {
+                            "properties": {
+                              "headers": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "path": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "responseTransformation": {
+                            "properties": {
+                              "advancedTemplates": {
+                                "type": "boolean"
+                              },
+                              "body": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "dynamicMetadataValues": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "metadataNamespace": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "extractors": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "body": {
+                                      "maxProperties": 0,
+                                      "type": "object"
+                                    },
+                                    "header": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    },
+                                    "subgroup": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headers": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headersToAppend": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "headersToRemove": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ignoreErrorOnParse": {
+                                "type": "boolean"
+                              },
+                              "mergeExtractorsToBody": {
+                                "type": "object"
+                              },
+                              "parseBodyBehavior": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "passthrough": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "kube": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "ref": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "subset": {
+                    "properties": {
+                      "values": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "upstream": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "options": {
+                "properties": {
+                  "bufferPerRoute": {
+                    "properties": {
+                      "buffer": {
+                        "properties": {
+                          "maxRequestBytes": {
+                            "maximum": 4294967295,
+                            "minimum": 0,
+                            "nullable": true,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "disabled": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "csrf": {
+                    "properties": {
+                      "additionalOrigins": {
+                        "items": {
+                          "properties": {
+                            "exact": {
+                              "type": "string"
+                            },
+                            "ignoreCase": {
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "safeRegex": {
+                              "properties": {
+                                "googleRe2": {
+                                  "properties": {
+                                    "maxProgramSize": {
+                                      "maximum": 4294967295,
+                                      "minimum": 0,
+                                      "nullable": true,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "regex": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "suffix": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "filterEnabled": {
+                        "properties": {
+                          "defaultValue": {
+                            "properties": {
+                              "denominator": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "numerator": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "runtimeKey": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "shadowEnabled": {
+                        "properties": {
+                          "defaultValue": {
+                            "properties": {
+                              "denominator": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "numerator": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "runtimeKey": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "extauth": {
+                    "properties": {
+                      "configRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "customAuth": {
+                        "properties": {
+                          "contextExtensions": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "disable": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "extensions": {
+                    "properties": {
+                      "configs": {
+                        "additionalProperties": {
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "headerManipulation": {
+                    "properties": {
+                      "requestHeadersToAdd": {
+                        "items": {
+                          "properties": {
+                            "append": {
+                              "nullable": true,
+                              "type": "boolean"
+                            },
+                            "header": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headerSecretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "requestHeadersToRemove": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "responseHeadersToAdd": {
+                        "items": {
+                          "properties": {
+                            "append": {
+                              "nullable": true,
+                              "type": "boolean"
+                            },
+                            "header": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "responseHeadersToRemove": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "stagedTransformations": {
+                    "properties": {
+                      "early": {
+                        "properties": {
+                          "requestTransforms": {
+                            "items": {
+                              "properties": {
+                                "clearRouteCache": {
+                                  "type": "boolean"
+                                },
+                                "matcher": {
+                                  "properties": {
+                                    "caseSensitive": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "exact": {
+                                      "type": "string"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "methods": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "queryParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "requestTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "responseTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "responseTransforms": {
+                            "items": {
+                              "properties": {
+                                "matchers": {
+                                  "items": {
+                                    "properties": {
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "regex": {
+                                        "type": "boolean"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "responseCodeDetails": {
+                                  "type": "string"
+                                },
+                                "responseTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "inheritTransformation": {
+                        "type": "boolean"
+                      },
+                      "regular": {
+                        "properties": {
+                          "requestTransforms": {
+                            "items": {
+                              "properties": {
+                                "clearRouteCache": {
+                                  "type": "boolean"
+                                },
+                                "matcher": {
+                                  "properties": {
+                                    "caseSensitive": {
+                                      "nullable": true,
+                                      "type": "boolean"
+                                    },
+                                    "exact": {
+                                      "type": "string"
+                                    },
+                                    "headers": {
+                                      "items": {
+                                        "properties": {
+                                          "invertMatch": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "methods": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "queryParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "regex": {
+                                            "type": "boolean"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "requestTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "responseTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "responseTransforms": {
+                            "items": {
+                              "properties": {
+                                "matchers": {
+                                  "items": {
+                                    "properties": {
+                                      "invertMatch": {
+                                        "type": "boolean"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "regex": {
+                                        "type": "boolean"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "responseCodeDetails": {
+                                  "type": "string"
+                                },
+                                "responseTransformation": {
+                                  "properties": {
+                                    "headerBodyTransform": {
+                                      "properties": {
+                                        "addRequestMetadata": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "transformationTemplate": {
+                                      "properties": {
+                                        "advancedTemplates": {
+                                          "type": "boolean"
+                                        },
+                                        "body": {
+                                          "properties": {
+                                            "text": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "dynamicMetadataValues": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "metadataNamespace": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "extractors": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "body": {
+                                                "maxProperties": 0,
+                                                "type": "object"
+                                              },
+                                              "header": {
+                                                "type": "string"
+                                              },
+                                              "regex": {
+                                                "type": "string"
+                                              },
+                                              "subgroup": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headers": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "text": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "object"
+                                        },
+                                        "headersToAppend": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "headersToRemove": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "ignoreErrorOnParse": {
+                                          "type": "boolean"
+                                        },
+                                        "mergeExtractorsToBody": {
+                                          "type": "object"
+                                        },
+                                        "parseBodyBehavior": {
+                                          "type": "string",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "passthrough": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "xsltTransformation": {
+                                      "properties": {
+                                        "nonXmlTransform": {
+                                          "type": "boolean"
+                                        },
+                                        "setContentType": {
+                                          "type": "string"
+                                        },
+                                        "xslt": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "transformations": {
+                    "properties": {
+                      "clearRouteCache": {
+                        "type": "boolean"
+                      },
+                      "requestTransformation": {
+                        "properties": {
+                          "headerBodyTransform": {
+                            "properties": {
+                              "addRequestMetadata": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "transformationTemplate": {
+                            "properties": {
+                              "advancedTemplates": {
+                                "type": "boolean"
+                              },
+                              "body": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "dynamicMetadataValues": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "metadataNamespace": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "extractors": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "body": {
+                                      "maxProperties": 0,
+                                      "type": "object"
+                                    },
+                                    "header": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    },
+                                    "subgroup": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headers": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headersToAppend": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "headersToRemove": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ignoreErrorOnParse": {
+                                "type": "boolean"
+                              },
+                              "mergeExtractorsToBody": {
+                                "type": "object"
+                              },
+                              "parseBodyBehavior": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "passthrough": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "xsltTransformation": {
+                            "properties": {
+                              "nonXmlTransform": {
+                                "type": "boolean"
+                              },
+                              "setContentType": {
+                                "type": "string"
+                              },
+                              "xslt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "responseTransformation": {
+                        "properties": {
+                          "headerBodyTransform": {
+                            "properties": {
+                              "addRequestMetadata": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "transformationTemplate": {
+                            "properties": {
+                              "advancedTemplates": {
+                                "type": "boolean"
+                              },
+                              "body": {
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "dynamicMetadataValues": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "metadataNamespace": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "extractors": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "body": {
+                                      "maxProperties": 0,
+                                      "type": "object"
+                                    },
+                                    "header": {
+                                      "type": "string"
+                                    },
+                                    "regex": {
+                                      "type": "string"
+                                    },
+                                    "subgroup": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headers": {
+                                "additionalProperties": {
+                                  "properties": {
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "object"
+                              },
+                              "headersToAppend": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "headersToRemove": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ignoreErrorOnParse": {
+                                "type": "boolean"
+                              },
+                              "mergeExtractorsToBody": {
+                                "type": "object"
+                              },
+                              "parseBodyBehavior": {
+                                "type": "string",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "passthrough": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "xsltTransformation": {
+                            "properties": {
+                              "nonXmlTransform": {
+                                "type": "boolean"
+                              },
+                              "setContentType": {
+                                "type": "string"
+                              },
+                              "xslt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "weight": {
+                "maximum": 4294967295,
+                "minimum": 0,
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/graphql.gloo.solo.io/graphqlapi_v1beta1.json
+++ b/graphql.gloo.solo.io/graphqlapi_v1beta1.json
@@ -1,0 +1,347 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "allowedQueryHashes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "executableSchema": {
+          "properties": {
+            "executor": {
+              "properties": {
+                "local": {
+                  "properties": {
+                    "enableIntrospection": {
+                      "type": "boolean"
+                    },
+                    "options": {
+                      "properties": {
+                        "maxDepth": {
+                          "maximum": 4294967295,
+                          "minimum": 0,
+                          "nullable": true,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "resolutions": {
+                      "additionalProperties": {
+                        "properties": {
+                          "grpcResolver": {
+                            "properties": {
+                              "requestTransform": {
+                                "properties": {
+                                  "methodName": {
+                                    "type": "string"
+                                  },
+                                  "outgoingMessageJson": {
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "requestMetadata": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "serviceName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spanName": {
+                                "type": "string"
+                              },
+                              "upstreamRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mockResolver": {
+                            "properties": {
+                              "asyncResponse": {
+                                "properties": {
+                                  "delay": {
+                                    "type": "string"
+                                  },
+                                  "response": {
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "errorResponse": {
+                                "type": "string"
+                              },
+                              "syncResponse": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restResolver": {
+                            "properties": {
+                              "request": {
+                                "properties": {
+                                  "body": {
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "headers": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "queryParams": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "response": {
+                                "properties": {
+                                  "resultRoot": {
+                                    "type": "string"
+                                  },
+                                  "setters": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spanName": {
+                                "type": "string"
+                              },
+                              "upstreamRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "statPrefix": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "remote": {
+                  "properties": {
+                    "headers": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "queryParams": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "spanName": {
+                      "type": "string"
+                    },
+                    "upstreamRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "grpcDescriptorRegistry": {
+              "properties": {
+                "protoDescriptor": {
+                  "type": "string"
+                },
+                "protoDescriptorBin": {
+                  "format": "byte",
+                  "type": "string"
+                },
+                "protoRefsList": {
+                  "properties": {
+                    "configMapRefs": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "schemaDefinition": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "namespacedStatuses": {
+          "properties": {
+            "statuses": {
+              "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "options": {
+          "properties": {
+            "logSensitiveInfo": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "persistedQueryCacheConfig": {
+          "properties": {
+            "cacheSize": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "statPrefix": {
+          "nullable": true,
+          "type": "string"
+        },
+        "stitchedSchema": {
+          "properties": {
+            "subschemas": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "typeMerge": {
+                    "additionalProperties": {
+                      "properties": {
+                        "args": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "queryName": {
+                          "type": "string"
+                        },
+                        "selectionSet": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "default": {},
+      "properties": {
+        "statuses": {
+          "default": {},
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true,
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/ratelimit.solo.io/ratelimitconfig_v1alpha1.json
+++ b/ratelimit.solo.io/ratelimitconfig_v1alpha1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}


### PR DESCRIPTION
this PR adds CRDs from gloo (https://docs.solo.io/gloo-edge/latest/) , a k8s API gateway. 
CRDs extracted with CRD extractor from pristine docker desktop following the gloo yaml install