### PR TITLE
Check if the yaml module is importable

### DIFF
--- a/Utilities/crd-extractor.sh
+++ b/Utilities/crd-extractor.sh
@@ -14,7 +14,7 @@ if ! command -v kubectl &> /dev/null; then
 fi
 
 # Check if the pyyaml module is installed
-if ! pip3 show pyyaml &> /dev/null; then
+if ! echo 'import yaml' | python3 &> /dev/null; then
     printf "the python3 module 'yaml' is required, and is not installed on your machine.\n"
     #printf "would you like to install it? y/n"
 


### PR DESCRIPTION
Instead of using pip3 which fails to find the yaml module if it is
installed globally via a different method (e.g. package manager) just
try to import it.
