### PR TITLE
Add Cluster API schemas

### DIFF
--- a/addons.cluster.x-k8s.io/clusterresourceset_v1alpha3.json
+++ b/addons.cluster.x-k8s.io/clusterresourceset_v1alpha3.json
@@ -1,0 +1,158 @@
+{
+  "description": "ClusterResourceSet is the Schema for the clusterresourcesets API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetSpec defines the desired state of ClusterResourceSet.",
+      "properties": {
+        "clusterSelector": {
+          "description": "Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.",
+          "items": {
+            "description": "ResourceRef specifies a resource.",
+            "properties": {
+              "kind": {
+                "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                "enum": [
+                  "Secret",
+                  "ConfigMap"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "strategy": {
+          "description": "Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.",
+          "enum": [
+            "ApplyOnce"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "clusterSelector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterResourceSetStatus defines the observed state of ClusterResourceSet.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the ClusterResourceSet.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/addons.cluster.x-k8s.io/clusterresourceset_v1alpha4.json
+++ b/addons.cluster.x-k8s.io/clusterresourceset_v1alpha4.json
@@ -1,0 +1,158 @@
+{
+  "description": "ClusterResourceSet is the Schema for the clusterresourcesets API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetSpec defines the desired state of ClusterResourceSet.",
+      "properties": {
+        "clusterSelector": {
+          "description": "Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable. Label selector cannot be empty.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.",
+          "items": {
+            "description": "ResourceRef specifies a resource.",
+            "properties": {
+              "kind": {
+                "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                "enum": [
+                  "Secret",
+                  "ConfigMap"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "strategy": {
+          "description": "Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.",
+          "enum": [
+            "ApplyOnce"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "clusterSelector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterResourceSetStatus defines the observed state of ClusterResourceSet.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the ClusterResourceSet.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/addons.cluster.x-k8s.io/clusterresourceset_v1beta1.json
+++ b/addons.cluster.x-k8s.io/clusterresourceset_v1beta1.json
@@ -1,0 +1,160 @@
+{
+  "description": "ClusterResourceSet is the Schema for the clusterresourcesets API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetSpec defines the desired state of ClusterResourceSet.",
+      "properties": {
+        "clusterSelector": {
+          "description": "Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable. Label selector cannot be empty.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.",
+          "items": {
+            "description": "ResourceRef specifies a resource.",
+            "properties": {
+              "kind": {
+                "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                "enum": [
+                  "Secret",
+                  "ConfigMap"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "strategy": {
+          "description": "Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.",
+          "enum": [
+            "ApplyOnce",
+            "Reconcile"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "clusterSelector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterResourceSetStatus defines the observed state of ClusterResourceSet.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the ClusterResourceSet.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/addons.cluster.x-k8s.io/clusterresourcesetbinding_v1alpha3.json
+++ b/addons.cluster.x-k8s.io/clusterresourcesetbinding_v1alpha3.json
@@ -1,0 +1,84 @@
+{
+  "description": "ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.",
+      "properties": {
+        "bindings": {
+          "description": "Bindings is a list of ClusterResourceSets and their resources.",
+          "items": {
+            "description": "ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.",
+            "properties": {
+              "clusterResourceSetName": {
+                "description": "ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.",
+                "type": "string"
+              },
+              "resources": {
+                "description": "Resources is a list of resources that the ClusterResourceSet has.",
+                "items": {
+                  "description": "ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.",
+                  "properties": {
+                    "applied": {
+                      "description": "Applied is to track if a resource is applied to the cluster or not.",
+                      "type": "boolean"
+                    },
+                    "hash": {
+                      "description": "Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For \"ApplyOnce\" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    },
+                    "lastAppliedTime": {
+                      "description": "LastAppliedTime identifies when this resource was last applied to the cluster.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "applied",
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "clusterResourceSetName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/addons.cluster.x-k8s.io/clusterresourcesetbinding_v1alpha4.json
+++ b/addons.cluster.x-k8s.io/clusterresourcesetbinding_v1alpha4.json
@@ -1,0 +1,84 @@
+{
+  "description": "ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.",
+      "properties": {
+        "bindings": {
+          "description": "Bindings is a list of ClusterResourceSets and their resources.",
+          "items": {
+            "description": "ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.",
+            "properties": {
+              "clusterResourceSetName": {
+                "description": "ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.",
+                "type": "string"
+              },
+              "resources": {
+                "description": "Resources is a list of resources that the ClusterResourceSet has.",
+                "items": {
+                  "description": "ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.",
+                  "properties": {
+                    "applied": {
+                      "description": "Applied is to track if a resource is applied to the cluster or not.",
+                      "type": "boolean"
+                    },
+                    "hash": {
+                      "description": "Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For \"ApplyOnce\" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    },
+                    "lastAppliedTime": {
+                      "description": "LastAppliedTime identifies when this resource was last applied to the cluster.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "applied",
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "clusterResourceSetName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/addons.cluster.x-k8s.io/clusterresourcesetbinding_v1beta1.json
+++ b/addons.cluster.x-k8s.io/clusterresourcesetbinding_v1beta1.json
@@ -1,0 +1,88 @@
+{
+  "description": "ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.",
+      "properties": {
+        "bindings": {
+          "description": "Bindings is a list of ClusterResourceSets and their resources.",
+          "items": {
+            "description": "ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.",
+            "properties": {
+              "clusterResourceSetName": {
+                "description": "ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.",
+                "type": "string"
+              },
+              "resources": {
+                "description": "Resources is a list of resources that the ClusterResourceSet has.",
+                "items": {
+                  "description": "ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.",
+                  "properties": {
+                    "applied": {
+                      "description": "Applied is to track if a resource is applied to the cluster or not.",
+                      "type": "boolean"
+                    },
+                    "hash": {
+                      "description": "Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For \"ApplyOnce\" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the resource. Supported kinds are: Secrets and ConfigMaps.",
+                      "enum": [
+                        "Secret",
+                        "ConfigMap"
+                      ],
+                      "type": "string"
+                    },
+                    "lastAppliedTime": {
+                      "description": "LastAppliedTime identifies when this resource was last applied to the cluster.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource that is in the same namespace with ClusterResourceSet object.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "applied",
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "clusterResourceSetName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this binding applies to. Note: this field mandatory in v1beta2.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/kubeadmconfig_v1alpha3.json
+++ b/bootstrap.cluster.x-k8s.io/kubeadmconfig_v1alpha3.json
@@ -1,0 +1,987 @@
+{
+  "description": "KubeadmConfig is the Schema for the kubeadmconfigs API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.",
+      "properties": {
+        "clusterConfiguration": {
+          "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+          "properties": {
+            "apiServer": {
+              "description": "APIServer contains extra settings for the API server control plane component",
+              "properties": {
+                "certSANs": {
+                  "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "extraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                  "type": "object"
+                },
+                "extraVolumes": {
+                  "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                  "items": {
+                    "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                    "properties": {
+                      "hostPath": {
+                        "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                        "type": "string"
+                      },
+                      "mountPath": {
+                        "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the volume inside the pod template.",
+                        "type": "string"
+                      },
+                      "pathType": {
+                        "description": "PathType is the type of the HostPath.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly controls write access to the volume",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "hostPath",
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "timeoutForControlPlane": {
+                  "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "certificatesDir": {
+              "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+              "type": "string"
+            },
+            "clusterName": {
+              "description": "The cluster name",
+              "type": "string"
+            },
+            "controlPlaneEndpoint": {
+              "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+              "type": "string"
+            },
+            "controllerManager": {
+              "description": "ControllerManager contains extra settings for the controller manager control plane component",
+              "properties": {
+                "extraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                  "type": "object"
+                },
+                "extraVolumes": {
+                  "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                  "items": {
+                    "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                    "properties": {
+                      "hostPath": {
+                        "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                        "type": "string"
+                      },
+                      "mountPath": {
+                        "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the volume inside the pod template.",
+                        "type": "string"
+                      },
+                      "pathType": {
+                        "description": "PathType is the type of the HostPath.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly controls write access to the volume",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "hostPath",
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dns": {
+              "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+              "properties": {
+                "imageRepository": {
+                  "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                  "type": "string"
+                },
+                "imageTag": {
+                  "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type defines the DNS add-on to be used",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "etcd": {
+              "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+              "properties": {
+                "external": {
+                  "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                  "properties": {
+                    "caFile": {
+                      "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                      "type": "string"
+                    },
+                    "certFile": {
+                      "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                      "type": "string"
+                    },
+                    "endpoints": {
+                      "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "keyFile": {
+                      "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "caFile",
+                    "certFile",
+                    "endpoints",
+                    "keyFile"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "local": {
+                  "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                  "properties": {
+                    "dataDir": {
+                      "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                      "type": "string"
+                    },
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                      "type": "object"
+                    },
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                      "type": "string"
+                    },
+                    "peerCertSANs": {
+                      "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "serverCertSANs": {
+                      "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "featureGates": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "description": "FeatureGates enabled by the user.",
+              "type": "object"
+            },
+            "imageRepository": {
+              "description": "ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "kubernetesVersion": {
+              "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+              "properties": {
+                "dnsDomain": {
+                  "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                  "type": "string"
+                },
+                "podSubnet": {
+                  "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                  "type": "string"
+                },
+                "serviceSubnet": {
+                  "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scheduler": {
+              "description": "Scheduler contains extra settings for the scheduler control plane component",
+              "properties": {
+                "extraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                  "type": "object"
+                },
+                "extraVolumes": {
+                  "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                  "items": {
+                    "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                    "properties": {
+                      "hostPath": {
+                        "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                        "type": "string"
+                      },
+                      "mountPath": {
+                        "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the volume inside the pod template.",
+                        "type": "string"
+                      },
+                      "pathType": {
+                        "description": "PathType is the type of the HostPath.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly controls write access to the volume",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "hostPath",
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "useHyperKubeImage": {
+              "description": "UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "diskSetup": {
+          "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+          "properties": {
+            "filesystems": {
+              "description": "Filesystems specifies the list of file systems to setup.",
+              "items": {
+                "description": "Filesystem defines the file systems to be created.",
+                "properties": {
+                  "device": {
+                    "description": "Device specifies the device name",
+                    "type": "string"
+                  },
+                  "extraOpts": {
+                    "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "filesystem": {
+                    "description": "Filesystem specifies the file system type.",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                    "type": "string"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                    "type": "boolean"
+                  },
+                  "partition": {
+                    "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                    "type": "string"
+                  },
+                  "replaceFS": {
+                    "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "device",
+                  "filesystem",
+                  "label"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "partitions": {
+              "description": "Partitions specifies the list of the partitions to setup.",
+              "items": {
+                "description": "Partition defines how to create and layout a partition.",
+                "properties": {
+                  "device": {
+                    "description": "Device is the name of the device.",
+                    "type": "string"
+                  },
+                  "layout": {
+                    "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                    "type": "boolean"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                    "type": "boolean"
+                  },
+                  "tableType": {
+                    "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "device",
+                  "layout"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "files": {
+          "description": "Files specifies extra files to be passed to user_data upon creation.",
+          "items": {
+            "description": "File defines the input for generating write_files in cloud-init.",
+            "properties": {
+              "content": {
+                "description": "Content is the actual content of the file.",
+                "type": "string"
+              },
+              "contentFrom": {
+                "description": "ContentFrom is a referenced source of content to populate the file.",
+                "properties": {
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this file.",
+                    "properties": {
+                      "key": {
+                        "description": "Key is the key in the secret's data map for this value.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "secret"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "encoding": {
+                "description": "Encoding specifies the encoding of the file contents.",
+                "enum": [
+                  "base64",
+                  "gzip",
+                  "gzip+base64"
+                ],
+                "type": "string"
+              },
+              "owner": {
+                "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                "type": "string"
+              },
+              "path": {
+                "description": "Path specifies the full path on disk where to store the file.",
+                "type": "string"
+              },
+              "permissions": {
+                "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "format": {
+          "description": "Format specifies the output format of the bootstrap data",
+          "enum": [
+            "cloud-config"
+          ],
+          "type": "string"
+        },
+        "initConfiguration": {
+          "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "bootstrapTokens": {
+              "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+              "items": {
+                "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                "properties": {
+                  "description": {
+                    "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                    "type": "string"
+                  },
+                  "expires": {
+                    "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "groups": {
+                    "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "token": {
+                    "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                    "type": "string"
+                  },
+                  "ttl": {
+                    "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                    "type": "string"
+                  },
+                  "usages": {
+                    "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "token"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "localAPIEndpoint": {
+              "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+              "properties": {
+                "advertiseAddress": {
+                  "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                  "type": "string"
+                },
+                "bindPort": {
+                  "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "advertiseAddress",
+                "bindPort"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeRegistration": {
+              "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+              "properties": {
+                "criSocket": {
+                  "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                  "type": "string"
+                },
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                  "type": "string"
+                },
+                "taints": {
+                  "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                  "items": {
+                    "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                    "properties": {
+                      "effect": {
+                        "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Required. The taint key to be applied to a node.",
+                        "type": "string"
+                      },
+                      "timeAdded": {
+                        "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The taint value corresponding to the taint key.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "effect",
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "joinConfiguration": {
+          "description": "JoinConfiguration is the kubeadm configuration for the join command",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "caCertPath": {
+              "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+              "type": "string"
+            },
+            "controlPlane": {
+              "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+              "properties": {
+                "localAPIEndpoint": {
+                  "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                  "properties": {
+                    "advertiseAddress": {
+                      "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                      "type": "string"
+                    },
+                    "bindPort": {
+                      "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "advertiseAddress",
+                    "bindPort"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "discovery": {
+              "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+              "properties": {
+                "bootstrapToken": {
+                  "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                  "properties": {
+                    "apiServerEndpoint": {
+                      "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                      "type": "string"
+                    },
+                    "caCertHashes": {
+                      "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "token": {
+                      "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                      "type": "string"
+                    },
+                    "unsafeSkipCAVerification": {
+                      "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "token",
+                    "unsafeSkipCAVerification"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "file": {
+                  "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                  "properties": {
+                    "kubeConfigPath": {
+                      "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kubeConfigPath"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "timeout": {
+                  "description": "Timeout modifies the discovery timeout",
+                  "type": "string"
+                },
+                "tlsBootstrapToken": {
+                  "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information TODO: revisit when there is defaulting from k/k",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "nodeRegistration": {
+              "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+              "properties": {
+                "criSocket": {
+                  "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                  "type": "string"
+                },
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                  "type": "string"
+                },
+                "taints": {
+                  "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                  "items": {
+                    "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                    "properties": {
+                      "effect": {
+                        "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Required. The taint key to be applied to a node.",
+                        "type": "string"
+                      },
+                      "timeAdded": {
+                        "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The taint value corresponding to the taint key.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "effect",
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mounts": {
+          "description": "Mounts specifies a list of mount points to be setup.",
+          "items": {
+            "description": "MountPoints defines input for generated mounts in cloud-init.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "ntp": {
+          "description": "NTP specifies NTP configuration",
+          "properties": {
+            "enabled": {
+              "description": "Enabled specifies whether NTP should be enabled",
+              "type": "boolean"
+            },
+            "servers": {
+              "description": "Servers specifies which NTP servers to use",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "postKubeadmCommands": {
+          "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "preKubeadmCommands": {
+          "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "useExperimentalRetryJoin": {
+          "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.",
+          "type": "boolean"
+        },
+        "users": {
+          "description": "Users specifies extra users to add",
+          "items": {
+            "description": "User defines the input for a generated user in cloud-init.",
+            "properties": {
+              "gecos": {
+                "description": "Gecos specifies the gecos to use for the user",
+                "type": "string"
+              },
+              "groups": {
+                "description": "Groups specifies the additional groups for the user",
+                "type": "string"
+              },
+              "homeDir": {
+                "description": "HomeDir specifies the home directory to use for the user",
+                "type": "string"
+              },
+              "inactive": {
+                "description": "Inactive specifies whether to mark the user as inactive",
+                "type": "boolean"
+              },
+              "lockPassword": {
+                "description": "LockPassword specifies if password login should be disabled",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Name specifies the user name",
+                "type": "string"
+              },
+              "passwd": {
+                "description": "Passwd specifies a hashed password for the user",
+                "type": "string"
+              },
+              "primaryGroup": {
+                "description": "PrimaryGroup specifies the primary group for the user",
+                "type": "string"
+              },
+              "shell": {
+                "description": "Shell specifies the user's shell",
+                "type": "string"
+              },
+              "sshAuthorizedKeys": {
+                "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "sudo": {
+                "description": "Sudo specifies a sudo role for the user",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "verbosity": {
+          "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KubeadmConfigStatus defines the observed state of KubeadmConfig.",
+      "properties": {
+        "bootstrapData": {
+          "description": "BootstrapData will be a cloud-init script for now. \n Deprecated: Switch to DataSecretName.",
+          "format": "byte",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the KubeadmConfig.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "dataSecretName": {
+          "description": "DataSecretName is the name of the secret that stores the bootstrap data script.",
+          "type": "string"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set on non-retryable errors",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set on non-retryable errors",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready indicates the BootstrapData field is ready to be consumed",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/kubeadmconfig_v1alpha4.json
+++ b/bootstrap.cluster.x-k8s.io/kubeadmconfig_v1alpha4.json
@@ -1,0 +1,979 @@
+{
+  "description": "KubeadmConfig is the Schema for the kubeadmconfigs API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.",
+      "properties": {
+        "clusterConfiguration": {
+          "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+          "properties": {
+            "apiServer": {
+              "description": "APIServer contains extra settings for the API server control plane component",
+              "properties": {
+                "certSANs": {
+                  "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "extraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                  "type": "object"
+                },
+                "extraVolumes": {
+                  "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                  "items": {
+                    "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                    "properties": {
+                      "hostPath": {
+                        "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                        "type": "string"
+                      },
+                      "mountPath": {
+                        "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the volume inside the pod template.",
+                        "type": "string"
+                      },
+                      "pathType": {
+                        "description": "PathType is the type of the HostPath.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly controls write access to the volume",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "hostPath",
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "timeoutForControlPlane": {
+                  "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "certificatesDir": {
+              "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+              "type": "string"
+            },
+            "clusterName": {
+              "description": "The cluster name",
+              "type": "string"
+            },
+            "controlPlaneEndpoint": {
+              "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+              "type": "string"
+            },
+            "controllerManager": {
+              "description": "ControllerManager contains extra settings for the controller manager control plane component",
+              "properties": {
+                "extraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                  "type": "object"
+                },
+                "extraVolumes": {
+                  "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                  "items": {
+                    "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                    "properties": {
+                      "hostPath": {
+                        "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                        "type": "string"
+                      },
+                      "mountPath": {
+                        "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the volume inside the pod template.",
+                        "type": "string"
+                      },
+                      "pathType": {
+                        "description": "PathType is the type of the HostPath.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly controls write access to the volume",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "hostPath",
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dns": {
+              "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+              "properties": {
+                "imageRepository": {
+                  "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                  "type": "string"
+                },
+                "imageTag": {
+                  "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "etcd": {
+              "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+              "properties": {
+                "external": {
+                  "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                  "properties": {
+                    "caFile": {
+                      "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                      "type": "string"
+                    },
+                    "certFile": {
+                      "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                      "type": "string"
+                    },
+                    "endpoints": {
+                      "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "keyFile": {
+                      "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "caFile",
+                    "certFile",
+                    "endpoints",
+                    "keyFile"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "local": {
+                  "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                  "properties": {
+                    "dataDir": {
+                      "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                      "type": "string"
+                    },
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                      "type": "object"
+                    },
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                      "type": "string"
+                    },
+                    "peerCertSANs": {
+                      "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "serverCertSANs": {
+                      "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "featureGates": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "description": "FeatureGates enabled by the user.",
+              "type": "object"
+            },
+            "imageRepository": {
+              "description": "ImageRepository sets the container registry to pull images from. If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io` will be used for all the other images.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "kubernetesVersion": {
+              "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+              "properties": {
+                "dnsDomain": {
+                  "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                  "type": "string"
+                },
+                "podSubnet": {
+                  "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                  "type": "string"
+                },
+                "serviceSubnet": {
+                  "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scheduler": {
+              "description": "Scheduler contains extra settings for the scheduler control plane component",
+              "properties": {
+                "extraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                  "type": "object"
+                },
+                "extraVolumes": {
+                  "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                  "items": {
+                    "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                    "properties": {
+                      "hostPath": {
+                        "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                        "type": "string"
+                      },
+                      "mountPath": {
+                        "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the volume inside the pod template.",
+                        "type": "string"
+                      },
+                      "pathType": {
+                        "description": "PathType is the type of the HostPath.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly controls write access to the volume",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "hostPath",
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "diskSetup": {
+          "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+          "properties": {
+            "filesystems": {
+              "description": "Filesystems specifies the list of file systems to setup.",
+              "items": {
+                "description": "Filesystem defines the file systems to be created.",
+                "properties": {
+                  "device": {
+                    "description": "Device specifies the device name",
+                    "type": "string"
+                  },
+                  "extraOpts": {
+                    "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "filesystem": {
+                    "description": "Filesystem specifies the file system type.",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                    "type": "string"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                    "type": "boolean"
+                  },
+                  "partition": {
+                    "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                    "type": "string"
+                  },
+                  "replaceFS": {
+                    "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "device",
+                  "filesystem",
+                  "label"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "partitions": {
+              "description": "Partitions specifies the list of the partitions to setup.",
+              "items": {
+                "description": "Partition defines how to create and layout a partition.",
+                "properties": {
+                  "device": {
+                    "description": "Device is the name of the device.",
+                    "type": "string"
+                  },
+                  "layout": {
+                    "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                    "type": "boolean"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                    "type": "boolean"
+                  },
+                  "tableType": {
+                    "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "device",
+                  "layout"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "files": {
+          "description": "Files specifies extra files to be passed to user_data upon creation.",
+          "items": {
+            "description": "File defines the input for generating write_files in cloud-init.",
+            "properties": {
+              "content": {
+                "description": "Content is the actual content of the file.",
+                "type": "string"
+              },
+              "contentFrom": {
+                "description": "ContentFrom is a referenced source of content to populate the file.",
+                "properties": {
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this file.",
+                    "properties": {
+                      "key": {
+                        "description": "Key is the key in the secret's data map for this value.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "secret"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "encoding": {
+                "description": "Encoding specifies the encoding of the file contents.",
+                "enum": [
+                  "base64",
+                  "gzip",
+                  "gzip+base64"
+                ],
+                "type": "string"
+              },
+              "owner": {
+                "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                "type": "string"
+              },
+              "path": {
+                "description": "Path specifies the full path on disk where to store the file.",
+                "type": "string"
+              },
+              "permissions": {
+                "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "format": {
+          "description": "Format specifies the output format of the bootstrap data",
+          "enum": [
+            "cloud-config"
+          ],
+          "type": "string"
+        },
+        "initConfiguration": {
+          "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "bootstrapTokens": {
+              "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+              "items": {
+                "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                "properties": {
+                  "description": {
+                    "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                    "type": "string"
+                  },
+                  "expires": {
+                    "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "groups": {
+                    "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "token": {
+                    "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                    "type": "string"
+                  },
+                  "ttl": {
+                    "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                    "type": "string"
+                  },
+                  "usages": {
+                    "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "token"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "localAPIEndpoint": {
+              "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+              "properties": {
+                "advertiseAddress": {
+                  "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                  "type": "string"
+                },
+                "bindPort": {
+                  "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeRegistration": {
+              "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+              "properties": {
+                "criSocket": {
+                  "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                  "type": "string"
+                },
+                "ignorePreflightErrors": {
+                  "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                  "type": "string"
+                },
+                "taints": {
+                  "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                  "items": {
+                    "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                    "properties": {
+                      "effect": {
+                        "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Required. The taint key to be applied to a node.",
+                        "type": "string"
+                      },
+                      "timeAdded": {
+                        "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The taint value corresponding to the taint key.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "effect",
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "joinConfiguration": {
+          "description": "JoinConfiguration is the kubeadm configuration for the join command",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "caCertPath": {
+              "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+              "type": "string"
+            },
+            "controlPlane": {
+              "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+              "properties": {
+                "localAPIEndpoint": {
+                  "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                  "properties": {
+                    "advertiseAddress": {
+                      "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                      "type": "string"
+                    },
+                    "bindPort": {
+                      "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "discovery": {
+              "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+              "properties": {
+                "bootstrapToken": {
+                  "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                  "properties": {
+                    "apiServerEndpoint": {
+                      "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                      "type": "string"
+                    },
+                    "caCertHashes": {
+                      "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "token": {
+                      "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                      "type": "string"
+                    },
+                    "unsafeSkipCAVerification": {
+                      "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "token"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "file": {
+                  "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                  "properties": {
+                    "kubeConfigPath": {
+                      "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kubeConfigPath"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "timeout": {
+                  "description": "Timeout modifies the discovery timeout",
+                  "type": "string"
+                },
+                "tlsBootstrapToken": {
+                  "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "nodeRegistration": {
+              "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+              "properties": {
+                "criSocket": {
+                  "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                  "type": "string"
+                },
+                "ignorePreflightErrors": {
+                  "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                  "type": "string"
+                },
+                "taints": {
+                  "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                  "items": {
+                    "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                    "properties": {
+                      "effect": {
+                        "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Required. The taint key to be applied to a node.",
+                        "type": "string"
+                      },
+                      "timeAdded": {
+                        "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The taint value corresponding to the taint key.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "effect",
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mounts": {
+          "description": "Mounts specifies a list of mount points to be setup.",
+          "items": {
+            "description": "MountPoints defines input for generated mounts in cloud-init.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "ntp": {
+          "description": "NTP specifies NTP configuration",
+          "properties": {
+            "enabled": {
+              "description": "Enabled specifies whether NTP should be enabled",
+              "type": "boolean"
+            },
+            "servers": {
+              "description": "Servers specifies which NTP servers to use",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "postKubeadmCommands": {
+          "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "preKubeadmCommands": {
+          "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "useExperimentalRetryJoin": {
+          "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.",
+          "type": "boolean"
+        },
+        "users": {
+          "description": "Users specifies extra users to add",
+          "items": {
+            "description": "User defines the input for a generated user in cloud-init.",
+            "properties": {
+              "gecos": {
+                "description": "Gecos specifies the gecos to use for the user",
+                "type": "string"
+              },
+              "groups": {
+                "description": "Groups specifies the additional groups for the user",
+                "type": "string"
+              },
+              "homeDir": {
+                "description": "HomeDir specifies the home directory to use for the user",
+                "type": "string"
+              },
+              "inactive": {
+                "description": "Inactive specifies whether to mark the user as inactive",
+                "type": "boolean"
+              },
+              "lockPassword": {
+                "description": "LockPassword specifies if password login should be disabled",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Name specifies the user name",
+                "type": "string"
+              },
+              "passwd": {
+                "description": "Passwd specifies a hashed password for the user",
+                "type": "string"
+              },
+              "primaryGroup": {
+                "description": "PrimaryGroup specifies the primary group for the user",
+                "type": "string"
+              },
+              "shell": {
+                "description": "Shell specifies the user's shell",
+                "type": "string"
+              },
+              "sshAuthorizedKeys": {
+                "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "sudo": {
+                "description": "Sudo specifies a sudo role for the user",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "verbosity": {
+          "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KubeadmConfigStatus defines the observed state of KubeadmConfig.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the KubeadmConfig.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "dataSecretName": {
+          "description": "DataSecretName is the name of the secret that stores the bootstrap data script.",
+          "type": "string"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set on non-retryable errors",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set on non-retryable errors",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready indicates the BootstrapData field is ready to be consumed",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/kubeadmconfig_v1beta1.json
+++ b/bootstrap.cluster.x-k8s.io/kubeadmconfig_v1beta1.json
@@ -1,0 +1,1090 @@
+{
+  "description": "KubeadmConfig is the Schema for the kubeadmconfigs API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.",
+      "properties": {
+        "clusterConfiguration": {
+          "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+          "properties": {
+            "apiServer": {
+              "description": "APIServer contains extra settings for the API server control plane component",
+              "properties": {
+                "certSANs": {
+                  "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "extraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                  "type": "object"
+                },
+                "extraVolumes": {
+                  "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                  "items": {
+                    "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                    "properties": {
+                      "hostPath": {
+                        "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                        "type": "string"
+                      },
+                      "mountPath": {
+                        "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the volume inside the pod template.",
+                        "type": "string"
+                      },
+                      "pathType": {
+                        "description": "PathType is the type of the HostPath.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly controls write access to the volume",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "hostPath",
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "timeoutForControlPlane": {
+                  "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "certificatesDir": {
+              "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+              "type": "string"
+            },
+            "clusterName": {
+              "description": "The cluster name",
+              "type": "string"
+            },
+            "controlPlaneEndpoint": {
+              "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+              "type": "string"
+            },
+            "controllerManager": {
+              "description": "ControllerManager contains extra settings for the controller manager control plane component",
+              "properties": {
+                "extraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                  "type": "object"
+                },
+                "extraVolumes": {
+                  "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                  "items": {
+                    "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                    "properties": {
+                      "hostPath": {
+                        "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                        "type": "string"
+                      },
+                      "mountPath": {
+                        "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the volume inside the pod template.",
+                        "type": "string"
+                      },
+                      "pathType": {
+                        "description": "PathType is the type of the HostPath.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly controls write access to the volume",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "hostPath",
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dns": {
+              "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+              "properties": {
+                "imageRepository": {
+                  "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                  "type": "string"
+                },
+                "imageTag": {
+                  "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "etcd": {
+              "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+              "properties": {
+                "external": {
+                  "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                  "properties": {
+                    "caFile": {
+                      "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                      "type": "string"
+                    },
+                    "certFile": {
+                      "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                      "type": "string"
+                    },
+                    "endpoints": {
+                      "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "keyFile": {
+                      "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "caFile",
+                    "certFile",
+                    "endpoints",
+                    "keyFile"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "local": {
+                  "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                  "properties": {
+                    "dataDir": {
+                      "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                      "type": "string"
+                    },
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                      "type": "object"
+                    },
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                      "type": "string"
+                    },
+                    "peerCertSANs": {
+                      "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "serverCertSANs": {
+                      "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "featureGates": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "description": "FeatureGates enabled by the user.",
+              "type": "object"
+            },
+            "imageRepository": {
+              "description": "ImageRepository sets the container registry to pull images from. * If not set, the default registry of kubeadm will be used, i.e. * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0 * k8s.gcr.io (old registry): all older versions Please note that when imageRepository is not set we don't allow upgrades to versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use a newer patch version with the new registry instead (i.e. >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0). * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io` will be used for all the other images.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "kubernetesVersion": {
+              "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+              "properties": {
+                "dnsDomain": {
+                  "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                  "type": "string"
+                },
+                "podSubnet": {
+                  "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                  "type": "string"
+                },
+                "serviceSubnet": {
+                  "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scheduler": {
+              "description": "Scheduler contains extra settings for the scheduler control plane component",
+              "properties": {
+                "extraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                  "type": "object"
+                },
+                "extraVolumes": {
+                  "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                  "items": {
+                    "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                    "properties": {
+                      "hostPath": {
+                        "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                        "type": "string"
+                      },
+                      "mountPath": {
+                        "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the volume inside the pod template.",
+                        "type": "string"
+                      },
+                      "pathType": {
+                        "description": "PathType is the type of the HostPath.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly controls write access to the volume",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "hostPath",
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "diskSetup": {
+          "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+          "properties": {
+            "filesystems": {
+              "description": "Filesystems specifies the list of file systems to setup.",
+              "items": {
+                "description": "Filesystem defines the file systems to be created.",
+                "properties": {
+                  "device": {
+                    "description": "Device specifies the device name",
+                    "type": "string"
+                  },
+                  "extraOpts": {
+                    "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "filesystem": {
+                    "description": "Filesystem specifies the file system type.",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                    "type": "string"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                    "type": "boolean"
+                  },
+                  "partition": {
+                    "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                    "type": "string"
+                  },
+                  "replaceFS": {
+                    "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "device",
+                  "filesystem",
+                  "label"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "partitions": {
+              "description": "Partitions specifies the list of the partitions to setup.",
+              "items": {
+                "description": "Partition defines how to create and layout a partition.",
+                "properties": {
+                  "device": {
+                    "description": "Device is the name of the device.",
+                    "type": "string"
+                  },
+                  "layout": {
+                    "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                    "type": "boolean"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                    "type": "boolean"
+                  },
+                  "tableType": {
+                    "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "device",
+                  "layout"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "files": {
+          "description": "Files specifies extra files to be passed to user_data upon creation.",
+          "items": {
+            "description": "File defines the input for generating write_files in cloud-init.",
+            "properties": {
+              "append": {
+                "description": "Append specifies whether to append Content to existing file if Path exists.",
+                "type": "boolean"
+              },
+              "content": {
+                "description": "Content is the actual content of the file.",
+                "type": "string"
+              },
+              "contentFrom": {
+                "description": "ContentFrom is a referenced source of content to populate the file.",
+                "properties": {
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this file.",
+                    "properties": {
+                      "key": {
+                        "description": "Key is the key in the secret's data map for this value.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "secret"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "encoding": {
+                "description": "Encoding specifies the encoding of the file contents.",
+                "enum": [
+                  "base64",
+                  "gzip",
+                  "gzip+base64"
+                ],
+                "type": "string"
+              },
+              "owner": {
+                "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                "type": "string"
+              },
+              "path": {
+                "description": "Path specifies the full path on disk where to store the file.",
+                "type": "string"
+              },
+              "permissions": {
+                "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "format": {
+          "description": "Format specifies the output format of the bootstrap data",
+          "enum": [
+            "cloud-config",
+            "ignition"
+          ],
+          "type": "string"
+        },
+        "ignition": {
+          "description": "Ignition contains Ignition specific configuration.",
+          "properties": {
+            "containerLinuxConfig": {
+              "description": "ContainerLinuxConfig contains CLC specific configuration.",
+              "properties": {
+                "additionalConfig": {
+                  "description": "AdditionalConfig contains additional configuration to be merged with the Ignition configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/",
+                  "type": "string"
+                },
+                "strict": {
+                  "description": "Strict controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "initConfiguration": {
+          "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "bootstrapTokens": {
+              "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+              "items": {
+                "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                "properties": {
+                  "description": {
+                    "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                    "type": "string"
+                  },
+                  "expires": {
+                    "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "groups": {
+                    "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "token": {
+                    "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                    "type": "string"
+                  },
+                  "ttl": {
+                    "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                    "type": "string"
+                  },
+                  "usages": {
+                    "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "token"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "localAPIEndpoint": {
+              "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+              "properties": {
+                "advertiseAddress": {
+                  "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                  "type": "string"
+                },
+                "bindPort": {
+                  "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeRegistration": {
+              "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+              "properties": {
+                "criSocket": {
+                  "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                  "type": "string"
+                },
+                "ignorePreflightErrors": {
+                  "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "imagePullPolicy": {
+                  "description": "ImagePullPolicy specifies the policy for image pulling during kubeadm \"init\" and \"join\" operations. The value of this field must be one of \"Always\", \"IfNotPresent\" or \"Never\". Defaults to \"IfNotPresent\". This can be used only with Kubernetes version equal to 1.22 and later.",
+                  "enum": [
+                    "Always",
+                    "IfNotPresent",
+                    "Never"
+                  ],
+                  "type": "string"
+                },
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                  "type": "string"
+                },
+                "taints": {
+                  "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.",
+                  "items": {
+                    "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                    "properties": {
+                      "effect": {
+                        "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Required. The taint key to be applied to a node.",
+                        "type": "string"
+                      },
+                      "timeAdded": {
+                        "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The taint value corresponding to the taint key.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "effect",
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "patches": {
+              "description": "Patches contains options related to applying patches to components deployed by kubeadm during \"kubeadm init\". The minimum kubernetes version needed to support Patches is v1.22",
+              "properties": {
+                "directory": {
+                  "description": "Directory is a path to a directory that contains files named \"target[suffix][+patchtype].extension\". For example, \"kube-apiserver0+merge.yaml\" or just \"etcd.json\". \"target\" can be one of \"kube-apiserver\", \"kube-controller-manager\", \"kube-scheduler\", \"etcd\". \"patchtype\" can be one of \"strategic\" \"merge\" or \"json\" and they match the patch formats supported by kubectl. The default \"patchtype\" is \"strategic\". \"extension\" must be either \"json\" or \"yaml\". \"suffix\" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "skipPhases": {
+              "description": "SkipPhases is a list of phases to skip during command execution. The list of phases can be obtained with the \"kubeadm init --help\" command. This option takes effect only on Kubernetes >=1.22.0.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "joinConfiguration": {
+          "description": "JoinConfiguration is the kubeadm configuration for the join command",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "caCertPath": {
+              "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+              "type": "string"
+            },
+            "controlPlane": {
+              "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+              "properties": {
+                "localAPIEndpoint": {
+                  "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                  "properties": {
+                    "advertiseAddress": {
+                      "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                      "type": "string"
+                    },
+                    "bindPort": {
+                      "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "discovery": {
+              "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+              "properties": {
+                "bootstrapToken": {
+                  "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                  "properties": {
+                    "apiServerEndpoint": {
+                      "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                      "type": "string"
+                    },
+                    "caCertHashes": {
+                      "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "token": {
+                      "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                      "type": "string"
+                    },
+                    "unsafeSkipCAVerification": {
+                      "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "token"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "file": {
+                  "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                  "properties": {
+                    "kubeConfigPath": {
+                      "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kubeConfigPath"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "timeout": {
+                  "description": "Timeout modifies the discovery timeout",
+                  "type": "string"
+                },
+                "tlsBootstrapToken": {
+                  "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "nodeRegistration": {
+              "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+              "properties": {
+                "criSocket": {
+                  "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                  "type": "string"
+                },
+                "ignorePreflightErrors": {
+                  "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "imagePullPolicy": {
+                  "description": "ImagePullPolicy specifies the policy for image pulling during kubeadm \"init\" and \"join\" operations. The value of this field must be one of \"Always\", \"IfNotPresent\" or \"Never\". Defaults to \"IfNotPresent\". This can be used only with Kubernetes version equal to 1.22 and later.",
+                  "enum": [
+                    "Always",
+                    "IfNotPresent",
+                    "Never"
+                  ],
+                  "type": "string"
+                },
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                  "type": "string"
+                },
+                "taints": {
+                  "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.",
+                  "items": {
+                    "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                    "properties": {
+                      "effect": {
+                        "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Required. The taint key to be applied to a node.",
+                        "type": "string"
+                      },
+                      "timeAdded": {
+                        "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The taint value corresponding to the taint key.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "effect",
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "patches": {
+              "description": "Patches contains options related to applying patches to components deployed by kubeadm during \"kubeadm join\". The minimum kubernetes version needed to support Patches is v1.22",
+              "properties": {
+                "directory": {
+                  "description": "Directory is a path to a directory that contains files named \"target[suffix][+patchtype].extension\". For example, \"kube-apiserver0+merge.yaml\" or just \"etcd.json\". \"target\" can be one of \"kube-apiserver\", \"kube-controller-manager\", \"kube-scheduler\", \"etcd\". \"patchtype\" can be one of \"strategic\" \"merge\" or \"json\" and they match the patch formats supported by kubectl. The default \"patchtype\" is \"strategic\". \"extension\" must be either \"json\" or \"yaml\". \"suffix\" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "skipPhases": {
+              "description": "SkipPhases is a list of phases to skip during command execution. The list of phases can be obtained with the \"kubeadm init --help\" command. This option takes effect only on Kubernetes >=1.22.0.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mounts": {
+          "description": "Mounts specifies a list of mount points to be setup.",
+          "items": {
+            "description": "MountPoints defines input for generated mounts in cloud-init.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "ntp": {
+          "description": "NTP specifies NTP configuration",
+          "properties": {
+            "enabled": {
+              "description": "Enabled specifies whether NTP should be enabled",
+              "type": "boolean"
+            },
+            "servers": {
+              "description": "Servers specifies which NTP servers to use",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "postKubeadmCommands": {
+          "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "preKubeadmCommands": {
+          "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "useExperimentalRetryJoin": {
+          "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055. \n Deprecated: This experimental fix is no longer needed and this field will be removed in a future release. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml",
+          "type": "boolean"
+        },
+        "users": {
+          "description": "Users specifies extra users to add",
+          "items": {
+            "description": "User defines the input for a generated user in cloud-init.",
+            "properties": {
+              "gecos": {
+                "description": "Gecos specifies the gecos to use for the user",
+                "type": "string"
+              },
+              "groups": {
+                "description": "Groups specifies the additional groups for the user",
+                "type": "string"
+              },
+              "homeDir": {
+                "description": "HomeDir specifies the home directory to use for the user",
+                "type": "string"
+              },
+              "inactive": {
+                "description": "Inactive specifies whether to mark the user as inactive",
+                "type": "boolean"
+              },
+              "lockPassword": {
+                "description": "LockPassword specifies if password login should be disabled",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Name specifies the user name",
+                "type": "string"
+              },
+              "passwd": {
+                "description": "Passwd specifies a hashed password for the user",
+                "type": "string"
+              },
+              "passwdFrom": {
+                "description": "PasswdFrom is a referenced source of passwd to populate the passwd.",
+                "properties": {
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this password.",
+                    "properties": {
+                      "key": {
+                        "description": "Key is the key in the secret's data map for this value.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "secret"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "primaryGroup": {
+                "description": "PrimaryGroup specifies the primary group for the user",
+                "type": "string"
+              },
+              "shell": {
+                "description": "Shell specifies the user's shell",
+                "type": "string"
+              },
+              "sshAuthorizedKeys": {
+                "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "sudo": {
+                "description": "Sudo specifies a sudo role for the user",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "verbosity": {
+          "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KubeadmConfigStatus defines the observed state of KubeadmConfig.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the KubeadmConfig.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "dataSecretName": {
+          "description": "DataSecretName is the name of the secret that stores the bootstrap data script.",
+          "type": "string"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set on non-retryable errors",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set on non-retryable errors",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready indicates the BootstrapData field is ready to be consumed",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1alpha3.json
+++ b/bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1alpha3.json
@@ -1,0 +1,931 @@
+{
+  "description": "KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.",
+      "properties": {
+        "template": {
+          "description": "KubeadmConfigTemplateResource defines the Template structure.",
+          "properties": {
+            "spec": {
+              "description": "KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.",
+              "properties": {
+                "clusterConfiguration": {
+                  "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+                  "properties": {
+                    "apiServer": {
+                      "description": "APIServer contains extra settings for the API server control plane component",
+                      "properties": {
+                        "certSANs": {
+                          "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                          "type": "object"
+                        },
+                        "extraVolumes": {
+                          "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                          "items": {
+                            "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                            "properties": {
+                              "hostPath": {
+                                "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                "type": "string"
+                              },
+                              "mountPath": {
+                                "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the volume inside the pod template.",
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "description": "PathType is the type of the HostPath.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly controls write access to the volume",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "hostPath",
+                              "mountPath",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "timeoutForControlPlane": {
+                          "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "apiVersion": {
+                      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                      "type": "string"
+                    },
+                    "certificatesDir": {
+                      "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+                      "type": "string"
+                    },
+                    "clusterName": {
+                      "description": "The cluster name",
+                      "type": "string"
+                    },
+                    "controlPlaneEndpoint": {
+                      "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+                      "type": "string"
+                    },
+                    "controllerManager": {
+                      "description": "ControllerManager contains extra settings for the controller manager control plane component",
+                      "properties": {
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                          "type": "object"
+                        },
+                        "extraVolumes": {
+                          "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                          "items": {
+                            "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                            "properties": {
+                              "hostPath": {
+                                "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                "type": "string"
+                              },
+                              "mountPath": {
+                                "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the volume inside the pod template.",
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "description": "PathType is the type of the HostPath.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly controls write access to the volume",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "hostPath",
+                              "mountPath",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "dns": {
+                      "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+                      "properties": {
+                        "imageRepository": {
+                          "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                          "type": "string"
+                        },
+                        "imageTag": {
+                          "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Type defines the DNS add-on to be used",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "etcd": {
+                      "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+                      "properties": {
+                        "external": {
+                          "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                          "properties": {
+                            "caFile": {
+                              "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                              "type": "string"
+                            },
+                            "certFile": {
+                              "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                              "type": "string"
+                            },
+                            "endpoints": {
+                              "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "keyFile": {
+                              "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "caFile",
+                            "certFile",
+                            "endpoints",
+                            "keyFile"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "local": {
+                          "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                          "properties": {
+                            "dataDir": {
+                              "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                              "type": "string"
+                            },
+                            "extraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                              "type": "object"
+                            },
+                            "imageRepository": {
+                              "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                              "type": "string"
+                            },
+                            "imageTag": {
+                              "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                              "type": "string"
+                            },
+                            "peerCertSANs": {
+                              "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "serverCertSANs": {
+                              "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "featureGates": {
+                      "additionalProperties": {
+                        "type": "boolean"
+                      },
+                      "description": "FeatureGates enabled by the user.",
+                      "type": "object"
+                    },
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "kubernetesVersion": {
+                      "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+                      "type": "string"
+                    },
+                    "networking": {
+                      "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+                      "properties": {
+                        "dnsDomain": {
+                          "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                          "type": "string"
+                        },
+                        "podSubnet": {
+                          "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                          "type": "string"
+                        },
+                        "serviceSubnet": {
+                          "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "scheduler": {
+                      "description": "Scheduler contains extra settings for the scheduler control plane component",
+                      "properties": {
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                          "type": "object"
+                        },
+                        "extraVolumes": {
+                          "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                          "items": {
+                            "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                            "properties": {
+                              "hostPath": {
+                                "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                "type": "string"
+                              },
+                              "mountPath": {
+                                "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the volume inside the pod template.",
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "description": "PathType is the type of the HostPath.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly controls write access to the volume",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "hostPath",
+                              "mountPath",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "useHyperKubeImage": {
+                      "description": "UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "diskSetup": {
+                  "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+                  "properties": {
+                    "filesystems": {
+                      "description": "Filesystems specifies the list of file systems to setup.",
+                      "items": {
+                        "description": "Filesystem defines the file systems to be created.",
+                        "properties": {
+                          "device": {
+                            "description": "Device specifies the device name",
+                            "type": "string"
+                          },
+                          "extraOpts": {
+                            "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "filesystem": {
+                            "description": "Filesystem specifies the file system type.",
+                            "type": "string"
+                          },
+                          "label": {
+                            "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                            "type": "string"
+                          },
+                          "overwrite": {
+                            "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                            "type": "boolean"
+                          },
+                          "partition": {
+                            "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                            "type": "string"
+                          },
+                          "replaceFS": {
+                            "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "device",
+                          "filesystem",
+                          "label"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "partitions": {
+                      "description": "Partitions specifies the list of the partitions to setup.",
+                      "items": {
+                        "description": "Partition defines how to create and layout a partition.",
+                        "properties": {
+                          "device": {
+                            "description": "Device is the name of the device.",
+                            "type": "string"
+                          },
+                          "layout": {
+                            "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                            "type": "boolean"
+                          },
+                          "overwrite": {
+                            "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                            "type": "boolean"
+                          },
+                          "tableType": {
+                            "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "device",
+                          "layout"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "files": {
+                  "description": "Files specifies extra files to be passed to user_data upon creation.",
+                  "items": {
+                    "description": "File defines the input for generating write_files in cloud-init.",
+                    "properties": {
+                      "content": {
+                        "description": "Content is the actual content of the file.",
+                        "type": "string"
+                      },
+                      "contentFrom": {
+                        "description": "ContentFrom is a referenced source of content to populate the file.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents a secret that should populate this file.",
+                            "properties": {
+                              "key": {
+                                "description": "Key is the key in the secret's data map for this value.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "secret"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "encoding": {
+                        "description": "Encoding specifies the encoding of the file contents.",
+                        "enum": [
+                          "base64",
+                          "gzip",
+                          "gzip+base64"
+                        ],
+                        "type": "string"
+                      },
+                      "owner": {
+                        "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path specifies the full path on disk where to store the file.",
+                        "type": "string"
+                      },
+                      "permissions": {
+                        "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "format": {
+                  "description": "Format specifies the output format of the bootstrap data",
+                  "enum": [
+                    "cloud-config"
+                  ],
+                  "type": "string"
+                },
+                "initConfiguration": {
+                  "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                      "type": "string"
+                    },
+                    "bootstrapTokens": {
+                      "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+                      "items": {
+                        "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                        "properties": {
+                          "description": {
+                            "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                            "type": "string"
+                          },
+                          "expires": {
+                            "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "groups": {
+                            "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "token": {
+                            "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                            "type": "string"
+                          },
+                          "ttl": {
+                            "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                            "type": "string"
+                          },
+                          "usages": {
+                            "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "token"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "localAPIEndpoint": {
+                      "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+                      "properties": {
+                        "advertiseAddress": {
+                          "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                          "type": "string"
+                        },
+                        "bindPort": {
+                          "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "advertiseAddress",
+                        "bindPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodeRegistration": {
+                      "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                      "properties": {
+                        "criSocket": {
+                          "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                          "type": "string"
+                        },
+                        "kubeletExtraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                          "type": "string"
+                        },
+                        "taints": {
+                          "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                          "items": {
+                            "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                            "properties": {
+                              "effect": {
+                                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Required. The taint key to be applied to a node.",
+                                "type": "string"
+                              },
+                              "timeAdded": {
+                                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The taint value corresponding to the taint key.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "effect",
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "joinConfiguration": {
+                  "description": "JoinConfiguration is the kubeadm configuration for the join command",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                      "type": "string"
+                    },
+                    "caCertPath": {
+                      "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+                      "type": "string"
+                    },
+                    "controlPlane": {
+                      "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+                      "properties": {
+                        "localAPIEndpoint": {
+                          "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                          "properties": {
+                            "advertiseAddress": {
+                              "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                              "type": "string"
+                            },
+                            "bindPort": {
+                              "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "advertiseAddress",
+                            "bindPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "discovery": {
+                      "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+                      "properties": {
+                        "bootstrapToken": {
+                          "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                          "properties": {
+                            "apiServerEndpoint": {
+                              "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                              "type": "string"
+                            },
+                            "caCertHashes": {
+                              "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "token": {
+                              "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                              "type": "string"
+                            },
+                            "unsafeSkipCAVerification": {
+                              "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "token",
+                            "unsafeSkipCAVerification"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "file": {
+                          "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                          "properties": {
+                            "kubeConfigPath": {
+                              "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kubeConfigPath"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "timeout": {
+                          "description": "Timeout modifies the discovery timeout",
+                          "type": "string"
+                        },
+                        "tlsBootstrapToken": {
+                          "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information TODO: revisit when there is defaulting from k/k",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "kind": {
+                      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "nodeRegistration": {
+                      "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                      "properties": {
+                        "criSocket": {
+                          "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                          "type": "string"
+                        },
+                        "kubeletExtraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                          "type": "string"
+                        },
+                        "taints": {
+                          "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                          "items": {
+                            "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                            "properties": {
+                              "effect": {
+                                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Required. The taint key to be applied to a node.",
+                                "type": "string"
+                              },
+                              "timeAdded": {
+                                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The taint value corresponding to the taint key.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "effect",
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "mounts": {
+                  "description": "Mounts specifies a list of mount points to be setup.",
+                  "items": {
+                    "description": "MountPoints defines input for generated mounts in cloud-init.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "ntp": {
+                  "description": "NTP specifies NTP configuration",
+                  "properties": {
+                    "enabled": {
+                      "description": "Enabled specifies whether NTP should be enabled",
+                      "type": "boolean"
+                    },
+                    "servers": {
+                      "description": "Servers specifies which NTP servers to use",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "postKubeadmCommands": {
+                  "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "preKubeadmCommands": {
+                  "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "useExperimentalRetryJoin": {
+                  "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.",
+                  "type": "boolean"
+                },
+                "users": {
+                  "description": "Users specifies extra users to add",
+                  "items": {
+                    "description": "User defines the input for a generated user in cloud-init.",
+                    "properties": {
+                      "gecos": {
+                        "description": "Gecos specifies the gecos to use for the user",
+                        "type": "string"
+                      },
+                      "groups": {
+                        "description": "Groups specifies the additional groups for the user",
+                        "type": "string"
+                      },
+                      "homeDir": {
+                        "description": "HomeDir specifies the home directory to use for the user",
+                        "type": "string"
+                      },
+                      "inactive": {
+                        "description": "Inactive specifies whether to mark the user as inactive",
+                        "type": "boolean"
+                      },
+                      "lockPassword": {
+                        "description": "LockPassword specifies if password login should be disabled",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name specifies the user name",
+                        "type": "string"
+                      },
+                      "passwd": {
+                        "description": "Passwd specifies a hashed password for the user",
+                        "type": "string"
+                      },
+                      "primaryGroup": {
+                        "description": "PrimaryGroup specifies the primary group for the user",
+                        "type": "string"
+                      },
+                      "shell": {
+                        "description": "Shell specifies the user's shell",
+                        "type": "string"
+                      },
+                      "sshAuthorizedKeys": {
+                        "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "sudo": {
+                        "description": "Sudo specifies a sudo role for the user",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "verbosity": {
+                  "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1alpha4.json
+++ b/bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1alpha4.json
@@ -1,0 +1,928 @@
+{
+  "description": "KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.",
+      "properties": {
+        "template": {
+          "description": "KubeadmConfigTemplateResource defines the Template structure.",
+          "properties": {
+            "spec": {
+              "description": "KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.",
+              "properties": {
+                "clusterConfiguration": {
+                  "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+                  "properties": {
+                    "apiServer": {
+                      "description": "APIServer contains extra settings for the API server control plane component",
+                      "properties": {
+                        "certSANs": {
+                          "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                          "type": "object"
+                        },
+                        "extraVolumes": {
+                          "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                          "items": {
+                            "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                            "properties": {
+                              "hostPath": {
+                                "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                "type": "string"
+                              },
+                              "mountPath": {
+                                "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the volume inside the pod template.",
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "description": "PathType is the type of the HostPath.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly controls write access to the volume",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "hostPath",
+                              "mountPath",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "timeoutForControlPlane": {
+                          "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "apiVersion": {
+                      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                      "type": "string"
+                    },
+                    "certificatesDir": {
+                      "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+                      "type": "string"
+                    },
+                    "clusterName": {
+                      "description": "The cluster name",
+                      "type": "string"
+                    },
+                    "controlPlaneEndpoint": {
+                      "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+                      "type": "string"
+                    },
+                    "controllerManager": {
+                      "description": "ControllerManager contains extra settings for the controller manager control plane component",
+                      "properties": {
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                          "type": "object"
+                        },
+                        "extraVolumes": {
+                          "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                          "items": {
+                            "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                            "properties": {
+                              "hostPath": {
+                                "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                "type": "string"
+                              },
+                              "mountPath": {
+                                "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the volume inside the pod template.",
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "description": "PathType is the type of the HostPath.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly controls write access to the volume",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "hostPath",
+                              "mountPath",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "dns": {
+                      "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+                      "properties": {
+                        "imageRepository": {
+                          "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                          "type": "string"
+                        },
+                        "imageTag": {
+                          "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "etcd": {
+                      "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+                      "properties": {
+                        "external": {
+                          "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                          "properties": {
+                            "caFile": {
+                              "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                              "type": "string"
+                            },
+                            "certFile": {
+                              "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                              "type": "string"
+                            },
+                            "endpoints": {
+                              "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "keyFile": {
+                              "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "caFile",
+                            "certFile",
+                            "endpoints",
+                            "keyFile"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "local": {
+                          "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                          "properties": {
+                            "dataDir": {
+                              "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                              "type": "string"
+                            },
+                            "extraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                              "type": "object"
+                            },
+                            "imageRepository": {
+                              "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                              "type": "string"
+                            },
+                            "imageTag": {
+                              "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                              "type": "string"
+                            },
+                            "peerCertSANs": {
+                              "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "serverCertSANs": {
+                              "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "featureGates": {
+                      "additionalProperties": {
+                        "type": "boolean"
+                      },
+                      "description": "FeatureGates enabled by the user.",
+                      "type": "object"
+                    },
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull images from. If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io` will be used for all the other images.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "kubernetesVersion": {
+                      "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+                      "type": "string"
+                    },
+                    "networking": {
+                      "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+                      "properties": {
+                        "dnsDomain": {
+                          "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                          "type": "string"
+                        },
+                        "podSubnet": {
+                          "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                          "type": "string"
+                        },
+                        "serviceSubnet": {
+                          "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "scheduler": {
+                      "description": "Scheduler contains extra settings for the scheduler control plane component",
+                      "properties": {
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                          "type": "object"
+                        },
+                        "extraVolumes": {
+                          "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                          "items": {
+                            "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                            "properties": {
+                              "hostPath": {
+                                "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                "type": "string"
+                              },
+                              "mountPath": {
+                                "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the volume inside the pod template.",
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "description": "PathType is the type of the HostPath.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly controls write access to the volume",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "hostPath",
+                              "mountPath",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "diskSetup": {
+                  "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+                  "properties": {
+                    "filesystems": {
+                      "description": "Filesystems specifies the list of file systems to setup.",
+                      "items": {
+                        "description": "Filesystem defines the file systems to be created.",
+                        "properties": {
+                          "device": {
+                            "description": "Device specifies the device name",
+                            "type": "string"
+                          },
+                          "extraOpts": {
+                            "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "filesystem": {
+                            "description": "Filesystem specifies the file system type.",
+                            "type": "string"
+                          },
+                          "label": {
+                            "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                            "type": "string"
+                          },
+                          "overwrite": {
+                            "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                            "type": "boolean"
+                          },
+                          "partition": {
+                            "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                            "type": "string"
+                          },
+                          "replaceFS": {
+                            "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "device",
+                          "filesystem",
+                          "label"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "partitions": {
+                      "description": "Partitions specifies the list of the partitions to setup.",
+                      "items": {
+                        "description": "Partition defines how to create and layout a partition.",
+                        "properties": {
+                          "device": {
+                            "description": "Device is the name of the device.",
+                            "type": "string"
+                          },
+                          "layout": {
+                            "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                            "type": "boolean"
+                          },
+                          "overwrite": {
+                            "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                            "type": "boolean"
+                          },
+                          "tableType": {
+                            "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "device",
+                          "layout"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "files": {
+                  "description": "Files specifies extra files to be passed to user_data upon creation.",
+                  "items": {
+                    "description": "File defines the input for generating write_files in cloud-init.",
+                    "properties": {
+                      "content": {
+                        "description": "Content is the actual content of the file.",
+                        "type": "string"
+                      },
+                      "contentFrom": {
+                        "description": "ContentFrom is a referenced source of content to populate the file.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents a secret that should populate this file.",
+                            "properties": {
+                              "key": {
+                                "description": "Key is the key in the secret's data map for this value.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "secret"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "encoding": {
+                        "description": "Encoding specifies the encoding of the file contents.",
+                        "enum": [
+                          "base64",
+                          "gzip",
+                          "gzip+base64"
+                        ],
+                        "type": "string"
+                      },
+                      "owner": {
+                        "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path specifies the full path on disk where to store the file.",
+                        "type": "string"
+                      },
+                      "permissions": {
+                        "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "format": {
+                  "description": "Format specifies the output format of the bootstrap data",
+                  "enum": [
+                    "cloud-config"
+                  ],
+                  "type": "string"
+                },
+                "initConfiguration": {
+                  "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                      "type": "string"
+                    },
+                    "bootstrapTokens": {
+                      "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+                      "items": {
+                        "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                        "properties": {
+                          "description": {
+                            "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                            "type": "string"
+                          },
+                          "expires": {
+                            "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "groups": {
+                            "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "token": {
+                            "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                            "type": "string"
+                          },
+                          "ttl": {
+                            "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                            "type": "string"
+                          },
+                          "usages": {
+                            "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "token"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "localAPIEndpoint": {
+                      "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+                      "properties": {
+                        "advertiseAddress": {
+                          "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                          "type": "string"
+                        },
+                        "bindPort": {
+                          "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodeRegistration": {
+                      "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                      "properties": {
+                        "criSocket": {
+                          "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                          "type": "string"
+                        },
+                        "ignorePreflightErrors": {
+                          "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "kubeletExtraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                          "type": "string"
+                        },
+                        "taints": {
+                          "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                          "items": {
+                            "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                            "properties": {
+                              "effect": {
+                                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Required. The taint key to be applied to a node.",
+                                "type": "string"
+                              },
+                              "timeAdded": {
+                                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The taint value corresponding to the taint key.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "effect",
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "joinConfiguration": {
+                  "description": "JoinConfiguration is the kubeadm configuration for the join command",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                      "type": "string"
+                    },
+                    "caCertPath": {
+                      "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+                      "type": "string"
+                    },
+                    "controlPlane": {
+                      "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+                      "properties": {
+                        "localAPIEndpoint": {
+                          "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                          "properties": {
+                            "advertiseAddress": {
+                              "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                              "type": "string"
+                            },
+                            "bindPort": {
+                              "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "discovery": {
+                      "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+                      "properties": {
+                        "bootstrapToken": {
+                          "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                          "properties": {
+                            "apiServerEndpoint": {
+                              "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                              "type": "string"
+                            },
+                            "caCertHashes": {
+                              "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "token": {
+                              "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                              "type": "string"
+                            },
+                            "unsafeSkipCAVerification": {
+                              "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "token"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "file": {
+                          "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                          "properties": {
+                            "kubeConfigPath": {
+                              "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kubeConfigPath"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "timeout": {
+                          "description": "Timeout modifies the discovery timeout",
+                          "type": "string"
+                        },
+                        "tlsBootstrapToken": {
+                          "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "kind": {
+                      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "nodeRegistration": {
+                      "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                      "properties": {
+                        "criSocket": {
+                          "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                          "type": "string"
+                        },
+                        "ignorePreflightErrors": {
+                          "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "kubeletExtraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                          "type": "string"
+                        },
+                        "taints": {
+                          "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                          "items": {
+                            "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                            "properties": {
+                              "effect": {
+                                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Required. The taint key to be applied to a node.",
+                                "type": "string"
+                              },
+                              "timeAdded": {
+                                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The taint value corresponding to the taint key.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "effect",
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "mounts": {
+                  "description": "Mounts specifies a list of mount points to be setup.",
+                  "items": {
+                    "description": "MountPoints defines input for generated mounts in cloud-init.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "ntp": {
+                  "description": "NTP specifies NTP configuration",
+                  "properties": {
+                    "enabled": {
+                      "description": "Enabled specifies whether NTP should be enabled",
+                      "type": "boolean"
+                    },
+                    "servers": {
+                      "description": "Servers specifies which NTP servers to use",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "postKubeadmCommands": {
+                  "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "preKubeadmCommands": {
+                  "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "useExperimentalRetryJoin": {
+                  "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.",
+                  "type": "boolean"
+                },
+                "users": {
+                  "description": "Users specifies extra users to add",
+                  "items": {
+                    "description": "User defines the input for a generated user in cloud-init.",
+                    "properties": {
+                      "gecos": {
+                        "description": "Gecos specifies the gecos to use for the user",
+                        "type": "string"
+                      },
+                      "groups": {
+                        "description": "Groups specifies the additional groups for the user",
+                        "type": "string"
+                      },
+                      "homeDir": {
+                        "description": "HomeDir specifies the home directory to use for the user",
+                        "type": "string"
+                      },
+                      "inactive": {
+                        "description": "Inactive specifies whether to mark the user as inactive",
+                        "type": "boolean"
+                      },
+                      "lockPassword": {
+                        "description": "LockPassword specifies if password login should be disabled",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name specifies the user name",
+                        "type": "string"
+                      },
+                      "passwd": {
+                        "description": "Passwd specifies a hashed password for the user",
+                        "type": "string"
+                      },
+                      "primaryGroup": {
+                        "description": "PrimaryGroup specifies the primary group for the user",
+                        "type": "string"
+                      },
+                      "shell": {
+                        "description": "Shell specifies the user's shell",
+                        "type": "string"
+                      },
+                      "sshAuthorizedKeys": {
+                        "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "sudo": {
+                        "description": "Sudo specifies a sudo role for the user",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "verbosity": {
+                  "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1beta1.json
+++ b/bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1beta1.json
@@ -1,0 +1,1059 @@
+{
+  "description": "KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.",
+      "properties": {
+        "template": {
+          "description": "KubeadmConfigTemplateResource defines the Template structure.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.",
+              "properties": {
+                "clusterConfiguration": {
+                  "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+                  "properties": {
+                    "apiServer": {
+                      "description": "APIServer contains extra settings for the API server control plane component",
+                      "properties": {
+                        "certSANs": {
+                          "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                          "type": "object"
+                        },
+                        "extraVolumes": {
+                          "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                          "items": {
+                            "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                            "properties": {
+                              "hostPath": {
+                                "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                "type": "string"
+                              },
+                              "mountPath": {
+                                "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the volume inside the pod template.",
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "description": "PathType is the type of the HostPath.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly controls write access to the volume",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "hostPath",
+                              "mountPath",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "timeoutForControlPlane": {
+                          "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "apiVersion": {
+                      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                      "type": "string"
+                    },
+                    "certificatesDir": {
+                      "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+                      "type": "string"
+                    },
+                    "clusterName": {
+                      "description": "The cluster name",
+                      "type": "string"
+                    },
+                    "controlPlaneEndpoint": {
+                      "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+                      "type": "string"
+                    },
+                    "controllerManager": {
+                      "description": "ControllerManager contains extra settings for the controller manager control plane component",
+                      "properties": {
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                          "type": "object"
+                        },
+                        "extraVolumes": {
+                          "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                          "items": {
+                            "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                            "properties": {
+                              "hostPath": {
+                                "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                "type": "string"
+                              },
+                              "mountPath": {
+                                "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the volume inside the pod template.",
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "description": "PathType is the type of the HostPath.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly controls write access to the volume",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "hostPath",
+                              "mountPath",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "dns": {
+                      "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+                      "properties": {
+                        "imageRepository": {
+                          "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                          "type": "string"
+                        },
+                        "imageTag": {
+                          "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "etcd": {
+                      "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+                      "properties": {
+                        "external": {
+                          "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                          "properties": {
+                            "caFile": {
+                              "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                              "type": "string"
+                            },
+                            "certFile": {
+                              "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                              "type": "string"
+                            },
+                            "endpoints": {
+                              "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "keyFile": {
+                              "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "caFile",
+                            "certFile",
+                            "endpoints",
+                            "keyFile"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "local": {
+                          "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                          "properties": {
+                            "dataDir": {
+                              "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                              "type": "string"
+                            },
+                            "extraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                              "type": "object"
+                            },
+                            "imageRepository": {
+                              "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                              "type": "string"
+                            },
+                            "imageTag": {
+                              "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                              "type": "string"
+                            },
+                            "peerCertSANs": {
+                              "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "serverCertSANs": {
+                              "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "featureGates": {
+                      "additionalProperties": {
+                        "type": "boolean"
+                      },
+                      "description": "FeatureGates enabled by the user.",
+                      "type": "object"
+                    },
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull images from. * If not set, the default registry of kubeadm will be used, i.e. * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0 * k8s.gcr.io (old registry): all older versions Please note that when imageRepository is not set we don't allow upgrades to versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use a newer patch version with the new registry instead (i.e. >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0). * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io` will be used for all the other images.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "kubernetesVersion": {
+                      "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+                      "type": "string"
+                    },
+                    "networking": {
+                      "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+                      "properties": {
+                        "dnsDomain": {
+                          "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                          "type": "string"
+                        },
+                        "podSubnet": {
+                          "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                          "type": "string"
+                        },
+                        "serviceSubnet": {
+                          "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "scheduler": {
+                      "description": "Scheduler contains extra settings for the scheduler control plane component",
+                      "properties": {
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                          "type": "object"
+                        },
+                        "extraVolumes": {
+                          "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                          "items": {
+                            "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                            "properties": {
+                              "hostPath": {
+                                "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                "type": "string"
+                              },
+                              "mountPath": {
+                                "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the volume inside the pod template.",
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "description": "PathType is the type of the HostPath.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "ReadOnly controls write access to the volume",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "hostPath",
+                              "mountPath",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "diskSetup": {
+                  "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+                  "properties": {
+                    "filesystems": {
+                      "description": "Filesystems specifies the list of file systems to setup.",
+                      "items": {
+                        "description": "Filesystem defines the file systems to be created.",
+                        "properties": {
+                          "device": {
+                            "description": "Device specifies the device name",
+                            "type": "string"
+                          },
+                          "extraOpts": {
+                            "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "filesystem": {
+                            "description": "Filesystem specifies the file system type.",
+                            "type": "string"
+                          },
+                          "label": {
+                            "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                            "type": "string"
+                          },
+                          "overwrite": {
+                            "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                            "type": "boolean"
+                          },
+                          "partition": {
+                            "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                            "type": "string"
+                          },
+                          "replaceFS": {
+                            "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "device",
+                          "filesystem",
+                          "label"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "partitions": {
+                      "description": "Partitions specifies the list of the partitions to setup.",
+                      "items": {
+                        "description": "Partition defines how to create and layout a partition.",
+                        "properties": {
+                          "device": {
+                            "description": "Device is the name of the device.",
+                            "type": "string"
+                          },
+                          "layout": {
+                            "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                            "type": "boolean"
+                          },
+                          "overwrite": {
+                            "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                            "type": "boolean"
+                          },
+                          "tableType": {
+                            "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "device",
+                          "layout"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "files": {
+                  "description": "Files specifies extra files to be passed to user_data upon creation.",
+                  "items": {
+                    "description": "File defines the input for generating write_files in cloud-init.",
+                    "properties": {
+                      "append": {
+                        "description": "Append specifies whether to append Content to existing file if Path exists.",
+                        "type": "boolean"
+                      },
+                      "content": {
+                        "description": "Content is the actual content of the file.",
+                        "type": "string"
+                      },
+                      "contentFrom": {
+                        "description": "ContentFrom is a referenced source of content to populate the file.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents a secret that should populate this file.",
+                            "properties": {
+                              "key": {
+                                "description": "Key is the key in the secret's data map for this value.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "secret"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "encoding": {
+                        "description": "Encoding specifies the encoding of the file contents.",
+                        "enum": [
+                          "base64",
+                          "gzip",
+                          "gzip+base64"
+                        ],
+                        "type": "string"
+                      },
+                      "owner": {
+                        "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path specifies the full path on disk where to store the file.",
+                        "type": "string"
+                      },
+                      "permissions": {
+                        "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "format": {
+                  "description": "Format specifies the output format of the bootstrap data",
+                  "enum": [
+                    "cloud-config",
+                    "ignition"
+                  ],
+                  "type": "string"
+                },
+                "ignition": {
+                  "description": "Ignition contains Ignition specific configuration.",
+                  "properties": {
+                    "containerLinuxConfig": {
+                      "description": "ContainerLinuxConfig contains CLC specific configuration.",
+                      "properties": {
+                        "additionalConfig": {
+                          "description": "AdditionalConfig contains additional configuration to be merged with the Ignition configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/",
+                          "type": "string"
+                        },
+                        "strict": {
+                          "description": "Strict controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initConfiguration": {
+                  "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                      "type": "string"
+                    },
+                    "bootstrapTokens": {
+                      "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+                      "items": {
+                        "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                        "properties": {
+                          "description": {
+                            "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                            "type": "string"
+                          },
+                          "expires": {
+                            "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "groups": {
+                            "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "token": {
+                            "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                            "type": "string"
+                          },
+                          "ttl": {
+                            "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                            "type": "string"
+                          },
+                          "usages": {
+                            "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "token"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "localAPIEndpoint": {
+                      "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+                      "properties": {
+                        "advertiseAddress": {
+                          "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                          "type": "string"
+                        },
+                        "bindPort": {
+                          "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodeRegistration": {
+                      "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                      "properties": {
+                        "criSocket": {
+                          "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                          "type": "string"
+                        },
+                        "ignorePreflightErrors": {
+                          "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "imagePullPolicy": {
+                          "description": "ImagePullPolicy specifies the policy for image pulling during kubeadm \"init\" and \"join\" operations. The value of this field must be one of \"Always\", \"IfNotPresent\" or \"Never\". Defaults to \"IfNotPresent\". This can be used only with Kubernetes version equal to 1.22 and later.",
+                          "enum": [
+                            "Always",
+                            "IfNotPresent",
+                            "Never"
+                          ],
+                          "type": "string"
+                        },
+                        "kubeletExtraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                          "type": "string"
+                        },
+                        "taints": {
+                          "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.",
+                          "items": {
+                            "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                            "properties": {
+                              "effect": {
+                                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Required. The taint key to be applied to a node.",
+                                "type": "string"
+                              },
+                              "timeAdded": {
+                                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The taint value corresponding to the taint key.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "effect",
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "patches": {
+                      "description": "Patches contains options related to applying patches to components deployed by kubeadm during \"kubeadm init\". The minimum kubernetes version needed to support Patches is v1.22",
+                      "properties": {
+                        "directory": {
+                          "description": "Directory is a path to a directory that contains files named \"target[suffix][+patchtype].extension\". For example, \"kube-apiserver0+merge.yaml\" or just \"etcd.json\". \"target\" can be one of \"kube-apiserver\", \"kube-controller-manager\", \"kube-scheduler\", \"etcd\". \"patchtype\" can be one of \"strategic\" \"merge\" or \"json\" and they match the patch formats supported by kubectl. The default \"patchtype\" is \"strategic\". \"extension\" must be either \"json\" or \"yaml\". \"suffix\" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "skipPhases": {
+                      "description": "SkipPhases is a list of phases to skip during command execution. The list of phases can be obtained with the \"kubeadm init --help\" command. This option takes effect only on Kubernetes >=1.22.0.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "joinConfiguration": {
+                  "description": "JoinConfiguration is the kubeadm configuration for the join command",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                      "type": "string"
+                    },
+                    "caCertPath": {
+                      "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+                      "type": "string"
+                    },
+                    "controlPlane": {
+                      "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+                      "properties": {
+                        "localAPIEndpoint": {
+                          "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                          "properties": {
+                            "advertiseAddress": {
+                              "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                              "type": "string"
+                            },
+                            "bindPort": {
+                              "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "discovery": {
+                      "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+                      "properties": {
+                        "bootstrapToken": {
+                          "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                          "properties": {
+                            "apiServerEndpoint": {
+                              "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                              "type": "string"
+                            },
+                            "caCertHashes": {
+                              "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "token": {
+                              "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                              "type": "string"
+                            },
+                            "unsafeSkipCAVerification": {
+                              "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "token"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "file": {
+                          "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                          "properties": {
+                            "kubeConfigPath": {
+                              "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kubeConfigPath"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "timeout": {
+                          "description": "Timeout modifies the discovery timeout",
+                          "type": "string"
+                        },
+                        "tlsBootstrapToken": {
+                          "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "kind": {
+                      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "nodeRegistration": {
+                      "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                      "properties": {
+                        "criSocket": {
+                          "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                          "type": "string"
+                        },
+                        "ignorePreflightErrors": {
+                          "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "imagePullPolicy": {
+                          "description": "ImagePullPolicy specifies the policy for image pulling during kubeadm \"init\" and \"join\" operations. The value of this field must be one of \"Always\", \"IfNotPresent\" or \"Never\". Defaults to \"IfNotPresent\". This can be used only with Kubernetes version equal to 1.22 and later.",
+                          "enum": [
+                            "Always",
+                            "IfNotPresent",
+                            "Never"
+                          ],
+                          "type": "string"
+                        },
+                        "kubeletExtraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                          "type": "string"
+                        },
+                        "taints": {
+                          "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.",
+                          "items": {
+                            "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                            "properties": {
+                              "effect": {
+                                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Required. The taint key to be applied to a node.",
+                                "type": "string"
+                              },
+                              "timeAdded": {
+                                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The taint value corresponding to the taint key.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "effect",
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "patches": {
+                      "description": "Patches contains options related to applying patches to components deployed by kubeadm during \"kubeadm join\". The minimum kubernetes version needed to support Patches is v1.22",
+                      "properties": {
+                        "directory": {
+                          "description": "Directory is a path to a directory that contains files named \"target[suffix][+patchtype].extension\". For example, \"kube-apiserver0+merge.yaml\" or just \"etcd.json\". \"target\" can be one of \"kube-apiserver\", \"kube-controller-manager\", \"kube-scheduler\", \"etcd\". \"patchtype\" can be one of \"strategic\" \"merge\" or \"json\" and they match the patch formats supported by kubectl. The default \"patchtype\" is \"strategic\". \"extension\" must be either \"json\" or \"yaml\". \"suffix\" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "skipPhases": {
+                      "description": "SkipPhases is a list of phases to skip during command execution. The list of phases can be obtained with the \"kubeadm init --help\" command. This option takes effect only on Kubernetes >=1.22.0.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "mounts": {
+                  "description": "Mounts specifies a list of mount points to be setup.",
+                  "items": {
+                    "description": "MountPoints defines input for generated mounts in cloud-init.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "ntp": {
+                  "description": "NTP specifies NTP configuration",
+                  "properties": {
+                    "enabled": {
+                      "description": "Enabled specifies whether NTP should be enabled",
+                      "type": "boolean"
+                    },
+                    "servers": {
+                      "description": "Servers specifies which NTP servers to use",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "postKubeadmCommands": {
+                  "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "preKubeadmCommands": {
+                  "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "useExperimentalRetryJoin": {
+                  "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055. \n Deprecated: This experimental fix is no longer needed and this field will be removed in a future release. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml",
+                  "type": "boolean"
+                },
+                "users": {
+                  "description": "Users specifies extra users to add",
+                  "items": {
+                    "description": "User defines the input for a generated user in cloud-init.",
+                    "properties": {
+                      "gecos": {
+                        "description": "Gecos specifies the gecos to use for the user",
+                        "type": "string"
+                      },
+                      "groups": {
+                        "description": "Groups specifies the additional groups for the user",
+                        "type": "string"
+                      },
+                      "homeDir": {
+                        "description": "HomeDir specifies the home directory to use for the user",
+                        "type": "string"
+                      },
+                      "inactive": {
+                        "description": "Inactive specifies whether to mark the user as inactive",
+                        "type": "boolean"
+                      },
+                      "lockPassword": {
+                        "description": "LockPassword specifies if password login should be disabled",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name specifies the user name",
+                        "type": "string"
+                      },
+                      "passwd": {
+                        "description": "Passwd specifies a hashed password for the user",
+                        "type": "string"
+                      },
+                      "passwdFrom": {
+                        "description": "PasswdFrom is a referenced source of passwd to populate the passwd.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents a secret that should populate this password.",
+                            "properties": {
+                              "key": {
+                                "description": "Key is the key in the secret's data map for this value.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "secret"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "primaryGroup": {
+                        "description": "PrimaryGroup specifies the primary group for the user",
+                        "type": "string"
+                      },
+                      "shell": {
+                        "description": "Shell specifies the user's shell",
+                        "type": "string"
+                      },
+                      "sshAuthorizedKeys": {
+                        "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "sudo": {
+                        "description": "Sudo specifies a sudo role for the user",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "verbosity": {
+                  "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/cluster_v1alpha1.json
+++ b/cluster.x-k8s.io/cluster_v1alpha1.json
@@ -1,0 +1,142 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "clusterNetwork": {
+          "description": "Cluster network configuration",
+          "properties": {
+            "pods": {
+              "description": "The network ranges from which Pod networks are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceDomain": {
+              "description": "Domain name for services.",
+              "type": "string"
+            },
+            "services": {
+              "description": "The network ranges from which service VIPs are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "services",
+            "pods",
+            "serviceDomain"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerSpec": {
+          "description": "Provider-specific serialized configuration to use during cluster creation. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field.",
+          "properties": {
+            "value": {
+              "description": "Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.",
+              "type": "object"
+            },
+            "valueFrom": {
+              "description": "Source for the provider configuration. Cannot be used if value is not empty.",
+              "properties": {
+                "machineClass": {
+                  "description": "The machine class from which the provider config should be sourced.",
+                  "properties": {
+                    "provider": {
+                      "description": "Provider is the name of the cloud-provider which MachineClass is intended for.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterNetwork"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "apiEndpoints": {
+          "description": "APIEndpoint represents the endpoint to communicate with the IP.",
+          "items": {
+            "properties": {
+              "host": {
+                "description": "The hostname on which the API server is serving.",
+                "type": "string"
+              },
+              "port": {
+                "description": "The port on which the API server is serving.",
+                "format": "int64",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "host",
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "errorMessage": {
+          "description": "If set, indicates that there is a problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "If set, indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "providerStatus": {
+          "description": "Provider-specific status. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+}

--- a/cluster.x-k8s.io/cluster_v1alpha2.json
+++ b/cluster.x-k8s.io/cluster_v1alpha2.json
@@ -1,0 +1,157 @@
+{
+  "description": "Cluster is the Schema for the clusters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterSpec defines the desired state of Cluster",
+      "properties": {
+        "clusterNetwork": {
+          "description": "Cluster network configuration",
+          "properties": {
+            "apiServerPort": {
+              "description": "APIServerPort specifies the port the API Server should bind to. Defaults to 6443.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "pods": {
+              "description": "The network ranges from which Pod networks are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceDomain": {
+              "description": "Domain name for services.",
+              "type": "string"
+            },
+            "services": {
+              "description": "The network ranges from which service VIPs are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterStatus defines the observed state of Cluster",
+      "properties": {
+        "apiEndpoints": {
+          "description": "APIEndpoints represents the endpoints to communicate with the control plane.",
+          "items": {
+            "description": "APIEndpoint represents a reachable Kubernetes API endpoint.",
+            "properties": {
+              "host": {
+                "description": "The hostname on which the API server is serving.",
+                "type": "string"
+              },
+              "port": {
+                "description": "The port on which the API server is serving.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "host",
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlPlaneInitialized": {
+          "description": "ControlPlaneInitialized defines if the control plane has been initialized.",
+          "type": "boolean"
+        },
+        "errorMessage": {
+          "description": "ErrorMessage indicates that there is a problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "ErrorReason indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/cluster_v1alpha3.json
+++ b/cluster.x-k8s.io/cluster_v1alpha3.json
@@ -1,0 +1,266 @@
+{
+  "description": "Cluster is the Schema for the clusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterSpec defines the desired state of Cluster.",
+      "properties": {
+        "clusterNetwork": {
+          "description": "Cluster network configuration.",
+          "properties": {
+            "apiServerPort": {
+              "description": "APIServerPort specifies the port the API Server should bind to. Defaults to 6443.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "pods": {
+              "description": "The network ranges from which Pod networks are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceDomain": {
+              "description": "Domain name for services.",
+              "type": "string"
+            },
+            "services": {
+              "description": "The network ranges from which service VIPs are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneRef": {
+          "description": "ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "paused": {
+          "description": "Paused can be used to prevent controllers from processing the Cluster and all its associated objects.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterStatus defines the observed state of Cluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the cluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlPlaneInitialized": {
+          "description": "ControlPlaneInitialized defines if the control plane has been initialized.",
+          "type": "boolean"
+        },
+        "controlPlaneReady": {
+          "description": "ControlPlaneReady defines if the control plane is ready.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of failure domain objects synced from the infrastructure provider.",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/cluster_v1alpha4.json
+++ b/cluster.x-k8s.io/cluster_v1alpha4.json
@@ -1,0 +1,375 @@
+{
+  "description": "Cluster is the Schema for the clusters API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterSpec defines the desired state of Cluster.",
+      "properties": {
+        "clusterNetwork": {
+          "description": "Cluster network configuration.",
+          "properties": {
+            "apiServerPort": {
+              "description": "APIServerPort specifies the port the API Server should bind to. Defaults to 6443.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "pods": {
+              "description": "The network ranges from which Pod networks are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceDomain": {
+              "description": "Domain name for services.",
+              "type": "string"
+            },
+            "services": {
+              "description": "The network ranges from which service VIPs are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneRef": {
+          "description": "ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "paused": {
+          "description": "Paused can be used to prevent controllers from processing the Cluster and all its associated objects.",
+          "type": "boolean"
+        },
+        "topology": {
+          "description": "This encapsulates the topology for the cluster. NOTE: It is required to enable the ClusterTopology feature gate flag to activate managed topologies support; this feature is highly experimental, and parts of it might still be not implemented.",
+          "properties": {
+            "class": {
+              "description": "The name of the ClusterClass object to create the topology.",
+              "type": "string"
+            },
+            "controlPlane": {
+              "description": "ControlPlane describes the cluster control plane.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass. \n This field is supported if and only if the control plane provider template referenced in the ClusterClass is Machine based.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "replicas": {
+                  "description": "Replicas is the number of control plane nodes. If the value is nil, the ControlPlane object is created without the number of Replicas and it's assumed that the control plane controller does not implement support for this field. When specified against a control plane provider that lacks support for this field, this value will be ignored.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rolloutAfter": {
+              "description": "RolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "version": {
+              "description": "The Kubernetes version of the cluster.",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Workers encapsulates the different constructs that form the worker nodes for the cluster.",
+              "properties": {
+                "machineDeployments": {
+                  "description": "MachineDeployments is a list of machine deployments in the cluster.",
+                  "items": {
+                    "description": "MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology. This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.",
+                    "properties": {
+                      "class": {
+                        "description": "Class is the name of the MachineDeploymentClass used to create the set of worker nodes. This should match one of the deployment classes defined in the ClusterClass object mentioned in the `Cluster.Spec.Class` field.",
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "description": "Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "description": "Name is the unique identifier for this MachineDeploymentTopology. The value is used with other unique identifiers to create a MachineDeployment's Name (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length, the values are hashed together.",
+                        "type": "string"
+                      },
+                      "replicas": {
+                        "description": "Replicas is the number of worker nodes belonging to this set. If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero) and it's assumed that an external entity (like cluster autoscaler) is responsible for the management of this value.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "class",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "class",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterStatus defines the observed state of Cluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the cluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlPlaneReady": {
+          "description": "ControlPlaneReady defines if the control plane is ready.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of failure domain objects synced from the infrastructure provider.",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/cluster_v1beta1.json
+++ b/cluster.x-k8s.io/cluster_v1beta1.json
@@ -1,0 +1,715 @@
+{
+  "description": "Cluster is the Schema for the clusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterSpec defines the desired state of Cluster.",
+      "properties": {
+        "clusterNetwork": {
+          "description": "Cluster network configuration.",
+          "properties": {
+            "apiServerPort": {
+              "description": "APIServerPort specifies the port the API Server should bind to. Defaults to 6443.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "pods": {
+              "description": "The network ranges from which Pod networks are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceDomain": {
+              "description": "Domain name for services.",
+              "type": "string"
+            },
+            "services": {
+              "description": "The network ranges from which service VIPs are allocated.",
+              "properties": {
+                "cidrBlocks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "cidrBlocks"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneRef": {
+          "description": "ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "paused": {
+          "description": "Paused can be used to prevent controllers from processing the Cluster and all its associated objects.",
+          "type": "boolean"
+        },
+        "topology": {
+          "description": "This encapsulates the topology for the cluster. NOTE: It is required to enable the ClusterTopology feature gate flag to activate managed topologies support; this feature is highly experimental, and parts of it might still be not implemented.",
+          "properties": {
+            "class": {
+              "description": "The name of the ClusterClass object to create the topology.",
+              "type": "string"
+            },
+            "controlPlane": {
+              "description": "ControlPlane describes the cluster control plane.",
+              "properties": {
+                "machineHealthCheck": {
+                  "description": "MachineHealthCheck allows to enable, disable and override the MachineHealthCheck configuration in the ClusterClass for this control plane.",
+                  "properties": {
+                    "enable": {
+                      "description": "Enable controls if a MachineHealthCheck should be created for the target machines. \n If false: No MachineHealthCheck will be created. \n If not set(default): A MachineHealthCheck will be created if it is defined here or in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created. \n If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will block if `enable` is true and no MachineHealthCheck definition is available.",
+                      "type": "boolean"
+                    },
+                    "maxUnhealthy": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "nodeStartupTimeout": {
+                      "description": "Machines older than this duration without a node will be considered to have failed and will be remediated. If you wish to disable this feature, set the value explicitly to 0.",
+                      "type": "string"
+                    },
+                    "remediationTemplate": {
+                      "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "unhealthyConditions": {
+                      "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy. The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+                      "items": {
+                        "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+                        "properties": {
+                          "status": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "timeout": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "timeout",
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "unhealthyRange": {
+                      "description": "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+                      "pattern": "^\\[[0-9]+-[0-9]+\\]$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "metadata": {
+                  "description": "Metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane if the ControlPlaneTemplate referenced by the ClusterClass is machine based. If not, it is applied only to the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "nodeDeletionTimeout": {
+                  "description": "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds.",
+                  "type": "string"
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "nodeVolumeDetachTimeout": {
+                  "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+                  "type": "string"
+                },
+                "replicas": {
+                  "description": "Replicas is the number of control plane nodes. If the value is nil, the ControlPlane object is created without the number of Replicas and it's assumed that the control plane controller does not implement support for this field. When specified against a control plane provider that lacks support for this field, this value will be ignored.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rolloutAfter": {
+              "description": "RolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "variables": {
+              "description": "Variables can be used to customize the Cluster through patches. They must comply to the corresponding VariableClasses defined in the ClusterClass.",
+              "items": {
+                "description": "ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a Variable definition in the ClusterClass `status` variables.",
+                "properties": {
+                  "definitionFrom": {
+                    "description": "DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass `.spec.patches` where the patch is external and provides external variables. This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the variable.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value of the variable. Note: the value will be validated against the schema of the corresponding ClusterClassVariable from the ClusterClass. Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools, i.e. it is not possible to have no type field. Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "version": {
+              "description": "The Kubernetes version of the cluster.",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Workers encapsulates the different constructs that form the worker nodes for the cluster.",
+              "properties": {
+                "machineDeployments": {
+                  "description": "MachineDeployments is a list of machine deployments in the cluster.",
+                  "items": {
+                    "description": "MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology. This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.",
+                    "properties": {
+                      "class": {
+                        "description": "Class is the name of the MachineDeploymentClass used to create the set of worker nodes. This should match one of the deployment classes defined in the ClusterClass object mentioned in the `Cluster.Spec.Class` field.",
+                        "type": "string"
+                      },
+                      "failureDomain": {
+                        "description": "FailureDomain is the failure domain the machines will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                        "type": "string"
+                      },
+                      "machineHealthCheck": {
+                        "description": "MachineHealthCheck allows to enable, disable and override the MachineHealthCheck configuration in the ClusterClass for this MachineDeployment.",
+                        "properties": {
+                          "enable": {
+                            "description": "Enable controls if a MachineHealthCheck should be created for the target machines. \n If false: No MachineHealthCheck will be created. \n If not set(default): A MachineHealthCheck will be created if it is defined here or in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created. \n If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will block if `enable` is true and no MachineHealthCheck definition is available.",
+                            "type": "boolean"
+                          },
+                          "maxUnhealthy": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "nodeStartupTimeout": {
+                            "description": "Machines older than this duration without a node will be considered to have failed and will be remediated. If you wish to disable this feature, set the value explicitly to 0.",
+                            "type": "string"
+                          },
+                          "remediationTemplate": {
+                            "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "API version of the referent.",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                "type": "string"
+                              },
+                              "resourceVersion": {
+                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "unhealthyConditions": {
+                            "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy. The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+                            "items": {
+                              "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+                              "properties": {
+                                "status": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "timeout": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "status",
+                                "timeout",
+                                "type"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "unhealthyRange": {
+                            "description": "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+                            "pattern": "^\\[[0-9]+-[0-9]+\\]$",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "metadata": {
+                        "description": "Metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "minReadySeconds": {
+                        "description": "Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "name": {
+                        "description": "Name is the unique identifier for this MachineDeploymentTopology. The value is used with other unique identifiers to create a MachineDeployment's Name (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length, the values are hashed together.",
+                        "type": "string"
+                      },
+                      "nodeDeletionTimeout": {
+                        "description": "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds.",
+                        "type": "string"
+                      },
+                      "nodeDrainTimeout": {
+                        "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                        "type": "string"
+                      },
+                      "nodeVolumeDetachTimeout": {
+                        "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+                        "type": "string"
+                      },
+                      "replicas": {
+                        "description": "Replicas is the number of worker nodes belonging to this set. If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to 1) and it's assumed that an external entity (like cluster autoscaler) is responsible for the management of this value.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "strategy": {
+                        "description": "The deployment strategy to use to replace existing machines with new ones.",
+                        "properties": {
+                          "rollingUpdate": {
+                            "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+                            "properties": {
+                              "deletePolicy": {
+                                "description": "DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are \"Random, \"Newest\", \"Oldest\" When no value is supplied, the default DeletePolicy of MachineSet is used",
+                                "enum": [
+                                  "Random",
+                                  "Newest",
+                                  "Oldest"
+                                ],
+                                "type": "string"
+                              },
+                              "maxSurge": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "maxUnavailable": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": {
+                            "description": "Type of deployment. Default is RollingUpdate.",
+                            "enum": [
+                              "RollingUpdate",
+                              "OnDelete"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "variables": {
+                        "description": "Variables can be used to customize the MachineDeployment through patches.",
+                        "properties": {
+                          "overrides": {
+                            "description": "Overrides can be used to override Cluster level variables.",
+                            "items": {
+                              "description": "ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a Variable definition in the ClusterClass `status` variables.",
+                              "properties": {
+                                "definitionFrom": {
+                                  "description": "DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass `.spec.patches` where the patch is external and provides external variables. This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the variable.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value of the variable. Note: the value will be validated against the schema of the corresponding ClusterClassVariable from the ClusterClass. Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools, i.e. it is not possible to have no type field. Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "class",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "class",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterStatus defines the observed state of Cluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the cluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlPlaneReady": {
+          "description": "ControlPlaneReady defines if the control plane is ready.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of failure domain objects synced from the infrastructure provider.",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/clusterclass_v1alpha4.json
+++ b/cluster.x-k8s.io/clusterclass_v1alpha4.json
@@ -1,0 +1,333 @@
+{
+  "description": "ClusterClass is a template which can be used to create managed topologies. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterClassSpec describes the desired state of the ClusterClass.",
+      "properties": {
+        "controlPlane": {
+          "description": "ControlPlane is a reference to a local struct that holds the details for provisioning the Control Plane for the Cluster.",
+          "properties": {
+            "machineInfrastructure": {
+              "description": "MachineTemplate defines the metadata and infrastructure information for control plane machines. \n This field is supported if and only if the control plane provider template referenced above is Machine based and supports setting replicas.",
+              "properties": {
+                "ref": {
+                  "description": "Ref is a required reference to a custom resource offered by a provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "ref"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "metadata": {
+              "description": "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the topology. \n This field is supported if and only if the control plane provider template referenced is Machine based.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ref": {
+              "description": "Ref is a required reference to a custom resource offered by a provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "ref"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "infrastructure": {
+          "description": "Infrastructure is a reference to a provider-specific template that holds the details for provisioning infrastructure specific cluster for the underlying provider. The underlying provider is responsible for the implementation of the template to an infrastructure cluster.",
+          "properties": {
+            "ref": {
+              "description": "Ref is a required reference to a custom resource offered by a provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "ref"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "workers": {
+          "description": "Workers describes the worker nodes for the cluster. It is a collection of node types which can be used to create the worker nodes of the cluster.",
+          "properties": {
+            "machineDeployments": {
+              "description": "MachineDeployments is a list of machine deployment classes that can be used to create a set of worker nodes.",
+              "items": {
+                "description": "MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster provisioned using the `ClusterClass`.",
+                "properties": {
+                  "class": {
+                    "description": "Class denotes a type of worker node present in the cluster, this name MUST be unique within a ClusterClass and can be referenced in the Cluster to create a managed MachineDeployment.",
+                    "type": "string"
+                  },
+                  "template": {
+                    "description": "Template is a local struct containing a collection of templates for creation of MachineDeployment objects representing a set of worker nodes.",
+                    "properties": {
+                      "bootstrap": {
+                        "description": "Bootstrap contains the bootstrap template reference to be used for the creation of worker Machines.",
+                        "properties": {
+                          "ref": {
+                            "description": "Ref is a required reference to a custom resource offered by a provider.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "API version of the referent.",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                "type": "string"
+                              },
+                              "resourceVersion": {
+                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "ref"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "infrastructure": {
+                        "description": "Infrastructure contains the infrastructure template reference to be used for the creation of worker Machines.",
+                        "properties": {
+                          "ref": {
+                            "description": "Ref is a required reference to a custom resource offered by a provider.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "API version of the referent.",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                "type": "string"
+                              },
+                              "resourceVersion": {
+                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "ref"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "metadata": {
+                        "description": "Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the topology.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "bootstrap",
+                      "infrastructure"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "class",
+                  "template"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/clusterclass_v1beta1.json
+++ b/cluster.x-k8s.io/clusterclass_v1beta1.json
@@ -1,0 +1,1117 @@
+{
+  "description": "ClusterClass is a template which can be used to create managed topologies.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterClassSpec describes the desired state of the ClusterClass.",
+      "properties": {
+        "controlPlane": {
+          "description": "ControlPlane is a reference to a local struct that holds the details for provisioning the Control Plane for the Cluster.",
+          "properties": {
+            "machineHealthCheck": {
+              "description": "MachineHealthCheck defines a MachineHealthCheck for this ControlPlaneClass. This field is supported if and only if the ControlPlane provider template referenced above is Machine based and supports setting replicas.",
+              "properties": {
+                "maxUnhealthy": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "nodeStartupTimeout": {
+                  "description": "Machines older than this duration without a node will be considered to have failed and will be remediated. If you wish to disable this feature, set the value explicitly to 0.",
+                  "type": "string"
+                },
+                "remediationTemplate": {
+                  "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "unhealthyConditions": {
+                  "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy. The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+                  "items": {
+                    "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+                    "properties": {
+                      "status": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "status",
+                      "timeout",
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "unhealthyRange": {
+                  "description": "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+                  "pattern": "^\\[[0-9]+-[0-9]+\\]$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "machineInfrastructure": {
+              "description": "MachineInfrastructure defines the metadata and infrastructure information for control plane machines. \n This field is supported if and only if the control plane provider template referenced above is Machine based and supports setting replicas.",
+              "properties": {
+                "ref": {
+                  "description": "Ref is a required reference to a custom resource offered by a provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "ref"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "metadata": {
+              "description": "Metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane if the ControlPlaneTemplate referenced is machine based. If not, it is applied only to the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the topology. \n This field is supported if and only if the control plane provider template referenced is Machine based.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeDeletionTimeout": {
+              "description": "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds. NOTE: This value can be overridden while defining a Cluster.Topology.",
+              "type": "string"
+            },
+            "nodeDrainTimeout": {
+              "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout` NOTE: This value can be overridden while defining a Cluster.Topology.",
+              "type": "string"
+            },
+            "nodeVolumeDetachTimeout": {
+              "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations. NOTE: This value can be overridden while defining a Cluster.Topology.",
+              "type": "string"
+            },
+            "ref": {
+              "description": "Ref is a required reference to a custom resource offered by a provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "ref"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "infrastructure": {
+          "description": "Infrastructure is a reference to a provider-specific template that holds the details for provisioning infrastructure specific cluster for the underlying provider. The underlying provider is responsible for the implementation of the template to an infrastructure cluster.",
+          "properties": {
+            "ref": {
+              "description": "Ref is a required reference to a custom resource offered by a provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "ref"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "patches": {
+          "description": "Patches defines the patches which are applied to customize referenced templates of a ClusterClass. Note: Patches will be applied in the order of the array.",
+          "items": {
+            "description": "ClusterClassPatch defines a patch which is applied to customize the referenced templates.",
+            "properties": {
+              "definitions": {
+                "description": "Definitions define inline patches. Note: Patches will be applied in the order of the array. Note: Exactly one of Definitions or External must be set.",
+                "items": {
+                  "description": "PatchDefinition defines a patch which is applied to customize the referenced templates.",
+                  "properties": {
+                    "jsonPatches": {
+                      "description": "JSONPatches defines the patches which should be applied on the templates matching the selector. Note: Patches will be applied in the order of the array.",
+                      "items": {
+                        "description": "JSONPatch defines a JSON patch.",
+                        "properties": {
+                          "op": {
+                            "description": "Op defines the operation of the patch. Note: Only `add`, `replace` and `remove` are supported.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path defines the path of the patch. Note: Only the spec of a template can be patched, thus the path has to start with /spec/. Note: For now the only allowed array modifications are `append` and `prepend`, i.e.: * for op: `add`: only index 0 (prepend) and - (append) are allowed * for op: `replace` or `remove`: no indexes are allowed",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value defines the value of the patch. Note: Either Value or ValueFrom is required for add and replace operations. Only one of them is allowed to be set at the same time. Note: We have to use apiextensionsv1.JSON instead of our JSON type, because controller-tools has a hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type (unset type field). Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "valueFrom": {
+                            "description": "ValueFrom defines the value of the patch. Note: Either Value or ValueFrom is required for add and replace operations. Only one of them is allowed to be set at the same time.",
+                            "properties": {
+                              "template": {
+                                "description": "Template is the Go template to be used to calculate the value. A template can reference variables defined in .spec.variables and builtin variables. Note: The template must evaluate to a valid YAML or JSON value.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable is the variable to be used as value. Variable can be one of the variables defined in .spec.variables or a builtin variable.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "op",
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "selector": {
+                      "description": "Selector defines on which templates the patch should be applied.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion filters templates by apiVersion.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind filters templates by kind.",
+                          "type": "string"
+                        },
+                        "matchResources": {
+                          "description": "MatchResources selects templates based on where they are referenced.",
+                          "properties": {
+                            "controlPlane": {
+                              "description": "ControlPlane selects templates referenced in .spec.ControlPlane. Note: this will match the controlPlane and also the controlPlane machineInfrastructure (depending on the kind and apiVersion).",
+                              "type": "boolean"
+                            },
+                            "infrastructureCluster": {
+                              "description": "InfrastructureCluster selects templates referenced in .spec.infrastructure.",
+                              "type": "boolean"
+                            },
+                            "machineDeploymentClass": {
+                              "description": "MachineDeploymentClass selects templates referenced in specific MachineDeploymentClasses in .spec.workers.machineDeployments.",
+                              "properties": {
+                                "names": {
+                                  "description": "Names selects templates by class names.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "apiVersion",
+                        "kind",
+                        "matchResources"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "jsonPatches",
+                    "selector"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "description": {
+                "description": "Description is a human-readable description of this patch.",
+                "type": "string"
+              },
+              "enabledIf": {
+                "description": "EnabledIf is a Go template to be used to calculate if a patch should be enabled. It can reference variables defined in .spec.variables and builtin variables. The patch will be enabled if the template evaluates to `true`, otherwise it will be disabled. If EnabledIf is not set, the patch will be enabled per default.",
+                "type": "string"
+              },
+              "external": {
+                "description": "External defines an external patch. Note: Exactly one of Definitions or External must be set.",
+                "properties": {
+                  "discoverVariablesExtension": {
+                    "description": "DiscoverVariablesExtension references an extension which is called to discover variables.",
+                    "type": "string"
+                  },
+                  "generateExtension": {
+                    "description": "GenerateExtension references an extension which is called to generate patches.",
+                    "type": "string"
+                  },
+                  "settings": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Settings defines key value pairs to be passed to the extensions. Values defined here take precedence over the values defined in the corresponding ExtensionConfig.",
+                    "type": "object"
+                  },
+                  "validateExtension": {
+                    "description": "ValidateExtension references an extension which is called to validate the topology.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name of the patch.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "variables": {
+          "description": "Variables defines the variables which can be configured in the Cluster topology and are then used in patches.",
+          "items": {
+            "description": "ClusterClassVariable defines a variable which can be configured in the Cluster topology and used in patches.",
+            "properties": {
+              "name": {
+                "description": "Name of the variable.",
+                "type": "string"
+              },
+              "required": {
+                "description": "Required specifies if the variable is required. Note: this applies to the variable as a whole and thus the top-level object defined in the schema. If nested fields are required, this will be specified inside the schema.",
+                "type": "boolean"
+              },
+              "schema": {
+                "description": "Schema defines the schema of the variable.",
+                "properties": {
+                  "openAPIV3Schema": {
+                    "description": "OpenAPIV3Schema defines the schema of a variable via OpenAPI v3 schema. The schema is a subset of the schema used in Kubernetes CRDs.",
+                    "properties": {
+                      "additionalProperties": {
+                        "description": "AdditionalProperties specifies the schema of values in a map (keys are always strings). NOTE: Can only be set if type is object. NOTE: AdditionalProperties is mutually exclusive with Properties. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "default": {
+                        "description": "Default is the default value of the variable. NOTE: Can be set for all types.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "description": {
+                        "description": "Description is a human-readable description of this variable.",
+                        "type": "string"
+                      },
+                      "enum": {
+                        "description": "Enum is the list of valid values of the variable. NOTE: Can be set for all types.",
+                        "items": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "type": "array"
+                      },
+                      "example": {
+                        "description": "Example is an example for this variable.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "exclusiveMaximum": {
+                        "description": "ExclusiveMaximum specifies if the Maximum is exclusive. NOTE: Can only be set if type is integer or number.",
+                        "type": "boolean"
+                      },
+                      "exclusiveMinimum": {
+                        "description": "ExclusiveMinimum specifies if the Minimum is exclusive. NOTE: Can only be set if type is integer or number.",
+                        "type": "boolean"
+                      },
+                      "format": {
+                        "description": "Format is an OpenAPI v3 format string. Unknown formats are ignored. For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using) https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go NOTE: Can only be set if type is string.",
+                        "type": "string"
+                      },
+                      "items": {
+                        "description": "Items specifies fields of an array. NOTE: Can only be set if type is array. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "maxItems": {
+                        "description": "MaxItems is the max length of an array variable. NOTE: Can only be set if type is array.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "maxLength": {
+                        "description": "MaxLength is the max length of a string variable. NOTE: Can only be set if type is string.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "maximum": {
+                        "description": "Maximum is the maximum of an integer or number variable. If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum. If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum. NOTE: Can only be set if type is integer or number.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "minItems": {
+                        "description": "MinItems is the min length of an array variable. NOTE: Can only be set if type is array.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "minLength": {
+                        "description": "MinLength is the min length of a string variable. NOTE: Can only be set if type is string.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "minimum": {
+                        "description": "Minimum is the minimum of an integer or number variable. If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum. If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum. NOTE: Can only be set if type is integer or number.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "pattern": {
+                        "description": "Pattern is the regex which a string variable must match. NOTE: Can only be set if type is string.",
+                        "type": "string"
+                      },
+                      "properties": {
+                        "description": "Properties specifies fields of an object. NOTE: Can only be set if type is object. NOTE: Properties is mutually exclusive with AdditionalProperties. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "required": {
+                        "description": "Required specifies which fields of an object are required. NOTE: Can only be set if type is object.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "type": {
+                        "description": "Type is the type of the variable. Valid values are: object, array, string, integer, number or boolean.",
+                        "type": "string"
+                      },
+                      "uniqueItems": {
+                        "description": "UniqueItems specifies if items in an array must be unique. NOTE: Can only be set if type is array.",
+                        "type": "boolean"
+                      },
+                      "x-kubernetes-preserve-unknown-fields": {
+                        "description": "XPreserveUnknownFields allows setting fields in a variable object which are not defined in the variable schema. This affects fields recursively, except if nested properties or additionalProperties are specified in the schema.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "openAPIV3Schema"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name",
+              "required",
+              "schema"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "workers": {
+          "description": "Workers describes the worker nodes for the cluster. It is a collection of node types which can be used to create the worker nodes of the cluster.",
+          "properties": {
+            "machineDeployments": {
+              "description": "MachineDeployments is a list of machine deployment classes that can be used to create a set of worker nodes.",
+              "items": {
+                "description": "MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster provisioned using the `ClusterClass`.",
+                "properties": {
+                  "class": {
+                    "description": "Class denotes a type of worker node present in the cluster, this name MUST be unique within a ClusterClass and can be referenced in the Cluster to create a managed MachineDeployment.",
+                    "type": "string"
+                  },
+                  "failureDomain": {
+                    "description": "FailureDomain is the failure domain the machines will be created in. Must match a key in the FailureDomains map stored on the cluster object. NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.",
+                    "type": "string"
+                  },
+                  "machineHealthCheck": {
+                    "description": "MachineHealthCheck defines a MachineHealthCheck for this MachineDeploymentClass.",
+                    "properties": {
+                      "maxUnhealthy": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "nodeStartupTimeout": {
+                        "description": "Machines older than this duration without a node will be considered to have failed and will be remediated. If you wish to disable this feature, set the value explicitly to 0.",
+                        "type": "string"
+                      },
+                      "remediationTemplate": {
+                        "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                            "type": "string"
+                          },
+                          "resourceVersion": {
+                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                          },
+                          "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "unhealthyConditions": {
+                        "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy. The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+                        "items": {
+                          "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+                          "properties": {
+                            "status": {
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "timeout": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status",
+                            "timeout",
+                            "type"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "unhealthyRange": {
+                        "description": "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+                        "pattern": "^\\[[0-9]+-[0-9]+\\]$",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "minReadySeconds": {
+                    "description": "Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready) NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "nodeDeletionTimeout": {
+                    "description": "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds. NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.",
+                    "type": "string"
+                  },
+                  "nodeDrainTimeout": {
+                    "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout` NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.",
+                    "type": "string"
+                  },
+                  "nodeVolumeDetachTimeout": {
+                    "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations. NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.",
+                    "type": "string"
+                  },
+                  "strategy": {
+                    "description": "The deployment strategy to use to replace existing machines with new ones. NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.",
+                    "properties": {
+                      "rollingUpdate": {
+                        "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+                        "properties": {
+                          "deletePolicy": {
+                            "description": "DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are \"Random, \"Newest\", \"Oldest\" When no value is supplied, the default DeletePolicy of MachineSet is used",
+                            "enum": [
+                              "Random",
+                              "Newest",
+                              "Oldest"
+                            ],
+                            "type": "string"
+                          },
+                          "maxSurge": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "maxUnavailable": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "description": "Type of deployment. Default is RollingUpdate.",
+                        "enum": [
+                          "RollingUpdate",
+                          "OnDelete"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "template": {
+                    "description": "Template is a local struct containing a collection of templates for creation of MachineDeployment objects representing a set of worker nodes.",
+                    "properties": {
+                      "bootstrap": {
+                        "description": "Bootstrap contains the bootstrap template reference to be used for the creation of worker Machines.",
+                        "properties": {
+                          "ref": {
+                            "description": "Ref is a required reference to a custom resource offered by a provider.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "API version of the referent.",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                "type": "string"
+                              },
+                              "resourceVersion": {
+                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "ref"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "infrastructure": {
+                        "description": "Infrastructure contains the infrastructure template reference to be used for the creation of worker Machines.",
+                        "properties": {
+                          "ref": {
+                            "description": "Ref is a required reference to a custom resource offered by a provider.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "API version of the referent.",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                "type": "string"
+                              },
+                              "resourceVersion": {
+                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "ref"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "metadata": {
+                        "description": "Metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the topology.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "bootstrap",
+                      "infrastructure"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "class",
+                  "template"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterClassStatus defines the observed state of the ClusterClass.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current observed state of the ClusterClass.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "variables": {
+          "description": "Variables is a list of ClusterClassStatusVariable that are defined for the ClusterClass.",
+          "items": {
+            "description": "ClusterClassStatusVariable defines a variable which appears in the status of a ClusterClass.",
+            "properties": {
+              "definitions": {
+                "description": "Definitions is a list of definitions for a variable.",
+                "items": {
+                  "description": "ClusterClassStatusVariableDefinition defines a variable which appears in the status of a ClusterClass.",
+                  "properties": {
+                    "from": {
+                      "description": "From specifies the origin of the variable definition. This will be `inline` for variables defined in the ClusterClass or the name of a patch defined in the ClusterClass for variables discovered from a DiscoverVariables runtime extensions.",
+                      "type": "string"
+                    },
+                    "required": {
+                      "description": "Required specifies if the variable is required. Note: this applies to the variable as a whole and thus the top-level object defined in the schema. If nested fields are required, this will be specified inside the schema.",
+                      "type": "boolean"
+                    },
+                    "schema": {
+                      "description": "Schema defines the schema of the variable.",
+                      "properties": {
+                        "openAPIV3Schema": {
+                          "description": "OpenAPIV3Schema defines the schema of a variable via OpenAPI v3 schema. The schema is a subset of the schema used in Kubernetes CRDs.",
+                          "properties": {
+                            "additionalProperties": {
+                              "description": "AdditionalProperties specifies the schema of values in a map (keys are always strings). NOTE: Can only be set if type is object. NOTE: AdditionalProperties is mutually exclusive with Properties. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "default": {
+                              "description": "Default is the default value of the variable. NOTE: Can be set for all types.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "description": {
+                              "description": "Description is a human-readable description of this variable.",
+                              "type": "string"
+                            },
+                            "enum": {
+                              "description": "Enum is the list of valid values of the variable. NOTE: Can be set for all types.",
+                              "items": {
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "type": "array"
+                            },
+                            "example": {
+                              "description": "Example is an example for this variable.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "exclusiveMaximum": {
+                              "description": "ExclusiveMaximum specifies if the Maximum is exclusive. NOTE: Can only be set if type is integer or number.",
+                              "type": "boolean"
+                            },
+                            "exclusiveMinimum": {
+                              "description": "ExclusiveMinimum specifies if the Minimum is exclusive. NOTE: Can only be set if type is integer or number.",
+                              "type": "boolean"
+                            },
+                            "format": {
+                              "description": "Format is an OpenAPI v3 format string. Unknown formats are ignored. For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using) https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go NOTE: Can only be set if type is string.",
+                              "type": "string"
+                            },
+                            "items": {
+                              "description": "Items specifies fields of an array. NOTE: Can only be set if type is array. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "maxItems": {
+                              "description": "MaxItems is the max length of an array variable. NOTE: Can only be set if type is array.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "maxLength": {
+                              "description": "MaxLength is the max length of a string variable. NOTE: Can only be set if type is string.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "maximum": {
+                              "description": "Maximum is the maximum of an integer or number variable. If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum. If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum. NOTE: Can only be set if type is integer or number.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "minItems": {
+                              "description": "MinItems is the min length of an array variable. NOTE: Can only be set if type is array.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "minLength": {
+                              "description": "MinLength is the min length of a string variable. NOTE: Can only be set if type is string.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "minimum": {
+                              "description": "Minimum is the minimum of an integer or number variable. If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum. If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum. NOTE: Can only be set if type is integer or number.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "pattern": {
+                              "description": "Pattern is the regex which a string variable must match. NOTE: Can only be set if type is string.",
+                              "type": "string"
+                            },
+                            "properties": {
+                              "description": "Properties specifies fields of an object. NOTE: Can only be set if type is object. NOTE: Properties is mutually exclusive with AdditionalProperties. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "required": {
+                              "description": "Required specifies which fields of an object are required. NOTE: Can only be set if type is object.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "type": {
+                              "description": "Type is the type of the variable. Valid values are: object, array, string, integer, number or boolean.",
+                              "type": "string"
+                            },
+                            "uniqueItems": {
+                              "description": "UniqueItems specifies if items in an array must be unique. NOTE: Can only be set if type is array.",
+                              "type": "boolean"
+                            },
+                            "x-kubernetes-preserve-unknown-fields": {
+                              "description": "XPreserveUnknownFields allows setting fields in a variable object which are not defined in the variable schema. This affects fields recursively, except if nested properties or additionalProperties are specified in the schema.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "openAPIV3Schema"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "from",
+                    "required",
+                    "schema"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "definitionsConflict": {
+                "description": "DefinitionsConflict specifies whether or not there are conflicting definitions for a single variable name.",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Name is the name of the variable.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "definitions",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machine_v1alpha1.json
+++ b/cluster.x-k8s.io/machine_v1alpha1.json
@@ -1,0 +1,177 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "configSource": {
+          "description": "ConfigSource is used to populate in the associated Node for dynamic kubelet config. This field already exists in Node, so any updates to it in the Machine spec will be automatically copied to the linked NodeRef from the status. The rest of dynamic kubelet config support should then work as-is.",
+          "type": "object"
+        },
+        "metadata": {
+          "description": "ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.",
+          "type": "object"
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+          "type": "string"
+        },
+        "providerSpec": {
+          "description": "ProviderSpec details Provider-specific configuration to use during node creation.",
+          "properties": {
+            "value": {
+              "description": "Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.",
+              "type": "object"
+            },
+            "valueFrom": {
+              "description": "Source for the provider configuration. Cannot be used if value is not empty.",
+              "properties": {
+                "machineClass": {
+                  "description": "The machine class from which the provider config should be sourced.",
+                  "properties": {
+                    "provider": {
+                      "description": "Provider is the name of the cloud-provider which MachineClass is intended for.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "taints": {
+          "description": "The list of the taints to be applied to the corresponding Node in additive manner. This list will not overwrite any other taints added to the Node on an ongoing basis by other entities. These taints should be actively reconciled e.g. if you ask the machine controller to apply a taint and then manually remove the taint the machine controller will put it back) but not have the machine controller remove any taints",
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "versions": {
+          "description": "Versions of key software to use. This field is optional at cluster creation time, and omitting the field indicates that the cluster installation tool should select defaults for the user. These defaults may differ based on the cluster installer, but the tool should populate the values it uses when persisting Machine objects. A Machine spec missing this field at runtime is invalid.",
+          "properties": {
+            "controlPlane": {
+              "description": "ControlPlane is the semantic version of the Kubernetes control plane to run. This should only be populated when the machine is a control plane.",
+              "type": "string"
+            },
+            "kubelet": {
+              "description": "Kubelet is the semantic version of kubelet to run",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kubelet"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "providerSpec"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "addresses": {
+          "description": "Addresses is a list of addresses assigned to the machine. Queried from cloud provider, if available.",
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions lists the conditions synced from the node conditions of the corresponding node-object. Machine-controller is responsible for keeping conditions up-to-date. MachineSet controller will be taking these conditions as a signal to decide if machine is healthy or needs to be replaced. Refer: https://kubernetes.io/docs/concepts/architecture/nodes/#condition",
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "errorMessage": {
+          "description": "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption.  This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured.  Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation.  This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured.  Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "lastOperation": {
+          "description": "LastOperation describes the last-operation performed by the machine-controller. This API should be useful as a history in terms of the latest operation performed on the specific machine. It should also convey the state of the latest-operation for example if it is still on-going, failed or completed successfully.",
+          "properties": {
+            "description": {
+              "description": "Description is the human-readable description of the last operation.",
+              "type": "string"
+            },
+            "lastUpdated": {
+              "description": "LastUpdated is the timestamp at which LastOperation API was last-updated.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "state": {
+              "description": "State is the current status of the last performed operation. E.g. Processing, Failed, Successful etc",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type is the type of operation which was last performed. E.g. Create, Delete, Update etc",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lastUpdated": {
+          "description": "LastUpdated identifies when this status was last observed.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "nodeRef": {
+          "description": "NodeRef will point to the corresponding Node if it exists.",
+          "type": "object"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        },
+        "providerStatus": {
+          "description": "ProviderStatus details a Provider-specific status. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field.",
+          "type": "object"
+        },
+        "versions": {
+          "description": "Versions specifies the current versions of software on the corresponding Node (if it exists). This is provided for a few reasons:  1) It is more convenient than checking the NodeRef, traversing it to    the Node, and finding the appropriate field in Node.Status.NodeInfo    (which uses different field names and formatting). 2) It removes some of the dependency on the structure of the Node,    so that if the structure of Node.Status.NodeInfo changes, only    machine controllers need to be updated, rather than every client    of the Machines API. 3) There is no other simple way to check the control plane    version. A client would have to connect directly to the apiserver    running on the target node in order to find out its version.",
+          "properties": {
+            "controlPlane": {
+              "description": "ControlPlane is the semantic version of the Kubernetes control plane to run. This should only be populated when the machine is a control plane.",
+              "type": "string"
+            },
+            "kubelet": {
+              "description": "Kubelet is the semantic version of kubelet to run",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kubelet"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+}

--- a/cluster.x-k8s.io/machine_v1alpha2.json
+++ b/cluster.x-k8s.io/machine_v1alpha2.json
@@ -1,0 +1,285 @@
+{
+  "description": "Machine is the Schema for the machines API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineSpec defines the desired state of Machine",
+      "properties": {
+        "bootstrap": {
+          "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+          "properties": {
+            "configRef": {
+              "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "data": {
+              "description": "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metadata": {
+          "description": "DEPRECATED: ObjectMeta has no function and isn't used anywhere.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+              "type": "object"
+            },
+            "generateName": {
+              "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+              "type": "object"
+            },
+            "name": {
+              "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+              "type": "string"
+            },
+            "ownerReferences": {
+              "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+              "items": {
+                "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                  },
+                  "blockOwnerDeletion": {
+                    "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                    "type": "boolean"
+                  },
+                  "controller": {
+                    "description": "If true, this reference points to the managing controller.",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "apiVersion",
+                  "kind",
+                  "name",
+                  "uid"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "bootstrap",
+        "infrastructureRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineStatus defines the observed state of Machine",
+      "properties": {
+        "addresses": {
+          "description": "Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bootstrapReady": {
+          "description": "BootstrapReady is the state of the bootstrap provider.",
+          "type": "boolean"
+        },
+        "errorMessage": {
+          "description": "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "lastUpdated": {
+          "description": "LastUpdated identifies when this status was last observed.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "nodeRef": {
+          "description": "NodeRef will point to the corresponding Node if it exists.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "phase": {
+          "description": "Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version specifies the current version of Kubernetes running on the corresponding Node. This is meant to be a means of bubbling up status from the Node to the Machine. It is entirely optional, but useful for end-user UX if it\u2019s present.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machine_v1alpha3.json
+++ b/cluster.x-k8s.io/machine_v1alpha3.json
@@ -1,0 +1,277 @@
+{
+  "description": "Machine is the Schema for the machines API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineSpec defines the desired state of Machine.",
+      "properties": {
+        "bootstrap": {
+          "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+          "properties": {
+            "configRef": {
+              "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "data": {
+              "description": "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName.",
+              "type": "string"
+            },
+            "dataSecretName": {
+              "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "failureDomain": {
+          "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+          "type": "string"
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "nodeDrainTimeout": {
+          "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "bootstrap",
+        "clusterName",
+        "infrastructureRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineStatus defines the observed state of Machine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bootstrapReady": {
+          "description": "BootstrapReady is the state of the bootstrap provider.",
+          "type": "boolean"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the Machine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "lastUpdated": {
+          "description": "LastUpdated identifies when the phase of the Machine last transitioned.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "nodeRef": {
+          "description": "NodeRef will point to the corresponding Node if it exists.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version specifies the current version of Kubernetes running on the corresponding Node. This is meant to be a means of bubbling up status from the Node to the Machine. It is entirely optional, but useful for end-user UX if it\u2019s present.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machine_v1alpha4.json
+++ b/cluster.x-k8s.io/machine_v1alpha4.json
@@ -1,0 +1,332 @@
+{
+  "description": "Machine is the Schema for the machines API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineSpec defines the desired state of Machine.",
+      "properties": {
+        "bootstrap": {
+          "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+          "properties": {
+            "configRef": {
+              "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "dataSecretName": {
+              "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "failureDomain": {
+          "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+          "type": "string"
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "nodeDrainTimeout": {
+          "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "bootstrap",
+        "clusterName",
+        "infrastructureRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineStatus defines the observed state of Machine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bootstrapReady": {
+          "description": "BootstrapReady is the state of the bootstrap provider.",
+          "type": "boolean"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the Machine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "lastUpdated": {
+          "description": "LastUpdated identifies when the phase of the Machine last transitioned.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "nodeInfo": {
+          "description": "NodeInfo is a set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info",
+          "properties": {
+            "architecture": {
+              "description": "The Architecture reported by the node",
+              "type": "string"
+            },
+            "bootID": {
+              "description": "Boot ID reported by the node.",
+              "type": "string"
+            },
+            "containerRuntimeVersion": {
+              "description": "ContainerRuntime Version reported by the node through runtime remote API (e.g. containerd://1.4.2).",
+              "type": "string"
+            },
+            "kernelVersion": {
+              "description": "Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).",
+              "type": "string"
+            },
+            "kubeProxyVersion": {
+              "description": "KubeProxy Version reported by the node.",
+              "type": "string"
+            },
+            "kubeletVersion": {
+              "description": "Kubelet Version reported by the node.",
+              "type": "string"
+            },
+            "machineID": {
+              "description": "MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html",
+              "type": "string"
+            },
+            "operatingSystem": {
+              "description": "The Operating System reported by the node",
+              "type": "string"
+            },
+            "osImage": {
+              "description": "OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).",
+              "type": "string"
+            },
+            "systemUUID": {
+              "description": "SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid",
+              "type": "string"
+            }
+          },
+          "required": [
+            "architecture",
+            "bootID",
+            "containerRuntimeVersion",
+            "kernelVersion",
+            "kubeProxyVersion",
+            "kubeletVersion",
+            "machineID",
+            "operatingSystem",
+            "osImage",
+            "systemUUID"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nodeRef": {
+          "description": "NodeRef will point to the corresponding Node if it exists.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version specifies the current version of Kubernetes running on the corresponding Node. This is meant to be a means of bubbling up status from the Node to the Machine. It is entirely optional, but useful for end-user UX if it\u2019s present.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machine_v1beta1.json
+++ b/cluster.x-k8s.io/machine_v1beta1.json
@@ -1,0 +1,342 @@
+{
+  "description": "Machine is the Schema for the machines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineSpec defines the desired state of Machine.",
+      "properties": {
+        "bootstrap": {
+          "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+          "properties": {
+            "configRef": {
+              "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "dataSecretName": {
+              "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "failureDomain": {
+          "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+          "type": "string"
+        },
+        "infrastructureRef": {
+          "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "nodeDeletionTimeout": {
+          "description": "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds.",
+          "type": "string"
+        },
+        "nodeDrainTimeout": {
+          "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+          "type": "string"
+        },
+        "nodeVolumeDetachTimeout": {
+          "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "bootstrap",
+        "clusterName",
+        "infrastructureRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineStatus defines the observed state of Machine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bootstrapReady": {
+          "description": "BootstrapReady is the state of the bootstrap provider.",
+          "type": "boolean"
+        },
+        "certificatesExpiryDate": {
+          "description": "CertificatesExpiryDate is the expiry date of the machine certificates. This value is only set for control plane machines.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the Machine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "lastUpdated": {
+          "description": "LastUpdated identifies when the phase of the Machine last transitioned.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "nodeInfo": {
+          "description": "NodeInfo is a set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info",
+          "properties": {
+            "architecture": {
+              "description": "The Architecture reported by the node",
+              "type": "string"
+            },
+            "bootID": {
+              "description": "Boot ID reported by the node.",
+              "type": "string"
+            },
+            "containerRuntimeVersion": {
+              "description": "ContainerRuntime Version reported by the node through runtime remote API (e.g. containerd://1.4.2).",
+              "type": "string"
+            },
+            "kernelVersion": {
+              "description": "Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).",
+              "type": "string"
+            },
+            "kubeProxyVersion": {
+              "description": "KubeProxy Version reported by the node.",
+              "type": "string"
+            },
+            "kubeletVersion": {
+              "description": "Kubelet Version reported by the node.",
+              "type": "string"
+            },
+            "machineID": {
+              "description": "MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html",
+              "type": "string"
+            },
+            "operatingSystem": {
+              "description": "The Operating System reported by the node",
+              "type": "string"
+            },
+            "osImage": {
+              "description": "OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).",
+              "type": "string"
+            },
+            "systemUUID": {
+              "description": "SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid",
+              "type": "string"
+            }
+          },
+          "required": [
+            "architecture",
+            "bootID",
+            "containerRuntimeVersion",
+            "kernelVersion",
+            "kubeProxyVersion",
+            "kubeletVersion",
+            "machineID",
+            "operatingSystem",
+            "osImage",
+            "systemUUID"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nodeRef": {
+          "description": "NodeRef will point to the corresponding Node if it exists.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machineclass_v1alpha1.json
+++ b/cluster.x-k8s.io/machineclass_v1alpha1.json
@@ -1,0 +1,22 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "providerSpec": {
+      "description": "Provider-specific configuration to use during node creation.",
+      "type": "object"
+    }
+  },
+  "required": [
+    "providerSpec"
+  ]
+}

--- a/cluster.x-k8s.io/machinedeployment_v1alpha1.json
+++ b/cluster.x-k8s.io/machinedeployment_v1alpha1.json
@@ -1,0 +1,216 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.",
+          "type": "object"
+        },
+        "strategy": {
+          "description": "The deployment strategy to use to replace existing machines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+              "properties": {
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "integer"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines."
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "integer"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines."
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of deployment. Currently the only supported strategy is \"RollingUpdate\". Default is RollingUpdate.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template describes the machines that will be created.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
+              "type": "object"
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+              "properties": {
+                "configSource": {
+                  "description": "ConfigSource is used to populate in the associated Node for dynamic kubelet config. This field already exists in Node, so any updates to it in the Machine spec will be automatically copied to the linked NodeRef from the status. The rest of dynamic kubelet config support should then work as-is.",
+                  "type": "object"
+                },
+                "metadata": {
+                  "description": "ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.",
+                  "type": "object"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "providerSpec": {
+                  "description": "ProviderSpec details Provider-specific configuration to use during node creation.",
+                  "properties": {
+                    "value": {
+                      "description": "Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.",
+                      "type": "object"
+                    },
+                    "valueFrom": {
+                      "description": "Source for the provider configuration. Cannot be used if value is not empty.",
+                      "properties": {
+                        "machineClass": {
+                          "description": "The machine class from which the provider config should be sourced.",
+                          "properties": {
+                            "provider": {
+                              "description": "Provider is the name of the cloud-provider which MachineClass is intended for.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "taints": {
+                  "description": "The list of the taints to be applied to the corresponding Node in additive manner. This list will not overwrite any other taints added to the Node on an ongoing basis by other entities. These taints should be actively reconciled e.g. if you ask the machine controller to apply a taint and then manually remove the taint the machine controller will put it back) but not have the machine controller remove any taints",
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "versions": {
+                  "description": "Versions of key software to use. This field is optional at cluster creation time, and omitting the field indicates that the cluster installation tool should select defaults for the user. These defaults may differ based on the cluster installer, but the tool should populate the values it uses when persisting Machine objects. A Machine spec missing this field at runtime is invalid.",
+                  "properties": {
+                    "controlPlane": {
+                      "description": "ControlPlane is the semantic version of the Kubernetes control plane to run. This should only be populated when the machine is a control plane.",
+                      "type": "string"
+                    },
+                    "kubelet": {
+                      "description": "Kubelet is the semantic version of kubelet to run",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kubelet"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "providerSpec"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "selector",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "Total number of ready machines targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+}

--- a/cluster.x-k8s.io/machinedeployment_v1alpha2.json
+++ b/cluster.x-k8s.io/machinedeployment_v1alpha2.json
@@ -1,0 +1,434 @@
+{
+  "description": "MachineDeployment is the Schema for the machinedeployments API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineDeploymentSpec defines the desired state of MachineDeployment",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "strategy": {
+          "description": "The deployment strategy to use to replace existing machines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+              "properties": {
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of deployment. Currently the only supported strategy is \"RollingUpdate\". Default is RollingUpdate.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template describes the machines that will be created.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "generateName": {
+                  "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                  "items": {
+                    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "description": "If true, this reference points to the managing controller.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "apiVersion",
+                      "kind",
+                      "name",
+                      "uid"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "data": {
+                      "description": "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "metadata": {
+                  "description": "DEPRECATED: ObjectMeta has no function and isn't used anywhere.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                      "type": "object"
+                    },
+                    "generateName": {
+                      "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                      "items": {
+                        "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "description": "If true, this reference points to the managing controller.",
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                            "type": "string"
+                          },
+                          "uid": {
+                            "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "apiVersion",
+                          "kind",
+                          "name",
+                          "uid"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "selector",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineDeploymentStatus defines the observed state of MachineDeployment",
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "Total number of ready machines targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machinedeployment_v1alpha3.json
+++ b/cluster.x-k8s.io/machinedeployment_v1alpha3.json
@@ -1,0 +1,392 @@
+{
+  "description": "MachineDeployment is the Schema for the machinedeployments API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineDeploymentSpec defines the desired state of MachineDeployment.",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "strategy": {
+          "description": "The deployment strategy to use to replace existing machines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+              "properties": {
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of deployment. Currently the only supported strategy is \"RollingUpdate\". Default is RollingUpdate.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template describes the machines that will be created.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "generateName": {
+                  "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "items": {
+                    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "description": "If true, this reference points to the managing controller.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "apiVersion",
+                      "kind",
+                      "name",
+                      "uid"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "data": {
+                      "description": "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName.",
+                      "type": "string"
+                    },
+                    "dataSecretName": {
+                      "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterName": {
+                  "description": "ClusterName is the name of the Cluster this object belongs to.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                  "type": "string"
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "clusterName",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterName",
+        "selector",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineDeploymentStatus defines the observed state of MachineDeployment.",
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of a MachineDeployment (ScalingUp, ScalingDown, Running, Failed, or Unknown).",
+          "type": "string"
+        },
+        "readyReplicas": {
+          "description": "Total number of ready machines targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machinedeployment_v1alpha4.json
+++ b/cluster.x-k8s.io/machinedeployment_v1alpha4.json
@@ -1,0 +1,388 @@
+{
+  "description": "MachineDeployment is the Schema for the machinedeployments API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineDeploymentSpec defines the desired state of MachineDeployment.",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "default": 1,
+          "description": "Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "strategy": {
+          "description": "The deployment strategy to use to replace existing machines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+              "properties": {
+                "deletePolicy": {
+                  "description": "DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are \"Random, \"Newest\", \"Oldest\" When no value is supplied, the default DeletePolicy of MachineSet is used",
+                  "enum": [
+                    "Random",
+                    "Newest",
+                    "Oldest"
+                  ],
+                  "type": "string"
+                },
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of deployment. Default is RollingUpdate.",
+              "enum": [
+                "RollingUpdate",
+                "OnDelete"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template describes the machines that will be created.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "dataSecretName": {
+                      "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterName": {
+                  "description": "ClusterName is the name of the Cluster this object belongs to.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                  "type": "string"
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "clusterName",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterName",
+        "selector",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineDeploymentStatus defines the observed state of MachineDeployment.",
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the MachineDeployment.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of a MachineDeployment (ScalingUp, ScalingDown, Running, Failed, or Unknown).",
+          "type": "string"
+        },
+        "readyReplicas": {
+          "description": "Total number of ready machines targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machinedeployment_v1beta1.json
+++ b/cluster.x-k8s.io/machinedeployment_v1beta1.json
@@ -1,0 +1,401 @@
+{
+  "description": "MachineDeployment is the Schema for the machinedeployments API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineDeploymentSpec defines the desired state of MachineDeployment.",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Number of desired machines. This is a pointer to distinguish between explicit zero and not specified. \n Defaults to: * if the Kubernetes autoscaler min size and max size annotations are set: - if it's a new MachineDeployment, use min size - if the replicas field of the old MachineDeployment is < min size, use min size - if the replicas field of the old MachineDeployment is > max size, use max size - if the replicas field of the old MachineDeployment is in the (min size, max size) range, keep the value from the oldMD * otherwise use 1 Note: Defaulting will be run whenever the replicas field is not set: * A new MachineDeployment is created with replicas not set. * On an existing MachineDeployment the replicas field was first set and is now unset. Those cases are especially relevant for the following Kubernetes autoscaler use cases: * A new MachineDeployment is created and replicas should be managed by the autoscaler * An existing MachineDeployment which initially wasn't controlled by the autoscaler should be later controlled by the autoscaler",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "rolloutAfter": {
+          "description": "RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the MachineDeployment. Example: In the YAML the time can be specified in the RFC3339 format. To specify the rolloutAfter target as March 9, 2023, at 9 am UTC use \"2023-03-09T09:00:00Z\".",
+          "format": "date-time",
+          "type": "string"
+        },
+        "selector": {
+          "description": "Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "strategy": {
+          "description": "The deployment strategy to use to replace existing machines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+              "properties": {
+                "deletePolicy": {
+                  "description": "DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are \"Random, \"Newest\", \"Oldest\" When no value is supplied, the default DeletePolicy of MachineSet is used",
+                  "enum": [
+                    "Random",
+                    "Newest",
+                    "Oldest"
+                  ],
+                  "type": "string"
+                },
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of deployment. Default is RollingUpdate.",
+              "enum": [
+                "RollingUpdate",
+                "OnDelete"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template describes the machines that will be created.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "dataSecretName": {
+                      "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterName": {
+                  "description": "ClusterName is the name of the Cluster this object belongs to.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                  "type": "string"
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "nodeDeletionTimeout": {
+                  "description": "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds.",
+                  "type": "string"
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "nodeVolumeDetachTimeout": {
+                  "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "clusterName",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterName",
+        "selector",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineDeploymentStatus defines the observed state of MachineDeployment.",
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the MachineDeployment.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of a MachineDeployment (ScalingUp, ScalingDown, Running, Failed, or Unknown).",
+          "type": "string"
+        },
+        "readyReplicas": {
+          "description": "Total number of ready machines targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated machines targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machinehealthcheck_v1alpha3.json
+++ b/cluster.x-k8s.io/machinehealthcheck_v1alpha3.json
@@ -1,0 +1,236 @@
+{
+  "description": "MachineHealthCheck is the Schema for the machinehealthchecks API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of machine health check policy",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "maxUnhealthy": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+          "x-kubernetes-int-or-string": true
+        },
+        "nodeStartupTimeout": {
+          "description": "Machines older than this duration without a node will be considered to have failed and will be remediated.",
+          "type": "string"
+        },
+        "remediationTemplate": {
+          "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "Label selector to match machines whose health will be exercised",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "unhealthyConditions": {
+          "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+          "items": {
+            "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+            "properties": {
+              "status": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "timeout": {
+                "type": "string"
+              },
+              "type": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "timeout",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "clusterName",
+        "selector",
+        "unhealthyConditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of MachineHealthCheck resource",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the MachineHealthCheck.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentHealthy": {
+          "description": "total number of healthy machines counted by this machine health check",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "expectedMachines": {
+          "description": "total number of machines counted by this machine health check",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "remediationsAllowed": {
+          "description": "RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "targets": {
+          "description": "Targets shows the current list of machines the machine health check is watching",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machinehealthcheck_v1alpha4.json
+++ b/cluster.x-k8s.io/machinehealthcheck_v1alpha4.json
@@ -1,0 +1,241 @@
+{
+  "description": "MachineHealthCheck is the Schema for the machinehealthchecks API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of machine health check policy",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "maxUnhealthy": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+          "x-kubernetes-int-or-string": true
+        },
+        "nodeStartupTimeout": {
+          "description": "Machines older than this duration without a node will be considered to have failed and will be remediated. If not set, this value is defaulted to 10 minutes. If you wish to disable this feature, set the value explicitly to 0.",
+          "type": "string"
+        },
+        "remediationTemplate": {
+          "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "Label selector to match machines whose health will be exercised",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "unhealthyConditions": {
+          "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+          "items": {
+            "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+            "properties": {
+              "status": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "timeout": {
+                "type": "string"
+              },
+              "type": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "timeout",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "unhealthyRange": {
+          "description": "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+          "pattern": "^\\[[0-9]+-[0-9]+\\]$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "clusterName",
+        "selector",
+        "unhealthyConditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of MachineHealthCheck resource",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the MachineHealthCheck.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentHealthy": {
+          "description": "total number of healthy machines counted by this machine health check",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "expectedMachines": {
+          "description": "total number of machines counted by this machine health check",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "remediationsAllowed": {
+          "description": "RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "targets": {
+          "description": "Targets shows the current list of machines the machine health check is watching",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machinehealthcheck_v1beta1.json
+++ b/cluster.x-k8s.io/machinehealthcheck_v1beta1.json
@@ -1,0 +1,242 @@
+{
+  "description": "MachineHealthCheck is the Schema for the machinehealthchecks API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of machine health check policy",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "maxUnhealthy": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+          "x-kubernetes-int-or-string": true
+        },
+        "nodeStartupTimeout": {
+          "description": "Machines older than this duration without a node will be considered to have failed and will be remediated. If not set, this value is defaulted to 10 minutes. If you wish to disable this feature, set the value explicitly to 0.",
+          "type": "string"
+        },
+        "remediationTemplate": {
+          "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "Label selector to match machines whose health will be exercised",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "unhealthyConditions": {
+          "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+          "items": {
+            "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+            "properties": {
+              "status": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "timeout": {
+                "type": "string"
+              },
+              "type": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "timeout",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "unhealthyRange": {
+          "description": "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+          "pattern": "^\\[[0-9]+-[0-9]+\\]$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "clusterName",
+        "selector",
+        "unhealthyConditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of MachineHealthCheck resource",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the MachineHealthCheck.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentHealthy": {
+          "description": "total number of healthy machines counted by this machine health check",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "expectedMachines": {
+          "description": "total number of machines counted by this machine health check",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "remediationsAllowed": {
+          "description": "RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "targets": {
+          "description": "Targets shows the current list of machines the machine health check is watching",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machinepool_v1alpha3.json
+++ b/cluster.x-k8s.io/machinepool_v1alpha3.json
@@ -1,0 +1,432 @@
+{
+  "description": "MachinePool is the Schema for the machinepools API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachinePoolSpec defines the desired state of MachinePool.",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "failureDomains": {
+          "description": "FailureDomains is the list of failure domains this MachinePool should be attached to.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created machine instances should be ready. Defaults to 0 (machine instance will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "replicas": {
+          "description": "Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "strategy": {
+          "description": "The deployment strategy to use to replace existing machine instances with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+              "properties": {
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of deployment. Currently the only supported strategy is \"RollingUpdate\". Default is RollingUpdate.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template describes the machines that will be created.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "generateName": {
+                  "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "items": {
+                    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "description": "If true, this reference points to the managing controller.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "apiVersion",
+                      "kind",
+                      "name",
+                      "uid"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "data": {
+                      "description": "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName.",
+                      "type": "string"
+                    },
+                    "dataSecretName": {
+                      "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterName": {
+                  "description": "ClusterName is the name of the Cluster this object belongs to.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                  "type": "string"
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "clusterName",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterName",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachinePoolStatus defines the observed state of MachinePool.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this MachinePool.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "bootstrapReady": {
+          "description": "BootstrapReady is the state of the bootstrap provider.",
+          "type": "boolean"
+        },
+        "conditions": {
+          "description": "Conditions define the current service state of the MachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "nodeRefs": {
+          "description": "NodeRefs will point to the corresponding Nodes if it they exist.",
+          "items": {
+            "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. \n Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "fieldPath": {
+                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                "type": "string"
+              },
+              "resourceVersion": {
+                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is \"Ready\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machine instances targeted by this machine pool. This is the total number of machine instances that are still required for the machine pool to have 100% available capacity. They may either be machine instances that are running but not yet available or machine instances that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machinepool_v1alpha4.json
+++ b/cluster.x-k8s.io/machinepool_v1alpha4.json
@@ -1,0 +1,332 @@
+{
+  "description": "MachinePool is the Schema for the machinepools API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachinePoolSpec defines the desired state of MachinePool.",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "failureDomains": {
+          "description": "FailureDomains is the list of failure domains this MachinePool should be attached to.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created machine instances should be ready. Defaults to 0 (machine instance will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "replicas": {
+          "description": "Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "template": {
+          "description": "Template describes the machines that will be created.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "dataSecretName": {
+                      "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterName": {
+                  "description": "ClusterName is the name of the Cluster this object belongs to.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                  "type": "string"
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "clusterName",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterName",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachinePoolStatus defines the observed state of MachinePool.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this MachinePool.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "bootstrapReady": {
+          "description": "BootstrapReady is the state of the bootstrap provider.",
+          "type": "boolean"
+        },
+        "conditions": {
+          "description": "Conditions define the current service state of the MachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "nodeRefs": {
+          "description": "NodeRefs will point to the corresponding Nodes if it they exist.",
+          "items": {
+            "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. \n Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "fieldPath": {
+                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                "type": "string"
+              },
+              "resourceVersion": {
+                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is \"Ready\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machine instances targeted by this machine pool. This is the total number of machine instances that are still required for the machine pool to have 100% available capacity. They may either be machine instances that are running but not yet available or machine instances that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machinepool_v1beta1.json
+++ b/cluster.x-k8s.io/machinepool_v1beta1.json
@@ -1,0 +1,341 @@
+{
+  "description": "MachinePool is the Schema for the machinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachinePoolSpec defines the desired state of MachinePool.",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "failureDomains": {
+          "description": "FailureDomains is the list of failure domains this MachinePool should be attached to.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created machine instances should be ready. Defaults to 0 (machine instance will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "replicas": {
+          "description": "Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "template": {
+          "description": "Template describes the machines that will be created.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "dataSecretName": {
+                      "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterName": {
+                  "description": "ClusterName is the name of the Cluster this object belongs to.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                  "type": "string"
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "nodeDeletionTimeout": {
+                  "description": "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds.",
+                  "type": "string"
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "nodeVolumeDetachTimeout": {
+                  "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "clusterName",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterName",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachinePoolStatus defines the observed state of MachinePool.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this MachinePool.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "bootstrapReady": {
+          "description": "BootstrapReady is the state of the bootstrap provider.",
+          "type": "boolean"
+        },
+        "conditions": {
+          "description": "Conditions define the current service state of the MachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage indicates that there is a problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "infrastructureReady": {
+          "description": "InfrastructureReady is the state of the infrastructure provider.",
+          "type": "boolean"
+        },
+        "nodeRefs": {
+          "description": "NodeRefs will point to the corresponding Nodes if it they exist.",
+          "items": {
+            "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. \n Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "fieldPath": {
+                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                "type": "string"
+              },
+              "resourceVersion": {
+                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.",
+          "type": "string"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is \"Ready\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machine instances targeted by this machine pool. This is the total number of machine instances that are still required for the machine pool to have 100% available capacity. They may either be machine instances that are running but not yet available or machine instances that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machineset_v1alpha1.json
+++ b/cluster.x-k8s.io/machineset_v1alpha1.json
@@ -1,0 +1,175 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "deletePolicy": {
+          "description": "DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+          "enum": [
+            "Random",
+            "Newest",
+            "Oldest"
+          ],
+          "type": "string"
+        },
+        "minReadySeconds": {
+          "description": "MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+          "type": "object"
+        },
+        "template": {
+          "description": "Template is the object that describes the machine that will be created if insufficient replicas are detected.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
+              "type": "object"
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+              "properties": {
+                "configSource": {
+                  "description": "ConfigSource is used to populate in the associated Node for dynamic kubelet config. This field already exists in Node, so any updates to it in the Machine spec will be automatically copied to the linked NodeRef from the status. The rest of dynamic kubelet config support should then work as-is.",
+                  "type": "object"
+                },
+                "metadata": {
+                  "description": "ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.",
+                  "type": "object"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "providerSpec": {
+                  "description": "ProviderSpec details Provider-specific configuration to use during node creation.",
+                  "properties": {
+                    "value": {
+                      "description": "Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.",
+                      "type": "object"
+                    },
+                    "valueFrom": {
+                      "description": "Source for the provider configuration. Cannot be used if value is not empty.",
+                      "properties": {
+                        "machineClass": {
+                          "description": "The machine class from which the provider config should be sourced.",
+                          "properties": {
+                            "provider": {
+                              "description": "Provider is the name of the cloud-provider which MachineClass is intended for.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "taints": {
+                  "description": "The list of the taints to be applied to the corresponding Node in additive manner. This list will not overwrite any other taints added to the Node on an ongoing basis by other entities. These taints should be actively reconciled e.g. if you ask the machine controller to apply a taint and then manually remove the taint the machine controller will put it back) but not have the machine controller remove any taints",
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "versions": {
+                  "description": "Versions of key software to use. This field is optional at cluster creation time, and omitting the field indicates that the cluster installation tool should select defaults for the user. These defaults may differ based on the cluster installer, but the tool should populate the values it uses when persisting Machine objects. A Machine spec missing this field at runtime is invalid.",
+                  "properties": {
+                    "controlPlane": {
+                      "description": "ControlPlane is the semantic version of the Kubernetes control plane to run. This should only be populated when the machine is a control plane.",
+                      "type": "string"
+                    },
+                    "kubelet": {
+                      "description": "Kubelet is the semantic version of kubelet to run",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kubelet"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "providerSpec"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "In the event that there is a terminal problem reconciling the replicas, both ErrorReason and ErrorMessage will be set. ErrorReason will be populated with a succinct value suitable for machine interpretation, while ErrorMessage will contain a more verbose string suitable for logging and human consumption.  These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured.  Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "fullyLabeledReplicas": {
+          "description": "The number of replicas that have labels matching the labels of the machine template of the MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed MachineSet.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is \"Ready\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+}

--- a/cluster.x-k8s.io/machineset_v1alpha2.json
+++ b/cluster.x-k8s.io/machineset_v1alpha2.json
@@ -1,0 +1,391 @@
+{
+  "description": "MachineSet is the Schema for the machinesets API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineSetSpec defines the desired state of MachineSet",
+      "properties": {
+        "deletePolicy": {
+          "description": "DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+          "enum": [
+            "Random",
+            "Newest",
+            "Oldest"
+          ],
+          "type": "string"
+        },
+        "minReadySeconds": {
+          "description": "MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template is the object that describes the machine that will be created if insufficient replicas are detected. Object references to custom resources resources are treated as templates.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "generateName": {
+                  "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                  "items": {
+                    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "description": "If true, this reference points to the managing controller.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "apiVersion",
+                      "kind",
+                      "name",
+                      "uid"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "data": {
+                      "description": "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "metadata": {
+                  "description": "DEPRECATED: ObjectMeta has no function and isn't used anywhere.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                      "type": "object"
+                    },
+                    "generateName": {
+                      "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                      "items": {
+                        "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "description": "If true, this reference points to the managing controller.",
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                            "type": "string"
+                          },
+                          "uid": {
+                            "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "apiVersion",
+                          "kind",
+                          "name",
+                          "uid"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineSetStatus defines the observed state of MachineSet",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "In the event that there is a terminal problem reconciling the replicas, both ErrorReason and ErrorMessage will be set. ErrorReason will be populated with a succinct value suitable for machine interpretation, while ErrorMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "fullyLabeledReplicas": {
+          "description": "The number of replicas that have labels matching the labels of the machine template of the MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed MachineSet.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is \"Ready\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        }
+      },
+      "required": [
+        "replicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machineset_v1alpha3.json
+++ b/cluster.x-k8s.io/machineset_v1alpha3.json
@@ -1,0 +1,342 @@
+{
+  "description": "MachineSet is the Schema for the machinesets API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineSetSpec defines the desired state of MachineSet.",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "deletePolicy": {
+          "description": "DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+          "enum": [
+            "Random",
+            "Newest",
+            "Oldest"
+          ],
+          "type": "string"
+        },
+        "minReadySeconds": {
+          "description": "MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template is the object that describes the machine that will be created if insufficient replicas are detected. Object references to custom resources are treated as templates.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "generateName": {
+                  "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. \n Deprecated: This field has no function and is going to be removed in a next release.",
+                  "items": {
+                    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "description": "If true, this reference points to the managing controller.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "apiVersion",
+                      "kind",
+                      "name",
+                      "uid"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "data": {
+                      "description": "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName.",
+                      "type": "string"
+                    },
+                    "dataSecretName": {
+                      "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterName": {
+                  "description": "ClusterName is the name of the Cluster this object belongs to.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                  "type": "string"
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "clusterName",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterName",
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineSetStatus defines the observed state of MachineSet.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "failureMessage": {
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "In the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "fullyLabeledReplicas": {
+          "description": "The number of replicas that have labels matching the labels of the machine template of the MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed MachineSet.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is \"Ready\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machineset_v1alpha4.json
+++ b/cluster.x-k8s.io/machineset_v1alpha4.json
@@ -1,0 +1,325 @@
+{
+  "description": "MachineSet is the Schema for the machinesets API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineSetSpec defines the desired state of MachineSet.",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "deletePolicy": {
+          "description": "DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+          "enum": [
+            "Random",
+            "Newest",
+            "Oldest"
+          ],
+          "type": "string"
+        },
+        "minReadySeconds": {
+          "description": "MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "default": 1,
+          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template is the object that describes the machine that will be created if insufficient replicas are detected. Object references to custom resources are treated as templates.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "dataSecretName": {
+                      "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterName": {
+                  "description": "ClusterName is the name of the Cluster this object belongs to.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                  "type": "string"
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "clusterName",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterName",
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineSetStatus defines the observed state of MachineSet.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the MachineSet.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "In the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "fullyLabeledReplicas": {
+          "description": "The number of replicas that have labels matching the labels of the machine template of the MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed MachineSet.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is \"Ready\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/cluster.x-k8s.io/machineset_v1beta1.json
+++ b/cluster.x-k8s.io/machineset_v1beta1.json
@@ -1,0 +1,334 @@
+{
+  "description": "MachineSet is the Schema for the machinesets API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineSetSpec defines the desired state of MachineSet.",
+      "properties": {
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "deletePolicy": {
+          "description": "DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+          "enum": [
+            "Random",
+            "Newest",
+            "Oldest"
+          ],
+          "type": "string"
+        },
+        "minReadySeconds": {
+          "description": "MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "default": 1,
+          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template is the object that describes the machine that will be created if insufficient replicas are detected. Object references to custom resources are treated as templates.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+              "properties": {
+                "bootstrap": {
+                  "description": "Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine\u2019s bootstrapping mechanism.",
+                  "properties": {
+                    "configRef": {
+                      "description": "ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "dataSecretName": {
+                      "description": "DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterName": {
+                  "description": "ClusterName is the name of the Cluster this object belongs to.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.",
+                  "type": "string"
+                },
+                "infrastructureRef": {
+                  "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "nodeDeletionTimeout": {
+                  "description": "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds.",
+                  "type": "string"
+                },
+                "nodeDrainTimeout": {
+                  "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                  "type": "string"
+                },
+                "nodeVolumeDetachTimeout": {
+                  "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bootstrap",
+                "clusterName",
+                "infrastructureRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterName",
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineSetStatus defines the observed state of MachineSet.",
+      "properties": {
+        "availableReplicas": {
+          "description": "The number of available replicas (ready for at least minReadySeconds) for this MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the MachineSet.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "In the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "fullyLabeledReplicas": {
+          "description": "The number of replicas that have labels matching the labels of the machine template of the MachineSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed MachineSet.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is \"Ready\".",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/clusterctl.cluster.x-k8s.io/provider_v1alpha3.json
+++ b/clusterctl.cluster.x-k8s.io/provider_v1alpha3.json
@@ -1,0 +1,33 @@
+{
+  "description": "Provider defines an entry in the provider inventory.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "providerName": {
+      "description": "ProviderName indicates the name of the provider.",
+      "type": "string"
+    },
+    "type": {
+      "description": "Type indicates the type of the provider. See ProviderType for a list of supported values",
+      "type": "string"
+    },
+    "version": {
+      "description": "Version indicates the component version.",
+      "type": "string"
+    },
+    "watchedNamespace": {
+      "description": "WatchedNamespace indicates the namespace where the provider controller is watching. If empty the provider controller is watching for objects in all namespaces. \n Deprecated: providers complying with the Cluster API v1alpha4 contract or above must watch all namespaces; this field will be removed in a future version of this API",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1alpha3.json
+++ b/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1alpha3.json
@@ -1,0 +1,1102 @@
+{
+  "description": "KubeadmControlPlane is the Schema for the KubeadmControlPlane API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.",
+      "properties": {
+        "infrastructureTemplate": {
+          "description": "InfrastructureTemplate is a required reference to a custom resource offered by an infrastructure provider.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "kubeadmConfigSpec": {
+          "description": "KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.",
+          "properties": {
+            "clusterConfiguration": {
+              "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+              "properties": {
+                "apiServer": {
+                  "description": "APIServer contains extra settings for the API server control plane component",
+                  "properties": {
+                    "certSANs": {
+                      "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                      "type": "object"
+                    },
+                    "extraVolumes": {
+                      "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                      "items": {
+                        "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                        "properties": {
+                          "hostPath": {
+                            "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                            "type": "string"
+                          },
+                          "mountPath": {
+                            "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the volume inside the pod template.",
+                            "type": "string"
+                          },
+                          "pathType": {
+                            "description": "PathType is the type of the HostPath.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly controls write access to the volume",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "hostPath",
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "timeoutForControlPlane": {
+                      "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "certificatesDir": {
+                  "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+                  "type": "string"
+                },
+                "clusterName": {
+                  "description": "The cluster name",
+                  "type": "string"
+                },
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+                  "type": "string"
+                },
+                "controllerManager": {
+                  "description": "ControllerManager contains extra settings for the controller manager control plane component",
+                  "properties": {
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                      "type": "object"
+                    },
+                    "extraVolumes": {
+                      "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                      "items": {
+                        "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                        "properties": {
+                          "hostPath": {
+                            "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                            "type": "string"
+                          },
+                          "mountPath": {
+                            "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the volume inside the pod template.",
+                            "type": "string"
+                          },
+                          "pathType": {
+                            "description": "PathType is the type of the HostPath.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly controls write access to the volume",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "hostPath",
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dns": {
+                  "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+                  "properties": {
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type defines the DNS add-on to be used",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "etcd": {
+                  "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+                  "properties": {
+                    "external": {
+                      "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                      "properties": {
+                        "caFile": {
+                          "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                          "type": "string"
+                        },
+                        "certFile": {
+                          "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                          "type": "string"
+                        },
+                        "endpoints": {
+                          "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "keyFile": {
+                          "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "caFile",
+                        "certFile",
+                        "endpoints",
+                        "keyFile"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "local": {
+                      "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                      "properties": {
+                        "dataDir": {
+                          "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                          "type": "string"
+                        },
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                          "type": "object"
+                        },
+                        "imageRepository": {
+                          "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                          "type": "string"
+                        },
+                        "imageTag": {
+                          "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                          "type": "string"
+                        },
+                        "peerCertSANs": {
+                          "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "serverCertSANs": {
+                          "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "featureGates": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "description": "FeatureGates enabled by the user.",
+                  "type": "object"
+                },
+                "imageRepository": {
+                  "description": "ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "kubernetesVersion": {
+                  "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+                  "type": "string"
+                },
+                "networking": {
+                  "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+                  "properties": {
+                    "dnsDomain": {
+                      "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                      "type": "string"
+                    },
+                    "podSubnet": {
+                      "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                      "type": "string"
+                    },
+                    "serviceSubnet": {
+                      "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "scheduler": {
+                  "description": "Scheduler contains extra settings for the scheduler control plane component",
+                  "properties": {
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                      "type": "object"
+                    },
+                    "extraVolumes": {
+                      "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                      "items": {
+                        "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                        "properties": {
+                          "hostPath": {
+                            "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                            "type": "string"
+                          },
+                          "mountPath": {
+                            "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the volume inside the pod template.",
+                            "type": "string"
+                          },
+                          "pathType": {
+                            "description": "PathType is the type of the HostPath.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly controls write access to the volume",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "hostPath",
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "useHyperKubeImage": {
+                  "description": "UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "diskSetup": {
+              "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+              "properties": {
+                "filesystems": {
+                  "description": "Filesystems specifies the list of file systems to setup.",
+                  "items": {
+                    "description": "Filesystem defines the file systems to be created.",
+                    "properties": {
+                      "device": {
+                        "description": "Device specifies the device name",
+                        "type": "string"
+                      },
+                      "extraOpts": {
+                        "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "filesystem": {
+                        "description": "Filesystem specifies the file system type.",
+                        "type": "string"
+                      },
+                      "label": {
+                        "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                        "type": "string"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                        "type": "boolean"
+                      },
+                      "partition": {
+                        "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                        "type": "string"
+                      },
+                      "replaceFS": {
+                        "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "device",
+                      "filesystem",
+                      "label"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "partitions": {
+                  "description": "Partitions specifies the list of the partitions to setup.",
+                  "items": {
+                    "description": "Partition defines how to create and layout a partition.",
+                    "properties": {
+                      "device": {
+                        "description": "Device is the name of the device.",
+                        "type": "string"
+                      },
+                      "layout": {
+                        "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                        "type": "boolean"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                        "type": "boolean"
+                      },
+                      "tableType": {
+                        "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "device",
+                      "layout"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "files": {
+              "description": "Files specifies extra files to be passed to user_data upon creation.",
+              "items": {
+                "description": "File defines the input for generating write_files in cloud-init.",
+                "properties": {
+                  "content": {
+                    "description": "Content is the actual content of the file.",
+                    "type": "string"
+                  },
+                  "contentFrom": {
+                    "description": "ContentFrom is a referenced source of content to populate the file.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents a secret that should populate this file.",
+                        "properties": {
+                          "key": {
+                            "description": "Key is the key in the secret's data map for this value.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "secret"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "encoding": {
+                    "description": "Encoding specifies the encoding of the file contents.",
+                    "enum": [
+                      "base64",
+                      "gzip",
+                      "gzip+base64"
+                    ],
+                    "type": "string"
+                  },
+                  "owner": {
+                    "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Path specifies the full path on disk where to store the file.",
+                    "type": "string"
+                  },
+                  "permissions": {
+                    "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "format": {
+              "description": "Format specifies the output format of the bootstrap data",
+              "enum": [
+                "cloud-config"
+              ],
+              "type": "string"
+            },
+            "initConfiguration": {
+              "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+              "properties": {
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "bootstrapTokens": {
+                  "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+                  "items": {
+                    "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                    "properties": {
+                      "description": {
+                        "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                        "type": "string"
+                      },
+                      "expires": {
+                        "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "groups": {
+                        "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "token": {
+                        "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                        "type": "string"
+                      },
+                      "ttl": {
+                        "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                        "type": "string"
+                      },
+                      "usages": {
+                        "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "token"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "localAPIEndpoint": {
+                  "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+                  "properties": {
+                    "advertiseAddress": {
+                      "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                      "type": "string"
+                    },
+                    "bindPort": {
+                      "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "advertiseAddress",
+                    "bindPort"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "nodeRegistration": {
+                  "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                  "properties": {
+                    "criSocket": {
+                      "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                      "type": "string"
+                    },
+                    "kubeletExtraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                      "type": "string"
+                    },
+                    "taints": {
+                      "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                      "items": {
+                        "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                        "properties": {
+                          "effect": {
+                            "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Required. The taint key to be applied to a node.",
+                            "type": "string"
+                          },
+                          "timeAdded": {
+                            "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "The taint value corresponding to the taint key.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "effect",
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "joinConfiguration": {
+              "description": "JoinConfiguration is the kubeadm configuration for the join command",
+              "properties": {
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "caCertPath": {
+                  "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+                  "type": "string"
+                },
+                "controlPlane": {
+                  "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+                  "properties": {
+                    "localAPIEndpoint": {
+                      "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                      "properties": {
+                        "advertiseAddress": {
+                          "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                          "type": "string"
+                        },
+                        "bindPort": {
+                          "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "advertiseAddress",
+                        "bindPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "discovery": {
+                  "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+                  "properties": {
+                    "bootstrapToken": {
+                      "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                      "properties": {
+                        "apiServerEndpoint": {
+                          "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                          "type": "string"
+                        },
+                        "caCertHashes": {
+                          "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "token": {
+                          "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                          "type": "string"
+                        },
+                        "unsafeSkipCAVerification": {
+                          "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "token",
+                        "unsafeSkipCAVerification"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "file": {
+                      "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                      "properties": {
+                        "kubeConfigPath": {
+                          "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kubeConfigPath"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "timeout": {
+                      "description": "Timeout modifies the discovery timeout",
+                      "type": "string"
+                    },
+                    "tlsBootstrapToken": {
+                      "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information TODO: revisit when there is defaulting from k/k",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "nodeRegistration": {
+                  "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                  "properties": {
+                    "criSocket": {
+                      "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                      "type": "string"
+                    },
+                    "kubeletExtraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                      "type": "string"
+                    },
+                    "taints": {
+                      "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                      "items": {
+                        "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                        "properties": {
+                          "effect": {
+                            "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Required. The taint key to be applied to a node.",
+                            "type": "string"
+                          },
+                          "timeAdded": {
+                            "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "The taint value corresponding to the taint key.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "effect",
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mounts": {
+              "description": "Mounts specifies a list of mount points to be setup.",
+              "items": {
+                "description": "MountPoints defines input for generated mounts in cloud-init.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "ntp": {
+              "description": "NTP specifies NTP configuration",
+              "properties": {
+                "enabled": {
+                  "description": "Enabled specifies whether NTP should be enabled",
+                  "type": "boolean"
+                },
+                "servers": {
+                  "description": "Servers specifies which NTP servers to use",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "postKubeadmCommands": {
+              "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "preKubeadmCommands": {
+              "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "useExperimentalRetryJoin": {
+              "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.",
+              "type": "boolean"
+            },
+            "users": {
+              "description": "Users specifies extra users to add",
+              "items": {
+                "description": "User defines the input for a generated user in cloud-init.",
+                "properties": {
+                  "gecos": {
+                    "description": "Gecos specifies the gecos to use for the user",
+                    "type": "string"
+                  },
+                  "groups": {
+                    "description": "Groups specifies the additional groups for the user",
+                    "type": "string"
+                  },
+                  "homeDir": {
+                    "description": "HomeDir specifies the home directory to use for the user",
+                    "type": "string"
+                  },
+                  "inactive": {
+                    "description": "Inactive specifies whether to mark the user as inactive",
+                    "type": "boolean"
+                  },
+                  "lockPassword": {
+                    "description": "LockPassword specifies if password login should be disabled",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Name specifies the user name",
+                    "type": "string"
+                  },
+                  "passwd": {
+                    "description": "Passwd specifies a hashed password for the user",
+                    "type": "string"
+                  },
+                  "primaryGroup": {
+                    "description": "PrimaryGroup specifies the primary group for the user",
+                    "type": "string"
+                  },
+                  "shell": {
+                    "description": "Shell specifies the user's shell",
+                    "type": "string"
+                  },
+                  "sshAuthorizedKeys": {
+                    "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sudo": {
+                    "description": "Sudo specifies a sudo role for the user",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "verbosity": {
+              "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nodeDrainTimeout": {
+          "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+          "type": "string"
+        },
+        "replicas": {
+          "description": "Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "rolloutStrategy": {
+          "description": "The RolloutStrategy to use to replace control plane machines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.",
+              "properties": {
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of rollout. Currently the only supported strategy is \"RollingUpdate\". Default is RollingUpdate.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "upgradeAfter": {
+          "description": "UpgradeAfter is a field to indicate an upgrade should be performed after the specified time even if no changes have been made to the KubeadmControlPlane",
+          "format": "date-time",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "infrastructureTemplate",
+        "kubeadmConfigSpec",
+        "version"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the KubeadmControlPlane.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a terminal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "initialized": {
+          "description": "Initialized denotes whether or not the control plane has the uploaded kubeadm-config configmap.",
+          "type": "boolean"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready denotes that the KubeadmControlPlane API Server is ready to receive requests.",
+          "type": "boolean"
+        },
+        "readyReplicas": {
+          "description": "Total number of fully running and ready control plane machines.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated machines targeted by this control plane (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated machines targeted by this control plane that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1alpha4.json
+++ b/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1alpha4.json
@@ -1,0 +1,1140 @@
+{
+  "description": "KubeadmControlPlane is the Schema for the KubeadmControlPlane API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.",
+      "properties": {
+        "kubeadmConfigSpec": {
+          "description": "KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.",
+          "properties": {
+            "clusterConfiguration": {
+              "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+              "properties": {
+                "apiServer": {
+                  "description": "APIServer contains extra settings for the API server control plane component",
+                  "properties": {
+                    "certSANs": {
+                      "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                      "type": "object"
+                    },
+                    "extraVolumes": {
+                      "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                      "items": {
+                        "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                        "properties": {
+                          "hostPath": {
+                            "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                            "type": "string"
+                          },
+                          "mountPath": {
+                            "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the volume inside the pod template.",
+                            "type": "string"
+                          },
+                          "pathType": {
+                            "description": "PathType is the type of the HostPath.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly controls write access to the volume",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "hostPath",
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "timeoutForControlPlane": {
+                      "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "certificatesDir": {
+                  "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+                  "type": "string"
+                },
+                "clusterName": {
+                  "description": "The cluster name",
+                  "type": "string"
+                },
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+                  "type": "string"
+                },
+                "controllerManager": {
+                  "description": "ControllerManager contains extra settings for the controller manager control plane component",
+                  "properties": {
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                      "type": "object"
+                    },
+                    "extraVolumes": {
+                      "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                      "items": {
+                        "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                        "properties": {
+                          "hostPath": {
+                            "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                            "type": "string"
+                          },
+                          "mountPath": {
+                            "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the volume inside the pod template.",
+                            "type": "string"
+                          },
+                          "pathType": {
+                            "description": "PathType is the type of the HostPath.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly controls write access to the volume",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "hostPath",
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dns": {
+                  "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+                  "properties": {
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "etcd": {
+                  "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+                  "properties": {
+                    "external": {
+                      "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                      "properties": {
+                        "caFile": {
+                          "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                          "type": "string"
+                        },
+                        "certFile": {
+                          "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                          "type": "string"
+                        },
+                        "endpoints": {
+                          "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "keyFile": {
+                          "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "caFile",
+                        "certFile",
+                        "endpoints",
+                        "keyFile"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "local": {
+                      "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                      "properties": {
+                        "dataDir": {
+                          "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                          "type": "string"
+                        },
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                          "type": "object"
+                        },
+                        "imageRepository": {
+                          "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                          "type": "string"
+                        },
+                        "imageTag": {
+                          "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                          "type": "string"
+                        },
+                        "peerCertSANs": {
+                          "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "serverCertSANs": {
+                          "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "featureGates": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "description": "FeatureGates enabled by the user.",
+                  "type": "object"
+                },
+                "imageRepository": {
+                  "description": "ImageRepository sets the container registry to pull images from. If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io` will be used for all the other images.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "kubernetesVersion": {
+                  "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+                  "type": "string"
+                },
+                "networking": {
+                  "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+                  "properties": {
+                    "dnsDomain": {
+                      "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                      "type": "string"
+                    },
+                    "podSubnet": {
+                      "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                      "type": "string"
+                    },
+                    "serviceSubnet": {
+                      "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "scheduler": {
+                  "description": "Scheduler contains extra settings for the scheduler control plane component",
+                  "properties": {
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                      "type": "object"
+                    },
+                    "extraVolumes": {
+                      "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                      "items": {
+                        "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                        "properties": {
+                          "hostPath": {
+                            "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                            "type": "string"
+                          },
+                          "mountPath": {
+                            "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the volume inside the pod template.",
+                            "type": "string"
+                          },
+                          "pathType": {
+                            "description": "PathType is the type of the HostPath.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly controls write access to the volume",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "hostPath",
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "diskSetup": {
+              "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+              "properties": {
+                "filesystems": {
+                  "description": "Filesystems specifies the list of file systems to setup.",
+                  "items": {
+                    "description": "Filesystem defines the file systems to be created.",
+                    "properties": {
+                      "device": {
+                        "description": "Device specifies the device name",
+                        "type": "string"
+                      },
+                      "extraOpts": {
+                        "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "filesystem": {
+                        "description": "Filesystem specifies the file system type.",
+                        "type": "string"
+                      },
+                      "label": {
+                        "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                        "type": "string"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                        "type": "boolean"
+                      },
+                      "partition": {
+                        "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                        "type": "string"
+                      },
+                      "replaceFS": {
+                        "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "device",
+                      "filesystem",
+                      "label"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "partitions": {
+                  "description": "Partitions specifies the list of the partitions to setup.",
+                  "items": {
+                    "description": "Partition defines how to create and layout a partition.",
+                    "properties": {
+                      "device": {
+                        "description": "Device is the name of the device.",
+                        "type": "string"
+                      },
+                      "layout": {
+                        "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                        "type": "boolean"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                        "type": "boolean"
+                      },
+                      "tableType": {
+                        "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "device",
+                      "layout"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "files": {
+              "description": "Files specifies extra files to be passed to user_data upon creation.",
+              "items": {
+                "description": "File defines the input for generating write_files in cloud-init.",
+                "properties": {
+                  "content": {
+                    "description": "Content is the actual content of the file.",
+                    "type": "string"
+                  },
+                  "contentFrom": {
+                    "description": "ContentFrom is a referenced source of content to populate the file.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents a secret that should populate this file.",
+                        "properties": {
+                          "key": {
+                            "description": "Key is the key in the secret's data map for this value.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "secret"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "encoding": {
+                    "description": "Encoding specifies the encoding of the file contents.",
+                    "enum": [
+                      "base64",
+                      "gzip",
+                      "gzip+base64"
+                    ],
+                    "type": "string"
+                  },
+                  "owner": {
+                    "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Path specifies the full path on disk where to store the file.",
+                    "type": "string"
+                  },
+                  "permissions": {
+                    "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "format": {
+              "description": "Format specifies the output format of the bootstrap data",
+              "enum": [
+                "cloud-config"
+              ],
+              "type": "string"
+            },
+            "initConfiguration": {
+              "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+              "properties": {
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "bootstrapTokens": {
+                  "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+                  "items": {
+                    "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                    "properties": {
+                      "description": {
+                        "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                        "type": "string"
+                      },
+                      "expires": {
+                        "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "groups": {
+                        "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "token": {
+                        "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                        "type": "string"
+                      },
+                      "ttl": {
+                        "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                        "type": "string"
+                      },
+                      "usages": {
+                        "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "token"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "localAPIEndpoint": {
+                  "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+                  "properties": {
+                    "advertiseAddress": {
+                      "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                      "type": "string"
+                    },
+                    "bindPort": {
+                      "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "nodeRegistration": {
+                  "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                  "properties": {
+                    "criSocket": {
+                      "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                      "type": "string"
+                    },
+                    "ignorePreflightErrors": {
+                      "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "kubeletExtraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                      "type": "string"
+                    },
+                    "taints": {
+                      "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                      "items": {
+                        "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                        "properties": {
+                          "effect": {
+                            "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Required. The taint key to be applied to a node.",
+                            "type": "string"
+                          },
+                          "timeAdded": {
+                            "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "The taint value corresponding to the taint key.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "effect",
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "joinConfiguration": {
+              "description": "JoinConfiguration is the kubeadm configuration for the join command",
+              "properties": {
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "caCertPath": {
+                  "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+                  "type": "string"
+                },
+                "controlPlane": {
+                  "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+                  "properties": {
+                    "localAPIEndpoint": {
+                      "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                      "properties": {
+                        "advertiseAddress": {
+                          "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                          "type": "string"
+                        },
+                        "bindPort": {
+                          "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "discovery": {
+                  "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+                  "properties": {
+                    "bootstrapToken": {
+                      "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                      "properties": {
+                        "apiServerEndpoint": {
+                          "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                          "type": "string"
+                        },
+                        "caCertHashes": {
+                          "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "token": {
+                          "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                          "type": "string"
+                        },
+                        "unsafeSkipCAVerification": {
+                          "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "token"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "file": {
+                      "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                      "properties": {
+                        "kubeConfigPath": {
+                          "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kubeConfigPath"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "timeout": {
+                      "description": "Timeout modifies the discovery timeout",
+                      "type": "string"
+                    },
+                    "tlsBootstrapToken": {
+                      "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "nodeRegistration": {
+                  "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                  "properties": {
+                    "criSocket": {
+                      "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                      "type": "string"
+                    },
+                    "ignorePreflightErrors": {
+                      "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "kubeletExtraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                      "type": "string"
+                    },
+                    "taints": {
+                      "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                      "items": {
+                        "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                        "properties": {
+                          "effect": {
+                            "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Required. The taint key to be applied to a node.",
+                            "type": "string"
+                          },
+                          "timeAdded": {
+                            "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "The taint value corresponding to the taint key.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "effect",
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mounts": {
+              "description": "Mounts specifies a list of mount points to be setup.",
+              "items": {
+                "description": "MountPoints defines input for generated mounts in cloud-init.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "ntp": {
+              "description": "NTP specifies NTP configuration",
+              "properties": {
+                "enabled": {
+                  "description": "Enabled specifies whether NTP should be enabled",
+                  "type": "boolean"
+                },
+                "servers": {
+                  "description": "Servers specifies which NTP servers to use",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "postKubeadmCommands": {
+              "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "preKubeadmCommands": {
+              "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "useExperimentalRetryJoin": {
+              "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.",
+              "type": "boolean"
+            },
+            "users": {
+              "description": "Users specifies extra users to add",
+              "items": {
+                "description": "User defines the input for a generated user in cloud-init.",
+                "properties": {
+                  "gecos": {
+                    "description": "Gecos specifies the gecos to use for the user",
+                    "type": "string"
+                  },
+                  "groups": {
+                    "description": "Groups specifies the additional groups for the user",
+                    "type": "string"
+                  },
+                  "homeDir": {
+                    "description": "HomeDir specifies the home directory to use for the user",
+                    "type": "string"
+                  },
+                  "inactive": {
+                    "description": "Inactive specifies whether to mark the user as inactive",
+                    "type": "boolean"
+                  },
+                  "lockPassword": {
+                    "description": "LockPassword specifies if password login should be disabled",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Name specifies the user name",
+                    "type": "string"
+                  },
+                  "passwd": {
+                    "description": "Passwd specifies a hashed password for the user",
+                    "type": "string"
+                  },
+                  "primaryGroup": {
+                    "description": "PrimaryGroup specifies the primary group for the user",
+                    "type": "string"
+                  },
+                  "shell": {
+                    "description": "Shell specifies the user's shell",
+                    "type": "string"
+                  },
+                  "sshAuthorizedKeys": {
+                    "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sudo": {
+                    "description": "Sudo specifies a sudo role for the user",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "verbosity": {
+              "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "machineTemplate": {
+          "description": "MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.",
+          "properties": {
+            "infrastructureRef": {
+              "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeDrainTimeout": {
+              "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+              "type": "string"
+            }
+          },
+          "required": [
+            "infrastructureRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "rolloutAfter": {
+          "description": "RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "rolloutStrategy": {
+          "default": {
+            "rollingUpdate": {
+              "maxSurge": 1
+            },
+            "type": "RollingUpdate"
+          },
+          "description": "The RolloutStrategy to use to replace control plane machines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.",
+              "properties": {
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of rollout. Currently the only supported strategy is \"RollingUpdate\". Default is RollingUpdate.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kubeadmConfigSpec",
+        "machineTemplate",
+        "version"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the KubeadmControlPlane.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a terminal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "initialized": {
+          "description": "Initialized denotes whether or not the control plane has the uploaded kubeadm-config configmap.",
+          "type": "boolean"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready denotes that the KubeadmControlPlane API Server is ready to receive requests.",
+          "type": "boolean"
+        },
+        "readyReplicas": {
+          "description": "Total number of fully running and ready control plane machines.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated machines targeted by this control plane (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated machines targeted by this control plane that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "version": {
+          "description": "Version represents the minimum Kubernetes version for the control plane machines in the cluster.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1beta1.json
+++ b/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1beta1.json
@@ -1,0 +1,1317 @@
+{
+  "description": "KubeadmControlPlane is the Schema for the KubeadmControlPlane API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.",
+      "properties": {
+        "kubeadmConfigSpec": {
+          "description": "KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.",
+          "properties": {
+            "clusterConfiguration": {
+              "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+              "properties": {
+                "apiServer": {
+                  "description": "APIServer contains extra settings for the API server control plane component",
+                  "properties": {
+                    "certSANs": {
+                      "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                      "type": "object"
+                    },
+                    "extraVolumes": {
+                      "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                      "items": {
+                        "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                        "properties": {
+                          "hostPath": {
+                            "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                            "type": "string"
+                          },
+                          "mountPath": {
+                            "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the volume inside the pod template.",
+                            "type": "string"
+                          },
+                          "pathType": {
+                            "description": "PathType is the type of the HostPath.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly controls write access to the volume",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "hostPath",
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "timeoutForControlPlane": {
+                      "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "certificatesDir": {
+                  "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+                  "type": "string"
+                },
+                "clusterName": {
+                  "description": "The cluster name",
+                  "type": "string"
+                },
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+                  "type": "string"
+                },
+                "controllerManager": {
+                  "description": "ControllerManager contains extra settings for the controller manager control plane component",
+                  "properties": {
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                      "type": "object"
+                    },
+                    "extraVolumes": {
+                      "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                      "items": {
+                        "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                        "properties": {
+                          "hostPath": {
+                            "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                            "type": "string"
+                          },
+                          "mountPath": {
+                            "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the volume inside the pod template.",
+                            "type": "string"
+                          },
+                          "pathType": {
+                            "description": "PathType is the type of the HostPath.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly controls write access to the volume",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "hostPath",
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dns": {
+                  "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+                  "properties": {
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "etcd": {
+                  "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+                  "properties": {
+                    "external": {
+                      "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                      "properties": {
+                        "caFile": {
+                          "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                          "type": "string"
+                        },
+                        "certFile": {
+                          "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                          "type": "string"
+                        },
+                        "endpoints": {
+                          "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "keyFile": {
+                          "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "caFile",
+                        "certFile",
+                        "endpoints",
+                        "keyFile"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "local": {
+                      "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                      "properties": {
+                        "dataDir": {
+                          "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                          "type": "string"
+                        },
+                        "extraArgs": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                          "type": "object"
+                        },
+                        "imageRepository": {
+                          "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                          "type": "string"
+                        },
+                        "imageTag": {
+                          "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                          "type": "string"
+                        },
+                        "peerCertSANs": {
+                          "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "serverCertSANs": {
+                          "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "featureGates": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "description": "FeatureGates enabled by the user.",
+                  "type": "object"
+                },
+                "imageRepository": {
+                  "description": "ImageRepository sets the container registry to pull images from. * If not set, the default registry of kubeadm will be used, i.e. * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0 * k8s.gcr.io (old registry): all older versions Please note that when imageRepository is not set we don't allow upgrades to versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use a newer patch version with the new registry instead (i.e. >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0). * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io` will be used for all the other images.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "kubernetesVersion": {
+                  "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+                  "type": "string"
+                },
+                "networking": {
+                  "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+                  "properties": {
+                    "dnsDomain": {
+                      "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                      "type": "string"
+                    },
+                    "podSubnet": {
+                      "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                      "type": "string"
+                    },
+                    "serviceSubnet": {
+                      "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "scheduler": {
+                  "description": "Scheduler contains extra settings for the scheduler control plane component",
+                  "properties": {
+                    "extraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                      "type": "object"
+                    },
+                    "extraVolumes": {
+                      "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                      "items": {
+                        "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                        "properties": {
+                          "hostPath": {
+                            "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                            "type": "string"
+                          },
+                          "mountPath": {
+                            "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the volume inside the pod template.",
+                            "type": "string"
+                          },
+                          "pathType": {
+                            "description": "PathType is the type of the HostPath.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "ReadOnly controls write access to the volume",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "hostPath",
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "diskSetup": {
+              "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+              "properties": {
+                "filesystems": {
+                  "description": "Filesystems specifies the list of file systems to setup.",
+                  "items": {
+                    "description": "Filesystem defines the file systems to be created.",
+                    "properties": {
+                      "device": {
+                        "description": "Device specifies the device name",
+                        "type": "string"
+                      },
+                      "extraOpts": {
+                        "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "filesystem": {
+                        "description": "Filesystem specifies the file system type.",
+                        "type": "string"
+                      },
+                      "label": {
+                        "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                        "type": "string"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                        "type": "boolean"
+                      },
+                      "partition": {
+                        "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                        "type": "string"
+                      },
+                      "replaceFS": {
+                        "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "device",
+                      "filesystem",
+                      "label"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "partitions": {
+                  "description": "Partitions specifies the list of the partitions to setup.",
+                  "items": {
+                    "description": "Partition defines how to create and layout a partition.",
+                    "properties": {
+                      "device": {
+                        "description": "Device is the name of the device.",
+                        "type": "string"
+                      },
+                      "layout": {
+                        "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                        "type": "boolean"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                        "type": "boolean"
+                      },
+                      "tableType": {
+                        "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "device",
+                      "layout"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "files": {
+              "description": "Files specifies extra files to be passed to user_data upon creation.",
+              "items": {
+                "description": "File defines the input for generating write_files in cloud-init.",
+                "properties": {
+                  "append": {
+                    "description": "Append specifies whether to append Content to existing file if Path exists.",
+                    "type": "boolean"
+                  },
+                  "content": {
+                    "description": "Content is the actual content of the file.",
+                    "type": "string"
+                  },
+                  "contentFrom": {
+                    "description": "ContentFrom is a referenced source of content to populate the file.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents a secret that should populate this file.",
+                        "properties": {
+                          "key": {
+                            "description": "Key is the key in the secret's data map for this value.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "secret"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "encoding": {
+                    "description": "Encoding specifies the encoding of the file contents.",
+                    "enum": [
+                      "base64",
+                      "gzip",
+                      "gzip+base64"
+                    ],
+                    "type": "string"
+                  },
+                  "owner": {
+                    "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Path specifies the full path on disk where to store the file.",
+                    "type": "string"
+                  },
+                  "permissions": {
+                    "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "format": {
+              "description": "Format specifies the output format of the bootstrap data",
+              "enum": [
+                "cloud-config",
+                "ignition"
+              ],
+              "type": "string"
+            },
+            "ignition": {
+              "description": "Ignition contains Ignition specific configuration.",
+              "properties": {
+                "containerLinuxConfig": {
+                  "description": "ContainerLinuxConfig contains CLC specific configuration.",
+                  "properties": {
+                    "additionalConfig": {
+                      "description": "AdditionalConfig contains additional configuration to be merged with the Ignition configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/",
+                      "type": "string"
+                    },
+                    "strict": {
+                      "description": "Strict controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "initConfiguration": {
+              "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+              "properties": {
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "bootstrapTokens": {
+                  "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+                  "items": {
+                    "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                    "properties": {
+                      "description": {
+                        "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                        "type": "string"
+                      },
+                      "expires": {
+                        "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "groups": {
+                        "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "token": {
+                        "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                        "type": "string"
+                      },
+                      "ttl": {
+                        "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                        "type": "string"
+                      },
+                      "usages": {
+                        "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "token"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "localAPIEndpoint": {
+                  "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+                  "properties": {
+                    "advertiseAddress": {
+                      "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                      "type": "string"
+                    },
+                    "bindPort": {
+                      "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "nodeRegistration": {
+                  "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                  "properties": {
+                    "criSocket": {
+                      "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                      "type": "string"
+                    },
+                    "ignorePreflightErrors": {
+                      "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "imagePullPolicy": {
+                      "description": "ImagePullPolicy specifies the policy for image pulling during kubeadm \"init\" and \"join\" operations. The value of this field must be one of \"Always\", \"IfNotPresent\" or \"Never\". Defaults to \"IfNotPresent\". This can be used only with Kubernetes version equal to 1.22 and later.",
+                      "enum": [
+                        "Always",
+                        "IfNotPresent",
+                        "Never"
+                      ],
+                      "type": "string"
+                    },
+                    "kubeletExtraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                      "type": "string"
+                    },
+                    "taints": {
+                      "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.",
+                      "items": {
+                        "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                        "properties": {
+                          "effect": {
+                            "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Required. The taint key to be applied to a node.",
+                            "type": "string"
+                          },
+                          "timeAdded": {
+                            "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "The taint value corresponding to the taint key.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "effect",
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "patches": {
+                  "description": "Patches contains options related to applying patches to components deployed by kubeadm during \"kubeadm init\". The minimum kubernetes version needed to support Patches is v1.22",
+                  "properties": {
+                    "directory": {
+                      "description": "Directory is a path to a directory that contains files named \"target[suffix][+patchtype].extension\". For example, \"kube-apiserver0+merge.yaml\" or just \"etcd.json\". \"target\" can be one of \"kube-apiserver\", \"kube-controller-manager\", \"kube-scheduler\", \"etcd\". \"patchtype\" can be one of \"strategic\" \"merge\" or \"json\" and they match the patch formats supported by kubectl. The default \"patchtype\" is \"strategic\". \"extension\" must be either \"json\" or \"yaml\". \"suffix\" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "skipPhases": {
+                  "description": "SkipPhases is a list of phases to skip during command execution. The list of phases can be obtained with the \"kubeadm init --help\" command. This option takes effect only on Kubernetes >=1.22.0.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "joinConfiguration": {
+              "description": "JoinConfiguration is the kubeadm configuration for the join command",
+              "properties": {
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "caCertPath": {
+                  "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+                  "type": "string"
+                },
+                "controlPlane": {
+                  "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+                  "properties": {
+                    "localAPIEndpoint": {
+                      "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                      "properties": {
+                        "advertiseAddress": {
+                          "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                          "type": "string"
+                        },
+                        "bindPort": {
+                          "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "discovery": {
+                  "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+                  "properties": {
+                    "bootstrapToken": {
+                      "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                      "properties": {
+                        "apiServerEndpoint": {
+                          "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                          "type": "string"
+                        },
+                        "caCertHashes": {
+                          "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "token": {
+                          "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                          "type": "string"
+                        },
+                        "unsafeSkipCAVerification": {
+                          "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "token"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "file": {
+                      "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                      "properties": {
+                        "kubeConfigPath": {
+                          "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kubeConfigPath"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "timeout": {
+                      "description": "Timeout modifies the discovery timeout",
+                      "type": "string"
+                    },
+                    "tlsBootstrapToken": {
+                      "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "nodeRegistration": {
+                  "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                  "properties": {
+                    "criSocket": {
+                      "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                      "type": "string"
+                    },
+                    "ignorePreflightErrors": {
+                      "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "imagePullPolicy": {
+                      "description": "ImagePullPolicy specifies the policy for image pulling during kubeadm \"init\" and \"join\" operations. The value of this field must be one of \"Always\", \"IfNotPresent\" or \"Never\". Defaults to \"IfNotPresent\". This can be used only with Kubernetes version equal to 1.22 and later.",
+                      "enum": [
+                        "Always",
+                        "IfNotPresent",
+                        "Never"
+                      ],
+                      "type": "string"
+                    },
+                    "kubeletExtraArgs": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                      "type": "string"
+                    },
+                    "taints": {
+                      "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.",
+                      "items": {
+                        "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                        "properties": {
+                          "effect": {
+                            "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Required. The taint key to be applied to a node.",
+                            "type": "string"
+                          },
+                          "timeAdded": {
+                            "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "The taint value corresponding to the taint key.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "effect",
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "patches": {
+                  "description": "Patches contains options related to applying patches to components deployed by kubeadm during \"kubeadm join\". The minimum kubernetes version needed to support Patches is v1.22",
+                  "properties": {
+                    "directory": {
+                      "description": "Directory is a path to a directory that contains files named \"target[suffix][+patchtype].extension\". For example, \"kube-apiserver0+merge.yaml\" or just \"etcd.json\". \"target\" can be one of \"kube-apiserver\", \"kube-controller-manager\", \"kube-scheduler\", \"etcd\". \"patchtype\" can be one of \"strategic\" \"merge\" or \"json\" and they match the patch formats supported by kubectl. The default \"patchtype\" is \"strategic\". \"extension\" must be either \"json\" or \"yaml\". \"suffix\" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "skipPhases": {
+                  "description": "SkipPhases is a list of phases to skip during command execution. The list of phases can be obtained with the \"kubeadm init --help\" command. This option takes effect only on Kubernetes >=1.22.0.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mounts": {
+              "description": "Mounts specifies a list of mount points to be setup.",
+              "items": {
+                "description": "MountPoints defines input for generated mounts in cloud-init.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "ntp": {
+              "description": "NTP specifies NTP configuration",
+              "properties": {
+                "enabled": {
+                  "description": "Enabled specifies whether NTP should be enabled",
+                  "type": "boolean"
+                },
+                "servers": {
+                  "description": "Servers specifies which NTP servers to use",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "postKubeadmCommands": {
+              "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "preKubeadmCommands": {
+              "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "useExperimentalRetryJoin": {
+              "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055. \n Deprecated: This experimental fix is no longer needed and this field will be removed in a future release. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml",
+              "type": "boolean"
+            },
+            "users": {
+              "description": "Users specifies extra users to add",
+              "items": {
+                "description": "User defines the input for a generated user in cloud-init.",
+                "properties": {
+                  "gecos": {
+                    "description": "Gecos specifies the gecos to use for the user",
+                    "type": "string"
+                  },
+                  "groups": {
+                    "description": "Groups specifies the additional groups for the user",
+                    "type": "string"
+                  },
+                  "homeDir": {
+                    "description": "HomeDir specifies the home directory to use for the user",
+                    "type": "string"
+                  },
+                  "inactive": {
+                    "description": "Inactive specifies whether to mark the user as inactive",
+                    "type": "boolean"
+                  },
+                  "lockPassword": {
+                    "description": "LockPassword specifies if password login should be disabled",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Name specifies the user name",
+                    "type": "string"
+                  },
+                  "passwd": {
+                    "description": "Passwd specifies a hashed password for the user",
+                    "type": "string"
+                  },
+                  "passwdFrom": {
+                    "description": "PasswdFrom is a referenced source of passwd to populate the passwd.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents a secret that should populate this password.",
+                        "properties": {
+                          "key": {
+                            "description": "Key is the key in the secret's data map for this value.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "secret"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "primaryGroup": {
+                    "description": "PrimaryGroup specifies the primary group for the user",
+                    "type": "string"
+                  },
+                  "shell": {
+                    "description": "Shell specifies the user's shell",
+                    "type": "string"
+                  },
+                  "sshAuthorizedKeys": {
+                    "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sudo": {
+                    "description": "Sudo specifies a sudo role for the user",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "verbosity": {
+              "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "machineTemplate": {
+          "description": "MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.",
+          "properties": {
+            "infrastructureRef": {
+              "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+              "properties": {
+                "apiVersion": {
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "fieldPath": {
+                  "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                  "type": "string"
+                },
+                "resourceVersion": {
+                  "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeDeletionTimeout": {
+              "description": "NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. If no value is provided, the default value for this property of the Machine resource will be used.",
+              "type": "string"
+            },
+            "nodeDrainTimeout": {
+              "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+              "type": "string"
+            },
+            "nodeVolumeDetachTimeout": {
+              "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "infrastructureRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "remediationStrategy": {
+          "description": "The RemediationStrategy that controls how control plane machine remediation happens.",
+          "properties": {
+            "maxRetry": {
+              "description": "MaxRetry is the Max number of retries while attempting to remediate an unhealthy machine. A retry happens when a machine that was created as a replacement for an unhealthy machine also fails. For example, given a control plane with three machines M1, M2, M3: \n M1 become unhealthy; remediation happens, and M1-1 is created as a replacement. If M1-1 (replacement of M1) has problems while bootstrapping it will become unhealthy, and then be remediated; such operation is considered a retry, remediation-retry #1. If M1-2 (replacement of M1-2) becomes unhealthy, remediation-retry #2 will happen, etc. \n A retry could happen only after RetryPeriod from the previous retry. If a machine is marked as unhealthy after MinHealthyPeriod from the previous remediation expired, this is not considered a retry anymore because the new issue is assumed unrelated from the previous one. \n If not set, the remedation will be retried infinitely.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "minHealthyPeriod": {
+              "description": "MinHealthyPeriod defines the duration after which KCP will consider any failure to a machine unrelated from the previous one. In this case the remediation is not considered a retry anymore, and thus the retry counter restarts from 0. For example, assuming MinHealthyPeriod is set to 1h (default) \n M1 become unhealthy; remediation happens, and M1-1 is created as a replacement. If M1-1 (replacement of M1) has problems within the 1hr after the creation, also this machine will be remediated and this operation is considered a retry - a problem related to the original issue happened to M1 -. \n If instead the problem on M1-1 is happening after MinHealthyPeriod expired, e.g. four days after m1-1 has been created as a remediation of M1, the problem on M1-1 is considered unrelated to the original issue happened to M1. \n If not set, this value is defaulted to 1h.",
+              "type": "string"
+            },
+            "retryPeriod": {
+              "description": "RetryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement for an unhealthy machine (a retry). \n If not set, a retry will happen immediately.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "rolloutAfter": {
+          "description": "RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane. Example: In the YAML the time can be specified in the RFC3339 format. To specify the rolloutAfter target as March 9, 2023, at 9 am UTC use \"2023-03-09T09:00:00Z\".",
+          "format": "date-time",
+          "type": "string"
+        },
+        "rolloutBefore": {
+          "description": "RolloutBefore is a field to indicate a rollout should be performed if the specified criteria is met.",
+          "properties": {
+            "certificatesExpiryDays": {
+              "description": "CertificatesExpiryDays indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "rolloutStrategy": {
+          "default": {
+            "rollingUpdate": {
+              "maxSurge": 1
+            },
+            "type": "RollingUpdate"
+          },
+          "description": "The RolloutStrategy to use to replace control plane machines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.",
+              "properties": {
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of rollout. Currently the only supported strategy is \"RollingUpdate\". Default is RollingUpdate.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version. Please note that if kubeadmConfigSpec.ClusterConfiguration.imageRepository is not set we don't allow upgrades to versions >= v1.22.0 for which kubeadm uses the old registry (k8s.gcr.io). Please use a newer patch version with the new registry instead. The default registries of kubeadm are: * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0 * k8s.gcr.io (old registry): all older versions",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kubeadmConfigSpec",
+        "machineTemplate",
+        "version"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the KubeadmControlPlane.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason indicates that there is a terminal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.",
+          "type": "string"
+        },
+        "initialized": {
+          "description": "Initialized denotes whether or not the control plane has the uploaded kubeadm-config configmap.",
+          "type": "boolean"
+        },
+        "lastRemediation": {
+          "description": "LastRemediation stores info about last remediation performed.",
+          "properties": {
+            "machine": {
+              "description": "Machine is the machine name of the latest machine being remediated.",
+              "type": "string"
+            },
+            "retryCount": {
+              "description": "RetryCount used to keep track of remediation retry for the last remediated machine. A retry happens when a machine that was created as a replacement for an unhealthy machine also fails.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "timestamp": {
+              "description": "Timestamp is when last remediation happened. It is represented in RFC3339 form and is in UTC.",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "required": [
+            "machine",
+            "retryCount",
+            "timestamp"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready denotes that the KubeadmControlPlane API Server is ready to receive requests.",
+          "type": "boolean"
+        },
+        "readyReplicas": {
+          "description": "Total number of fully running and ready control plane machines.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminated machines targeted by this control plane (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+          "type": "string"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminated machines targeted by this control plane that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "version": {
+          "description": "Version represents the minimum Kubernetes version for the control plane machines in the cluster.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/controlplane.cluster.x-k8s.io/kubeadmcontrolplanetemplate_v1alpha4.json
+++ b/controlplane.cluster.x-k8s.io/kubeadmcontrolplanetemplate_v1alpha4.json
@@ -1,0 +1,1064 @@
+{
+  "description": "KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmControlPlaneTemplateSpec defines the desired state of KubeadmControlPlaneTemplate.",
+      "properties": {
+        "template": {
+          "description": "KubeadmControlPlaneTemplateResource describes the data needed to create a KubeadmControlPlane from a template.",
+          "properties": {
+            "spec": {
+              "description": "KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.",
+              "properties": {
+                "kubeadmConfigSpec": {
+                  "description": "KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.",
+                  "properties": {
+                    "clusterConfiguration": {
+                      "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+                      "properties": {
+                        "apiServer": {
+                          "description": "APIServer contains extra settings for the API server control plane component",
+                          "properties": {
+                            "certSANs": {
+                              "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "extraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                              "type": "object"
+                            },
+                            "extraVolumes": {
+                              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                              "items": {
+                                "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                                "properties": {
+                                  "hostPath": {
+                                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                    "type": "string"
+                                  },
+                                  "mountPath": {
+                                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the volume inside the pod template.",
+                                    "type": "string"
+                                  },
+                                  "pathType": {
+                                    "description": "PathType is the type of the HostPath.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "ReadOnly controls write access to the volume",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "hostPath",
+                                  "mountPath",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "timeoutForControlPlane": {
+                              "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "apiVersion": {
+                          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                          "type": "string"
+                        },
+                        "certificatesDir": {
+                          "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+                          "type": "string"
+                        },
+                        "clusterName": {
+                          "description": "The cluster name",
+                          "type": "string"
+                        },
+                        "controlPlaneEndpoint": {
+                          "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+                          "type": "string"
+                        },
+                        "controllerManager": {
+                          "description": "ControllerManager contains extra settings for the controller manager control plane component",
+                          "properties": {
+                            "extraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                              "type": "object"
+                            },
+                            "extraVolumes": {
+                              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                              "items": {
+                                "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                                "properties": {
+                                  "hostPath": {
+                                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                    "type": "string"
+                                  },
+                                  "mountPath": {
+                                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the volume inside the pod template.",
+                                    "type": "string"
+                                  },
+                                  "pathType": {
+                                    "description": "PathType is the type of the HostPath.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "ReadOnly controls write access to the volume",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "hostPath",
+                                  "mountPath",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dns": {
+                          "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+                          "properties": {
+                            "imageRepository": {
+                              "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                              "type": "string"
+                            },
+                            "imageTag": {
+                              "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "etcd": {
+                          "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+                          "properties": {
+                            "external": {
+                              "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                              "properties": {
+                                "caFile": {
+                                  "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                                  "type": "string"
+                                },
+                                "certFile": {
+                                  "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                                  "type": "string"
+                                },
+                                "endpoints": {
+                                  "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "keyFile": {
+                                  "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "caFile",
+                                "certFile",
+                                "endpoints",
+                                "keyFile"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "local": {
+                              "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                              "properties": {
+                                "dataDir": {
+                                  "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                                  "type": "string"
+                                },
+                                "extraArgs": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                                  "type": "object"
+                                },
+                                "imageRepository": {
+                                  "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                                  "type": "string"
+                                },
+                                "imageTag": {
+                                  "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                                  "type": "string"
+                                },
+                                "peerCertSANs": {
+                                  "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "serverCertSANs": {
+                                  "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "featureGates": {
+                          "additionalProperties": {
+                            "type": "boolean"
+                          },
+                          "description": "FeatureGates enabled by the user.",
+                          "type": "object"
+                        },
+                        "imageRepository": {
+                          "description": "ImageRepository sets the container registry to pull images from. If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io` will be used for all the other images.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "kubernetesVersion": {
+                          "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+                          "type": "string"
+                        },
+                        "networking": {
+                          "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+                          "properties": {
+                            "dnsDomain": {
+                              "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                              "type": "string"
+                            },
+                            "podSubnet": {
+                              "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                              "type": "string"
+                            },
+                            "serviceSubnet": {
+                              "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "scheduler": {
+                          "description": "Scheduler contains extra settings for the scheduler control plane component",
+                          "properties": {
+                            "extraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                              "type": "object"
+                            },
+                            "extraVolumes": {
+                              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                              "items": {
+                                "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                                "properties": {
+                                  "hostPath": {
+                                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                    "type": "string"
+                                  },
+                                  "mountPath": {
+                                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the volume inside the pod template.",
+                                    "type": "string"
+                                  },
+                                  "pathType": {
+                                    "description": "PathType is the type of the HostPath.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "ReadOnly controls write access to the volume",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "hostPath",
+                                  "mountPath",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "diskSetup": {
+                      "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+                      "properties": {
+                        "filesystems": {
+                          "description": "Filesystems specifies the list of file systems to setup.",
+                          "items": {
+                            "description": "Filesystem defines the file systems to be created.",
+                            "properties": {
+                              "device": {
+                                "description": "Device specifies the device name",
+                                "type": "string"
+                              },
+                              "extraOpts": {
+                                "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "filesystem": {
+                                "description": "Filesystem specifies the file system type.",
+                                "type": "string"
+                              },
+                              "label": {
+                                "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                                "type": "string"
+                              },
+                              "overwrite": {
+                                "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                                "type": "boolean"
+                              },
+                              "partition": {
+                                "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                                "type": "string"
+                              },
+                              "replaceFS": {
+                                "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "device",
+                              "filesystem",
+                              "label"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "partitions": {
+                          "description": "Partitions specifies the list of the partitions to setup.",
+                          "items": {
+                            "description": "Partition defines how to create and layout a partition.",
+                            "properties": {
+                              "device": {
+                                "description": "Device is the name of the device.",
+                                "type": "string"
+                              },
+                              "layout": {
+                                "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                                "type": "boolean"
+                              },
+                              "overwrite": {
+                                "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                                "type": "boolean"
+                              },
+                              "tableType": {
+                                "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "device",
+                              "layout"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "description": "Files specifies extra files to be passed to user_data upon creation.",
+                      "items": {
+                        "description": "File defines the input for generating write_files in cloud-init.",
+                        "properties": {
+                          "content": {
+                            "description": "Content is the actual content of the file.",
+                            "type": "string"
+                          },
+                          "contentFrom": {
+                            "description": "ContentFrom is a referenced source of content to populate the file.",
+                            "properties": {
+                              "secret": {
+                                "description": "Secret represents a secret that should populate this file.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the key in the secret's data map for this value.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "encoding": {
+                            "description": "Encoding specifies the encoding of the file contents.",
+                            "enum": [
+                              "base64",
+                              "gzip",
+                              "gzip+base64"
+                            ],
+                            "type": "string"
+                          },
+                          "owner": {
+                            "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path specifies the full path on disk where to store the file.",
+                            "type": "string"
+                          },
+                          "permissions": {
+                            "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "format": {
+                      "description": "Format specifies the output format of the bootstrap data",
+                      "enum": [
+                        "cloud-config"
+                      ],
+                      "type": "string"
+                    },
+                    "initConfiguration": {
+                      "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                          "type": "string"
+                        },
+                        "bootstrapTokens": {
+                          "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+                          "items": {
+                            "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                            "properties": {
+                              "description": {
+                                "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                                "type": "string"
+                              },
+                              "expires": {
+                                "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "groups": {
+                                "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "token": {
+                                "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                                "type": "string"
+                              },
+                              "ttl": {
+                                "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                                "type": "string"
+                              },
+                              "usages": {
+                                "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "token"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "kind": {
+                          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "localAPIEndpoint": {
+                          "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+                          "properties": {
+                            "advertiseAddress": {
+                              "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                              "type": "string"
+                            },
+                            "bindPort": {
+                              "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "nodeRegistration": {
+                          "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                          "properties": {
+                            "criSocket": {
+                              "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                              "type": "string"
+                            },
+                            "ignorePreflightErrors": {
+                              "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "kubeletExtraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                              "type": "string"
+                            },
+                            "taints": {
+                              "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                              "items": {
+                                "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                                "properties": {
+                                  "effect": {
+                                    "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "Required. The taint key to be applied to a node.",
+                                    "type": "string"
+                                  },
+                                  "timeAdded": {
+                                    "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                    "format": "date-time",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The taint value corresponding to the taint key.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "effect",
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "joinConfiguration": {
+                      "description": "JoinConfiguration is the kubeadm configuration for the join command",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                          "type": "string"
+                        },
+                        "caCertPath": {
+                          "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+                          "type": "string"
+                        },
+                        "controlPlane": {
+                          "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+                          "properties": {
+                            "localAPIEndpoint": {
+                              "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                              "properties": {
+                                "advertiseAddress": {
+                                  "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                                  "type": "string"
+                                },
+                                "bindPort": {
+                                  "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "discovery": {
+                          "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+                          "properties": {
+                            "bootstrapToken": {
+                              "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                              "properties": {
+                                "apiServerEndpoint": {
+                                  "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                                  "type": "string"
+                                },
+                                "caCertHashes": {
+                                  "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "token": {
+                                  "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                                  "type": "string"
+                                },
+                                "unsafeSkipCAVerification": {
+                                  "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "token"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "file": {
+                              "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                              "properties": {
+                                "kubeConfigPath": {
+                                  "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kubeConfigPath"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "timeout": {
+                              "description": "Timeout modifies the discovery timeout",
+                              "type": "string"
+                            },
+                            "tlsBootstrapToken": {
+                              "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "kind": {
+                          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "nodeRegistration": {
+                          "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                          "properties": {
+                            "criSocket": {
+                              "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                              "type": "string"
+                            },
+                            "ignorePreflightErrors": {
+                              "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "kubeletExtraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                              "type": "string"
+                            },
+                            "taints": {
+                              "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                              "items": {
+                                "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                                "properties": {
+                                  "effect": {
+                                    "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "Required. The taint key to be applied to a node.",
+                                    "type": "string"
+                                  },
+                                  "timeAdded": {
+                                    "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                    "format": "date-time",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The taint value corresponding to the taint key.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "effect",
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "mounts": {
+                      "description": "Mounts specifies a list of mount points to be setup.",
+                      "items": {
+                        "description": "MountPoints defines input for generated mounts in cloud-init.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "type": "array"
+                    },
+                    "ntp": {
+                      "description": "NTP specifies NTP configuration",
+                      "properties": {
+                        "enabled": {
+                          "description": "Enabled specifies whether NTP should be enabled",
+                          "type": "boolean"
+                        },
+                        "servers": {
+                          "description": "Servers specifies which NTP servers to use",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "postKubeadmCommands": {
+                      "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "preKubeadmCommands": {
+                      "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "useExperimentalRetryJoin": {
+                      "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.",
+                      "type": "boolean"
+                    },
+                    "users": {
+                      "description": "Users specifies extra users to add",
+                      "items": {
+                        "description": "User defines the input for a generated user in cloud-init.",
+                        "properties": {
+                          "gecos": {
+                            "description": "Gecos specifies the gecos to use for the user",
+                            "type": "string"
+                          },
+                          "groups": {
+                            "description": "Groups specifies the additional groups for the user",
+                            "type": "string"
+                          },
+                          "homeDir": {
+                            "description": "HomeDir specifies the home directory to use for the user",
+                            "type": "string"
+                          },
+                          "inactive": {
+                            "description": "Inactive specifies whether to mark the user as inactive",
+                            "type": "boolean"
+                          },
+                          "lockPassword": {
+                            "description": "LockPassword specifies if password login should be disabled",
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "description": "Name specifies the user name",
+                            "type": "string"
+                          },
+                          "passwd": {
+                            "description": "Passwd specifies a hashed password for the user",
+                            "type": "string"
+                          },
+                          "primaryGroup": {
+                            "description": "PrimaryGroup specifies the primary group for the user",
+                            "type": "string"
+                          },
+                          "shell": {
+                            "description": "Shell specifies the user's shell",
+                            "type": "string"
+                          },
+                          "sshAuthorizedKeys": {
+                            "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "sudo": {
+                            "description": "Sudo specifies a sudo role for the user",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "verbosity": {
+                      "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "machineTemplate": {
+                  "description": "MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.",
+                  "properties": {
+                    "infrastructureRef": {
+                      "description": "InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "API version of the referent.",
+                          "type": "string"
+                        },
+                        "fieldPath": {
+                          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                          "type": "string"
+                        },
+                        "resourceVersion": {
+                          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "metadata": {
+                      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodeDrainTimeout": {
+                      "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "infrastructureRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "replicas": {
+                  "description": "Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "rolloutAfter": {
+                  "description": "RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane.",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "rolloutStrategy": {
+                  "default": {
+                    "rollingUpdate": {
+                      "maxSurge": 1
+                    },
+                    "type": "RollingUpdate"
+                  },
+                  "description": "The RolloutStrategy to use to replace control plane machines with new ones.",
+                  "properties": {
+                    "rollingUpdate": {
+                      "description": "Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.",
+                      "properties": {
+                        "maxSurge": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "Type of rollout. Currently the only supported strategy is \"RollingUpdate\". Default is RollingUpdate.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "version": {
+                  "description": "Version defines the desired Kubernetes version.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kubeadmConfigSpec",
+                "machineTemplate",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/controlplane.cluster.x-k8s.io/kubeadmcontrolplanetemplate_v1beta1.json
+++ b/controlplane.cluster.x-k8s.io/kubeadmcontrolplanetemplate_v1beta1.json
@@ -1,0 +1,1185 @@
+{
+  "description": "KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeadmControlPlaneTemplateSpec defines the desired state of KubeadmControlPlaneTemplate.",
+      "properties": {
+        "template": {
+          "description": "KubeadmControlPlaneTemplateResource describes the data needed to create a KubeadmControlPlane from a template.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "KubeadmControlPlaneTemplateResourceSpec defines the desired state of KubeadmControlPlane. NOTE: KubeadmControlPlaneTemplateResourceSpec is similar to KubeadmControlPlaneSpec but omits Replicas and Version fields. These fields do not make sense on the KubeadmControlPlaneTemplate, because they are calculated by the Cluster topology reconciler during reconciliation and thus cannot be configured on the KubeadmControlPlaneTemplate.",
+              "properties": {
+                "kubeadmConfigSpec": {
+                  "description": "KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.",
+                  "properties": {
+                    "clusterConfiguration": {
+                      "description": "ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command",
+                      "properties": {
+                        "apiServer": {
+                          "description": "APIServer contains extra settings for the API server control plane component",
+                          "properties": {
+                            "certSANs": {
+                              "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "extraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                              "type": "object"
+                            },
+                            "extraVolumes": {
+                              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                              "items": {
+                                "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                                "properties": {
+                                  "hostPath": {
+                                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                    "type": "string"
+                                  },
+                                  "mountPath": {
+                                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the volume inside the pod template.",
+                                    "type": "string"
+                                  },
+                                  "pathType": {
+                                    "description": "PathType is the type of the HostPath.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "ReadOnly controls write access to the volume",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "hostPath",
+                                  "mountPath",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "timeoutForControlPlane": {
+                              "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "apiVersion": {
+                          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                          "type": "string"
+                        },
+                        "certificatesDir": {
+                          "description": "CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`",
+                          "type": "string"
+                        },
+                        "clusterName": {
+                          "description": "The cluster name",
+                          "type": "string"
+                        },
+                        "controlPlaneEndpoint": {
+                          "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.",
+                          "type": "string"
+                        },
+                        "controllerManager": {
+                          "description": "ControllerManager contains extra settings for the controller manager control plane component",
+                          "properties": {
+                            "extraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                              "type": "object"
+                            },
+                            "extraVolumes": {
+                              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                              "items": {
+                                "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                                "properties": {
+                                  "hostPath": {
+                                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                    "type": "string"
+                                  },
+                                  "mountPath": {
+                                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the volume inside the pod template.",
+                                    "type": "string"
+                                  },
+                                  "pathType": {
+                                    "description": "PathType is the type of the HostPath.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "ReadOnly controls write access to the volume",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "hostPath",
+                                  "mountPath",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dns": {
+                          "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+                          "properties": {
+                            "imageRepository": {
+                              "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                              "type": "string"
+                            },
+                            "imageTag": {
+                              "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "etcd": {
+                          "description": "Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd",
+                          "properties": {
+                            "external": {
+                              "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+                              "properties": {
+                                "caFile": {
+                                  "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                                  "type": "string"
+                                },
+                                "certFile": {
+                                  "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                                  "type": "string"
+                                },
+                                "endpoints": {
+                                  "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "keyFile": {
+                                  "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "caFile",
+                                "certFile",
+                                "endpoints",
+                                "keyFile"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "local": {
+                              "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+                              "properties": {
+                                "dataDir": {
+                                  "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                                  "type": "string"
+                                },
+                                "extraArgs": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                                  "type": "object"
+                                },
+                                "imageRepository": {
+                                  "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                                  "type": "string"
+                                },
+                                "imageTag": {
+                                  "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                                  "type": "string"
+                                },
+                                "peerCertSANs": {
+                                  "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "serverCertSANs": {
+                                  "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "featureGates": {
+                          "additionalProperties": {
+                            "type": "boolean"
+                          },
+                          "description": "FeatureGates enabled by the user.",
+                          "type": "object"
+                        },
+                        "imageRepository": {
+                          "description": "ImageRepository sets the container registry to pull images from. * If not set, the default registry of kubeadm will be used, i.e. * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0 * k8s.gcr.io (old registry): all older versions Please note that when imageRepository is not set we don't allow upgrades to versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use a newer patch version with the new registry instead (i.e. >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0). * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io` will be used for all the other images.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "kubernetesVersion": {
+                          "description": "KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version",
+                          "type": "string"
+                        },
+                        "networking": {
+                          "description": "Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.",
+                          "properties": {
+                            "dnsDomain": {
+                              "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+                              "type": "string"
+                            },
+                            "podSubnet": {
+                              "description": "PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set",
+                              "type": "string"
+                            },
+                            "serviceSubnet": {
+                              "description": "ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to \"10.96.0.0/12\" if that's unset.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "scheduler": {
+                          "description": "Scheduler contains extra settings for the scheduler control plane component",
+                          "properties": {
+                            "extraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+                              "type": "object"
+                            },
+                            "extraVolumes": {
+                              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+                              "items": {
+                                "description": "HostPathMount contains elements describing volumes that are mounted from the host.",
+                                "properties": {
+                                  "hostPath": {
+                                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                                    "type": "string"
+                                  },
+                                  "mountPath": {
+                                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the volume inside the pod template.",
+                                    "type": "string"
+                                  },
+                                  "pathType": {
+                                    "description": "PathType is the type of the HostPath.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "ReadOnly controls write access to the volume",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "hostPath",
+                                  "mountPath",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "diskSetup": {
+                      "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+                      "properties": {
+                        "filesystems": {
+                          "description": "Filesystems specifies the list of file systems to setup.",
+                          "items": {
+                            "description": "Filesystem defines the file systems to be created.",
+                            "properties": {
+                              "device": {
+                                "description": "Device specifies the device name",
+                                "type": "string"
+                              },
+                              "extraOpts": {
+                                "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "filesystem": {
+                                "description": "Filesystem specifies the file system type.",
+                                "type": "string"
+                              },
+                              "label": {
+                                "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                                "type": "string"
+                              },
+                              "overwrite": {
+                                "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                                "type": "boolean"
+                              },
+                              "partition": {
+                                "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                                "type": "string"
+                              },
+                              "replaceFS": {
+                                "description": "ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the 'any' partition directive.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "device",
+                              "filesystem",
+                              "label"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "partitions": {
+                          "description": "Partitions specifies the list of the partitions to setup.",
+                          "items": {
+                            "description": "Partition defines how to create and layout a partition.",
+                            "properties": {
+                              "device": {
+                                "description": "Device is the name of the device.",
+                                "type": "string"
+                              },
+                              "layout": {
+                                "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                                "type": "boolean"
+                              },
+                              "overwrite": {
+                                "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                                "type": "boolean"
+                              },
+                              "tableType": {
+                                "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "device",
+                              "layout"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "description": "Files specifies extra files to be passed to user_data upon creation.",
+                      "items": {
+                        "description": "File defines the input for generating write_files in cloud-init.",
+                        "properties": {
+                          "append": {
+                            "description": "Append specifies whether to append Content to existing file if Path exists.",
+                            "type": "boolean"
+                          },
+                          "content": {
+                            "description": "Content is the actual content of the file.",
+                            "type": "string"
+                          },
+                          "contentFrom": {
+                            "description": "ContentFrom is a referenced source of content to populate the file.",
+                            "properties": {
+                              "secret": {
+                                "description": "Secret represents a secret that should populate this file.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the key in the secret's data map for this value.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "encoding": {
+                            "description": "Encoding specifies the encoding of the file contents.",
+                            "enum": [
+                              "base64",
+                              "gzip",
+                              "gzip+base64"
+                            ],
+                            "type": "string"
+                          },
+                          "owner": {
+                            "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path specifies the full path on disk where to store the file.",
+                            "type": "string"
+                          },
+                          "permissions": {
+                            "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "format": {
+                      "description": "Format specifies the output format of the bootstrap data",
+                      "enum": [
+                        "cloud-config",
+                        "ignition"
+                      ],
+                      "type": "string"
+                    },
+                    "ignition": {
+                      "description": "Ignition contains Ignition specific configuration.",
+                      "properties": {
+                        "containerLinuxConfig": {
+                          "description": "ContainerLinuxConfig contains CLC specific configuration.",
+                          "properties": {
+                            "additionalConfig": {
+                              "description": "AdditionalConfig contains additional configuration to be merged with the Ignition configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/",
+                              "type": "string"
+                            },
+                            "strict": {
+                              "description": "Strict controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initConfiguration": {
+                      "description": "InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                          "type": "string"
+                        },
+                        "bootstrapTokens": {
+                          "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+                          "items": {
+                            "description": "BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.",
+                            "properties": {
+                              "description": {
+                                "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                                "type": "string"
+                              },
+                              "expires": {
+                                "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "groups": {
+                                "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "token": {
+                                "description": "Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.",
+                                "type": "string"
+                              },
+                              "ttl": {
+                                "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                                "type": "string"
+                              },
+                              "usages": {
+                                "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "token"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "kind": {
+                          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "localAPIEndpoint": {
+                          "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+                          "properties": {
+                            "advertiseAddress": {
+                              "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                              "type": "string"
+                            },
+                            "bindPort": {
+                              "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "nodeRegistration": {
+                          "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                          "properties": {
+                            "criSocket": {
+                              "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                              "type": "string"
+                            },
+                            "ignorePreflightErrors": {
+                              "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "imagePullPolicy": {
+                              "description": "ImagePullPolicy specifies the policy for image pulling during kubeadm \"init\" and \"join\" operations. The value of this field must be one of \"Always\", \"IfNotPresent\" or \"Never\". Defaults to \"IfNotPresent\". This can be used only with Kubernetes version equal to 1.22 and later.",
+                              "enum": [
+                                "Always",
+                                "IfNotPresent",
+                                "Never"
+                              ],
+                              "type": "string"
+                            },
+                            "kubeletExtraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                              "type": "string"
+                            },
+                            "taints": {
+                              "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.",
+                              "items": {
+                                "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                                "properties": {
+                                  "effect": {
+                                    "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "Required. The taint key to be applied to a node.",
+                                    "type": "string"
+                                  },
+                                  "timeAdded": {
+                                    "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                    "format": "date-time",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The taint value corresponding to the taint key.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "effect",
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "patches": {
+                          "description": "Patches contains options related to applying patches to components deployed by kubeadm during \"kubeadm init\". The minimum kubernetes version needed to support Patches is v1.22",
+                          "properties": {
+                            "directory": {
+                              "description": "Directory is a path to a directory that contains files named \"target[suffix][+patchtype].extension\". For example, \"kube-apiserver0+merge.yaml\" or just \"etcd.json\". \"target\" can be one of \"kube-apiserver\", \"kube-controller-manager\", \"kube-scheduler\", \"etcd\". \"patchtype\" can be one of \"strategic\" \"merge\" or \"json\" and they match the patch formats supported by kubectl. The default \"patchtype\" is \"strategic\". \"extension\" must be either \"json\" or \"yaml\". \"suffix\" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "skipPhases": {
+                          "description": "SkipPhases is a list of phases to skip during command execution. The list of phases can be obtained with the \"kubeadm init --help\" command. This option takes effect only on Kubernetes >=1.22.0.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "joinConfiguration": {
+                      "description": "JoinConfiguration is the kubeadm configuration for the join command",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                          "type": "string"
+                        },
+                        "caCertPath": {
+                          "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to \"/etc/kubernetes/pki/ca.crt\". TODO: revisit when there is defaulting from k/k",
+                          "type": "string"
+                        },
+                        "controlPlane": {
+                          "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+                          "properties": {
+                            "localAPIEndpoint": {
+                              "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                              "properties": {
+                                "advertiseAddress": {
+                                  "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                                  "type": "string"
+                                },
+                                "bindPort": {
+                                  "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "discovery": {
+                          "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k",
+                          "properties": {
+                            "bootstrapToken": {
+                              "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                              "properties": {
+                                "apiServerEndpoint": {
+                                  "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                                  "type": "string"
+                                },
+                                "caCertHashes": {
+                                  "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "token": {
+                                  "description": "Token is a token used to validate cluster information fetched from the control-plane.",
+                                  "type": "string"
+                                },
+                                "unsafeSkipCAVerification": {
+                                  "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "token"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "file": {
+                              "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                              "properties": {
+                                "kubeConfigPath": {
+                                  "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kubeConfigPath"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "timeout": {
+                              "description": "Timeout modifies the discovery timeout",
+                              "type": "string"
+                            },
+                            "tlsBootstrapToken": {
+                              "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "kind": {
+                          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                          "type": "string"
+                        },
+                        "nodeRegistration": {
+                          "description": "NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration",
+                          "properties": {
+                            "criSocket": {
+                              "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                              "type": "string"
+                            },
+                            "ignorePreflightErrors": {
+                              "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "imagePullPolicy": {
+                              "description": "ImagePullPolicy specifies the policy for image pulling during kubeadm \"init\" and \"join\" operations. The value of this field must be one of \"Always\", \"IfNotPresent\" or \"Never\". Defaults to \"IfNotPresent\". This can be used only with Kubernetes version equal to 1.22 and later.",
+                              "enum": [
+                                "Always",
+                                "IfNotPresent",
+                                "Never"
+                              ],
+                              "type": "string"
+                            },
+                            "kubeletExtraArgs": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                              "type": "object"
+                            },
+                            "name": {
+                              "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                              "type": "string"
+                            },
+                            "taints": {
+                              "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.",
+                              "items": {
+                                "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                                "properties": {
+                                  "effect": {
+                                    "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "Required. The taint key to be applied to a node.",
+                                    "type": "string"
+                                  },
+                                  "timeAdded": {
+                                    "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                    "format": "date-time",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The taint value corresponding to the taint key.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "effect",
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "patches": {
+                          "description": "Patches contains options related to applying patches to components deployed by kubeadm during \"kubeadm join\". The minimum kubernetes version needed to support Patches is v1.22",
+                          "properties": {
+                            "directory": {
+                              "description": "Directory is a path to a directory that contains files named \"target[suffix][+patchtype].extension\". For example, \"kube-apiserver0+merge.yaml\" or just \"etcd.json\". \"target\" can be one of \"kube-apiserver\", \"kube-controller-manager\", \"kube-scheduler\", \"etcd\". \"patchtype\" can be one of \"strategic\" \"merge\" or \"json\" and they match the patch formats supported by kubectl. The default \"patchtype\" is \"strategic\". \"extension\" must be either \"json\" or \"yaml\". \"suffix\" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "skipPhases": {
+                          "description": "SkipPhases is a list of phases to skip during command execution. The list of phases can be obtained with the \"kubeadm init --help\" command. This option takes effect only on Kubernetes >=1.22.0.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "mounts": {
+                      "description": "Mounts specifies a list of mount points to be setup.",
+                      "items": {
+                        "description": "MountPoints defines input for generated mounts in cloud-init.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "type": "array"
+                    },
+                    "ntp": {
+                      "description": "NTP specifies NTP configuration",
+                      "properties": {
+                        "enabled": {
+                          "description": "Enabled specifies whether NTP should be enabled",
+                          "type": "boolean"
+                        },
+                        "servers": {
+                          "description": "Servers specifies which NTP servers to use",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "postKubeadmCommands": {
+                      "description": "PostKubeadmCommands specifies extra commands to run after kubeadm runs",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "preKubeadmCommands": {
+                      "description": "PreKubeadmCommands specifies extra commands to run before kubeadm runs",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "useExperimentalRetryJoin": {
+                      "description": "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055. \n Deprecated: This experimental fix is no longer needed and this field will be removed in a future release. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml",
+                      "type": "boolean"
+                    },
+                    "users": {
+                      "description": "Users specifies extra users to add",
+                      "items": {
+                        "description": "User defines the input for a generated user in cloud-init.",
+                        "properties": {
+                          "gecos": {
+                            "description": "Gecos specifies the gecos to use for the user",
+                            "type": "string"
+                          },
+                          "groups": {
+                            "description": "Groups specifies the additional groups for the user",
+                            "type": "string"
+                          },
+                          "homeDir": {
+                            "description": "HomeDir specifies the home directory to use for the user",
+                            "type": "string"
+                          },
+                          "inactive": {
+                            "description": "Inactive specifies whether to mark the user as inactive",
+                            "type": "boolean"
+                          },
+                          "lockPassword": {
+                            "description": "LockPassword specifies if password login should be disabled",
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "description": "Name specifies the user name",
+                            "type": "string"
+                          },
+                          "passwd": {
+                            "description": "Passwd specifies a hashed password for the user",
+                            "type": "string"
+                          },
+                          "passwdFrom": {
+                            "description": "PasswdFrom is a referenced source of passwd to populate the passwd.",
+                            "properties": {
+                              "secret": {
+                                "description": "Secret represents a secret that should populate this password.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the key in the secret's data map for this value.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "primaryGroup": {
+                            "description": "PrimaryGroup specifies the primary group for the user",
+                            "type": "string"
+                          },
+                          "shell": {
+                            "description": "Shell specifies the user's shell",
+                            "type": "string"
+                          },
+                          "sshAuthorizedKeys": {
+                            "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "sudo": {
+                            "description": "Sudo specifies a sudo role for the user",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "verbosity": {
+                      "description": "Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "machineTemplate": {
+                  "description": "MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.",
+                  "properties": {
+                    "metadata": {
+                      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodeDeletionTimeout": {
+                      "description": "NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. If no value is provided, the default value for this property of the Machine resource will be used.",
+                      "type": "string"
+                    },
+                    "nodeDrainTimeout": {
+                      "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+                      "type": "string"
+                    },
+                    "nodeVolumeDetachTimeout": {
+                      "description": "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "remediationStrategy": {
+                  "description": "The RemediationStrategy that controls how control plane machine remediation happens.",
+                  "properties": {
+                    "maxRetry": {
+                      "description": "MaxRetry is the Max number of retries while attempting to remediate an unhealthy machine. A retry happens when a machine that was created as a replacement for an unhealthy machine also fails. For example, given a control plane with three machines M1, M2, M3: \n M1 become unhealthy; remediation happens, and M1-1 is created as a replacement. If M1-1 (replacement of M1) has problems while bootstrapping it will become unhealthy, and then be remediated; such operation is considered a retry, remediation-retry #1. If M1-2 (replacement of M1-2) becomes unhealthy, remediation-retry #2 will happen, etc. \n A retry could happen only after RetryPeriod from the previous retry. If a machine is marked as unhealthy after MinHealthyPeriod from the previous remediation expired, this is not considered a retry anymore because the new issue is assumed unrelated from the previous one. \n If not set, the remedation will be retried infinitely.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "minHealthyPeriod": {
+                      "description": "MinHealthyPeriod defines the duration after which KCP will consider any failure to a machine unrelated from the previous one. In this case the remediation is not considered a retry anymore, and thus the retry counter restarts from 0. For example, assuming MinHealthyPeriod is set to 1h (default) \n M1 become unhealthy; remediation happens, and M1-1 is created as a replacement. If M1-1 (replacement of M1) has problems within the 1hr after the creation, also this machine will be remediated and this operation is considered a retry - a problem related to the original issue happened to M1 -. \n If instead the problem on M1-1 is happening after MinHealthyPeriod expired, e.g. four days after m1-1 has been created as a remediation of M1, the problem on M1-1 is considered unrelated to the original issue happened to M1. \n If not set, this value is defaulted to 1h.",
+                      "type": "string"
+                    },
+                    "retryPeriod": {
+                      "description": "RetryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement for an unhealthy machine (a retry). \n If not set, a retry will happen immediately.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rolloutAfter": {
+                  "description": "RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane.",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "rolloutBefore": {
+                  "description": "RolloutBefore is a field to indicate a rollout should be performed if the specified criteria is met.",
+                  "properties": {
+                    "certificatesExpiryDays": {
+                      "description": "CertificatesExpiryDays indicates a rollout needs to be performed if the certificates of the machine will expire within the specified days.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rolloutStrategy": {
+                  "default": {
+                    "rollingUpdate": {
+                      "maxSurge": 1
+                    },
+                    "type": "RollingUpdate"
+                  },
+                  "description": "The RolloutStrategy to use to replace control plane machines with new ones.",
+                  "properties": {
+                    "rollingUpdate": {
+                      "description": "Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.",
+                      "properties": {
+                        "maxSurge": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "Type of rollout. Currently the only supported strategy is \"RollingUpdate\". Default is RollingUpdate.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "kubeadmConfigSpec"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockercluster_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/dockercluster_v1alpha2.json
@@ -1,0 +1,58 @@
+{
+  "description": "DockerCluster is the Schema for the dockerclusters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+      "type": "object"
+    },
+    "status": {
+      "description": "DockerClusterStatus defines the observed state of DockerCluster.",
+      "properties": {
+        "apiEndpoints": {
+          "description": "APIEndpoints represents the endpoints to communicate with the control plane.",
+          "items": {
+            "description": "APIEndpoint represents a reachable Kubernetes API endpoint.",
+            "properties": {
+              "host": {
+                "description": "Host is the hostname on which the API server is serving.",
+                "type": "string"
+              },
+              "port": {
+                "description": "Port is the port on which the API server is serving.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "host",
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ready": {
+          "description": "Ready denotes that the docker cluster (infrastructure) is ready.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockercluster_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/dockercluster_v1alpha3.json
@@ -1,0 +1,141 @@
+{
+  "description": "DockerCluster is the Schema for the dockerclusters API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "Host is the hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port is the port on which the API server is serving.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains are not usulaly defined on the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerClusterStatus defines the observed state of DockerCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API will use this if we populate it.",
+          "type": "object"
+        },
+        "ready": {
+          "description": "Ready denotes that the docker cluster (infrastructure) is ready.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockercluster_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/dockercluster_v1alpha4.json
@@ -1,0 +1,156 @@
+{
+  "description": "DockerCluster is the Schema for the dockerclusters API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "Host is the hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port is the port on which the API server is serving.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains are not usulaly defined on the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+          "type": "object"
+        },
+        "loadBalancer": {
+          "description": "LoadBalancer allows defining configurations for the cluster load balancer.",
+          "properties": {
+            "imageRepository": {
+              "description": "ImageRepository sets the container registry to pull the haproxy image from. if not set, \"kindest\" will be used instead.",
+              "type": "string"
+            },
+            "imageTag": {
+              "description": "ImageTag allows to specify a tag for the haproxy image. if not set, \"v20210715-a6da3463\" will be used instead.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerClusterStatus defines the observed state of DockerCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API will use this if we populate it.",
+          "type": "object"
+        },
+        "ready": {
+          "description": "Ready denotes that the docker cluster (infrastructure) is ready.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockercluster_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/dockercluster_v1beta1.json
@@ -1,0 +1,154 @@
+{
+  "description": "DockerCluster is the Schema for the dockerclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "Host is the hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port is the port on which the API server is serving. Defaults to 6443 if not set.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains are usually not defined in the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+          "type": "object"
+        },
+        "loadBalancer": {
+          "description": "LoadBalancer allows defining configurations for the cluster load balancer.",
+          "properties": {
+            "imageRepository": {
+              "description": "ImageRepository sets the container registry to pull the haproxy image from. if not set, \"kindest\" will be used instead.",
+              "type": "string"
+            },
+            "imageTag": {
+              "description": "ImageTag allows to specify a tag for the haproxy image. if not set, \"v20210715-a6da3463\" will be used instead.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerClusterStatus defines the observed state of DockerCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API will use this if we populate it.",
+          "type": "object"
+        },
+        "ready": {
+          "description": "Ready denotes that the docker cluster (infrastructure) is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockerclustertemplate_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/dockerclustertemplate_v1alpha4.json
@@ -1,0 +1,100 @@
+{
+  "description": "DockerClusterTemplate is the Schema for the dockerclustertemplates API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterTemplateSpec defines the desired state of DockerClusterTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerClusterTemplateResource describes the data needed to create a DockerCluster from a template.",
+          "properties": {
+            "spec": {
+              "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+              "properties": {
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+                  "properties": {
+                    "host": {
+                      "description": "Host is the hostname on which the API server is serving.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port is the port on which the API server is serving.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "host",
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureDomains": {
+                  "additionalProperties": {
+                    "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+                    "properties": {
+                      "attributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                        "type": "object"
+                      },
+                      "controlPlane": {
+                        "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "description": "FailureDomains are not usulaly defined on the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+                  "type": "object"
+                },
+                "loadBalancer": {
+                  "description": "LoadBalancer allows defining configurations for the cluster load balancer.",
+                  "properties": {
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull the haproxy image from. if not set, \"kindest\" will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the haproxy image. if not set, \"v20210715-a6da3463\" will be used instead.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockerclustertemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/dockerclustertemplate_v1beta1.json
@@ -1,0 +1,121 @@
+{
+  "description": "DockerClusterTemplate is the Schema for the dockerclustertemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerClusterTemplateSpec defines the desired state of DockerClusterTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerClusterTemplateResource describes the data needed to create a DockerCluster from a template.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "DockerClusterSpec defines the desired state of DockerCluster.",
+              "properties": {
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+                  "properties": {
+                    "host": {
+                      "description": "Host is the hostname on which the API server is serving.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port is the port on which the API server is serving. Defaults to 6443 if not set.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "host",
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureDomains": {
+                  "additionalProperties": {
+                    "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+                    "properties": {
+                      "attributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                        "type": "object"
+                      },
+                      "controlPlane": {
+                        "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "description": "FailureDomains are usually not defined in the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.",
+                  "type": "object"
+                },
+                "loadBalancer": {
+                  "description": "LoadBalancer allows defining configurations for the cluster load balancer.",
+                  "properties": {
+                    "imageRepository": {
+                      "description": "ImageRepository sets the container registry to pull the haproxy image from. if not set, \"kindest\" will be used instead.",
+                      "type": "string"
+                    },
+                    "imageTag": {
+                      "description": "ImageTag allows to specify a tag for the haproxy image. if not set, \"v20210715-a6da3463\" will be used instead.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachine_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachine_v1alpha2.json
@@ -1,0 +1,46 @@
+{
+  "description": "DockerMachine is the Schema for the dockermachines API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineSpec defines the desired state of DockerMachine",
+      "properties": {
+        "customImage": {
+          "description": "CustomImage allows customizing the container image that is used for running the machine",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachineStatus defines the observed state of DockerMachine",
+      "properties": {
+        "ready": {
+          "description": "Ready denotes that the machine (docker container) is ready",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachine_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachine_v1alpha3.json
@@ -1,0 +1,144 @@
+{
+  "description": "DockerMachine is the Schema for the dockermachines API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineSpec defines the desired state of DockerMachine.",
+      "properties": {
+        "bootstrapped": {
+          "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+          "type": "boolean"
+        },
+        "customImage": {
+          "description": "CustomImage allows customizing the container image that is used for running the machine",
+          "type": "string"
+        },
+        "extraMounts": {
+          "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+          "items": {
+            "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+            "properties": {
+              "containerPath": {
+                "description": "Path of the mount within the container.",
+                "type": "string"
+              },
+              "hostPath": {
+                "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "If set, the mount is read-only.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "preLoadImages": {
+          "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachineStatus defines the observed state of DockerMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the associated addresses for the docker machine.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "loadBalancerConfigured": {
+          "description": "LoadBalancerConfigured denotes that the machine has been added to the load balancer",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine (docker container) is ready",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachine_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachine_v1alpha4.json
@@ -1,0 +1,144 @@
+{
+  "description": "DockerMachine is the Schema for the dockermachines API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineSpec defines the desired state of DockerMachine.",
+      "properties": {
+        "bootstrapped": {
+          "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+          "type": "boolean"
+        },
+        "customImage": {
+          "description": "CustomImage allows customizing the container image that is used for running the machine",
+          "type": "string"
+        },
+        "extraMounts": {
+          "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+          "items": {
+            "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+            "properties": {
+              "containerPath": {
+                "description": "Path of the mount within the container.",
+                "type": "string"
+              },
+              "hostPath": {
+                "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "If set, the mount is read-only.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "preLoadImages": {
+          "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachineStatus defines the observed state of DockerMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the associated addresses for the docker machine.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "loadBalancerConfigured": {
+          "description": "LoadBalancerConfigured denotes that the machine has been added to the load balancer",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine (docker container) is ready",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachine_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachine_v1beta1.json
@@ -1,0 +1,145 @@
+{
+  "description": "DockerMachine is the Schema for the dockermachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineSpec defines the desired state of DockerMachine.",
+      "properties": {
+        "bootstrapped": {
+          "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine \n Deprecated: This field will be removed in the next apiVersion. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml.",
+          "type": "boolean"
+        },
+        "customImage": {
+          "description": "CustomImage allows customizing the container image that is used for running the machine",
+          "type": "string"
+        },
+        "extraMounts": {
+          "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+          "items": {
+            "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+            "properties": {
+              "containerPath": {
+                "description": "Path of the mount within the container.",
+                "type": "string"
+              },
+              "hostPath": {
+                "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "If set, the mount is read-only.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "preLoadImages": {
+          "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachineStatus defines the observed state of DockerMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the associated addresses for the docker machine.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "loadBalancerConfigured": {
+          "description": "LoadBalancerConfigured denotes that the machine has been added to the load balancer",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine (docker container) is ready",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachinepool_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachinepool_v1alpha3.json
@@ -1,0 +1,191 @@
+{
+  "description": "DockerMachinePool is the Schema for the dockermachinepools API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachinePoolSpec defines the desired state of DockerMachinePool.",
+      "properties": {
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Machine Pool",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList is the list of identification IDs of machine instances managed by this Machine Pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "template": {
+          "description": "Template contains the details used to build a replica machine within the Machine Pool",
+          "properties": {
+            "customImage": {
+              "description": "CustomImage allows customizing the container image that is used for running the machine",
+              "type": "string"
+            },
+            "extraMounts": {
+              "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+              "items": {
+                "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                "properties": {
+                  "containerPath": {
+                    "description": "Path of the mount within the container.",
+                    "type": "string"
+                  },
+                  "hostPath": {
+                    "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "If set, the mount is read-only.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "preLoadImages": {
+              "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachinePoolStatus defines the observed state of DockerMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "DockerMachinePoolInstanceStatus contains status information about a DockerMachinePool.",
+            "properties": {
+              "addresses": {
+                "description": "Addresses contains the associated addresses for the docker machine.",
+                "items": {
+                  "description": "MachineAddress contains information for the node's address.",
+                  "properties": {
+                    "address": {
+                      "description": "The machine address.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "bootstrapped": {
+                "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                "type": "boolean"
+              },
+              "instanceName": {
+                "description": "InstanceName is the identification of the Machine Instance within the Machine Pool",
+                "type": "string"
+              },
+              "providerID": {
+                "description": "ProviderID is the provider identification of the Machine Pool Instance",
+                "type": "string"
+              },
+              "ready": {
+                "description": "Ready denotes that the machine (docker container) is ready",
+                "type": "boolean"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine pool is ready",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachinepool_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachinepool_v1alpha4.json
@@ -1,0 +1,191 @@
+{
+  "description": "DockerMachinePool is the Schema for the dockermachinepools API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachinePoolSpec defines the desired state of DockerMachinePool.",
+      "properties": {
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Machine Pool",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList is the list of identification IDs of machine instances managed by this Machine Pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "template": {
+          "description": "Template contains the details used to build a replica machine within the Machine Pool",
+          "properties": {
+            "customImage": {
+              "description": "CustomImage allows customizing the container image that is used for running the machine",
+              "type": "string"
+            },
+            "extraMounts": {
+              "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+              "items": {
+                "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                "properties": {
+                  "containerPath": {
+                    "description": "Path of the mount within the container.",
+                    "type": "string"
+                  },
+                  "hostPath": {
+                    "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "If set, the mount is read-only.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "preLoadImages": {
+              "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachinePoolStatus defines the observed state of DockerMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "DockerMachinePoolInstanceStatus contains status information about a DockerMachinePool.",
+            "properties": {
+              "addresses": {
+                "description": "Addresses contains the associated addresses for the docker machine.",
+                "items": {
+                  "description": "MachineAddress contains information for the node's address.",
+                  "properties": {
+                    "address": {
+                      "description": "The machine address.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "bootstrapped": {
+                "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                "type": "boolean"
+              },
+              "instanceName": {
+                "description": "InstanceName is the identification of the Machine Instance within the Machine Pool",
+                "type": "string"
+              },
+              "providerID": {
+                "description": "ProviderID is the provider identification of the Machine Pool Instance",
+                "type": "string"
+              },
+              "ready": {
+                "description": "Ready denotes that the machine (docker container) is ready",
+                "type": "boolean"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine pool is ready",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachinepool_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachinepool_v1beta1.json
@@ -1,0 +1,192 @@
+{
+  "description": "DockerMachinePool is the Schema for the dockermachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachinePoolSpec defines the desired state of DockerMachinePool.",
+      "properties": {
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Machine Pool",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList is the list of identification IDs of machine instances managed by this Machine Pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "template": {
+          "description": "Template contains the details used to build a replica machine within the Machine Pool",
+          "properties": {
+            "customImage": {
+              "description": "CustomImage allows customizing the container image that is used for running the machine",
+              "type": "string"
+            },
+            "extraMounts": {
+              "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+              "items": {
+                "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                "properties": {
+                  "containerPath": {
+                    "description": "Path of the mount within the container.",
+                    "type": "string"
+                  },
+                  "hostPath": {
+                    "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "If set, the mount is read-only.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "preLoadImages": {
+              "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DockerMachinePoolStatus defines the observed state of DockerMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the DockerMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "DockerMachinePoolInstanceStatus contains status information about a DockerMachinePool.",
+            "properties": {
+              "addresses": {
+                "description": "Addresses contains the associated addresses for the docker machine.",
+                "items": {
+                  "description": "MachineAddress contains information for the node's address.",
+                  "properties": {
+                    "address": {
+                      "description": "The machine address.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "bootstrapped": {
+                "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine \n Deprecated: This field will be removed in the next apiVersion. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml",
+                "type": "boolean"
+              },
+              "instanceName": {
+                "description": "InstanceName is the identification of the Machine Instance within the Machine Pool",
+                "type": "string"
+              },
+              "providerID": {
+                "description": "ProviderID is the provider identification of the Machine Pool Instance",
+                "type": "string"
+              },
+              "ready": {
+                "description": "Ready denotes that the machine (docker container) is ready",
+                "type": "boolean"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready denotes that the machine pool is ready",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1alpha2.json
@@ -1,0 +1,52 @@
+{
+  "description": "DockerMachineTemplate is the Schema for the dockermachinetemplates API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate",
+      "properties": {
+        "template": {
+          "description": "DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "customImage": {
+                  "description": "CustomImage allows customizing the container image that is used for running the machine",
+                  "type": "string"
+                },
+                "providerID": {
+                  "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1alpha3.json
@@ -1,0 +1,86 @@
+{
+  "description": "DockerMachineTemplate is the Schema for the dockermachinetemplates API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template.",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "bootstrapped": {
+                  "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                  "type": "boolean"
+                },
+                "customImage": {
+                  "description": "CustomImage allows customizing the container image that is used for running the machine",
+                  "type": "string"
+                },
+                "extraMounts": {
+                  "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+                  "items": {
+                    "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                    "properties": {
+                      "containerPath": {
+                        "description": "Path of the mount within the container.",
+                        "type": "string"
+                      },
+                      "hostPath": {
+                        "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "If set, the mount is read-only.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "preLoadImages": {
+                  "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1alpha4.json
@@ -1,0 +1,86 @@
+{
+  "description": "DockerMachineTemplate is the Schema for the dockermachinetemplates API. \n Deprecated: This type will be removed in one of the next releases.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template.",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "bootstrapped": {
+                  "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine",
+                  "type": "boolean"
+                },
+                "customImage": {
+                  "description": "CustomImage allows customizing the container image that is used for running the machine",
+                  "type": "string"
+                },
+                "extraMounts": {
+                  "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+                  "items": {
+                    "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                    "properties": {
+                      "containerPath": {
+                        "description": "Path of the mount within the container.",
+                        "type": "string"
+                      },
+                      "hostPath": {
+                        "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "If set, the mount is read-only.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "preLoadImages": {
+                  "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1beta1.json
@@ -1,0 +1,107 @@
+{
+  "description": "DockerMachineTemplate is the Schema for the dockermachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "bootstrapped": {
+                  "description": "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine \n Deprecated: This field will be removed in the next apiVersion. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml.",
+                  "type": "boolean"
+                },
+                "customImage": {
+                  "description": "CustomImage allows customizing the container image that is used for running the machine",
+                  "type": "string"
+                },
+                "extraMounts": {
+                  "description": "ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath",
+                  "items": {
+                    "description": "Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.",
+                    "properties": {
+                      "containerPath": {
+                        "description": "Path of the mount within the container.",
+                        "type": "string"
+                      },
+                      "hostPath": {
+                        "description": "Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "If set, the mount is read-only.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "preLoadImages": {
+                  "description": "PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID will be the container name in ProviderID format (docker:////<containername>)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/ipam.cluster.x-k8s.io/ipaddress_v1alpha1.json
+++ b/ipam.cluster.x-k8s.io/ipaddress_v1alpha1.json
@@ -1,0 +1,78 @@
+{
+  "description": "IPAddress is the Schema for the ipaddress API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "IPAddressSpec is the desired state of an IPAddress.",
+      "properties": {
+        "address": {
+          "description": "Address is the IP address.",
+          "type": "string"
+        },
+        "claimRef": {
+          "description": "ClaimRef is a reference to the claim this IPAddress was created for.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gateway": {
+          "description": "Gateway is the network gateway of the network the address is from.",
+          "type": "string"
+        },
+        "poolRef": {
+          "description": "PoolRef is a reference to the pool that this IPAddress was created from.",
+          "properties": {
+            "apiGroup": {
+              "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is the type of resource being referenced",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of resource being referenced",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiGroup",
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "prefix": {
+          "description": "Prefix is the prefix of the address.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "address",
+        "claimRef",
+        "gateway",
+        "poolRef",
+        "prefix"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/ipam.cluster.x-k8s.io/ipaddressclaim_v1alpha1.json
+++ b/ipam.cluster.x-k8s.io/ipaddressclaim_v1alpha1.json
@@ -1,0 +1,113 @@
+{
+  "description": "IPAddressClaim is the Schema for the ipaddressclaim API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "IPAddressClaimSpec is the desired state of an IPAddressClaim.",
+      "properties": {
+        "poolRef": {
+          "description": "PoolRef is a reference to the pool from which an IP address should be created.",
+          "properties": {
+            "apiGroup": {
+              "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is the type of resource being referenced",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of resource being referenced",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiGroup",
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "poolRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "IPAddressClaimStatus is the observed status of a IPAddressClaim.",
+      "properties": {
+        "addressRef": {
+          "description": "AddressRef is a reference to the address that was created for this claim.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions summarises the current state of the IPAddressClaim",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "addressRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/runtime.cluster.x-k8s.io/extensionconfig_v1alpha1.json
+++ b/runtime.cluster.x-k8s.io/extensionconfig_v1alpha1.json
@@ -1,0 +1,221 @@
+{
+  "description": "ExtensionConfig is the Schema for the ExtensionConfig API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ExtensionConfigSpec is the desired state of the ExtensionConfig",
+      "properties": {
+        "clientConfig": {
+          "description": "ClientConfig defines how to communicate with the Extension server.",
+          "properties": {
+            "caBundle": {
+              "description": "CABundle is a PEM encoded CA bundle which will be used to validate the Extension server's server certificate.",
+              "format": "byte",
+              "type": "string"
+            },
+            "service": {
+              "description": "Service is a reference to the Kubernetes service for the Extension server. Note: Exactly one of `url` or `service` must be specified. \n If the Extension server is running within a cluster, then you should use `service`.",
+              "properties": {
+                "name": {
+                  "description": "Name is the name of the service.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace is the namespace of the service.",
+                  "type": "string"
+                },
+                "path": {
+                  "description": "Path is an optional URL path and if present may be any string permissible in a URL. If a path is set it will be used as prefix to the hook-specific path.",
+                  "type": "string"
+                },
+                "port": {
+                  "description": "Port is the port on the service that's hosting the Extension server. Defaults to 443. Port should be a valid port number (1-65535, inclusive).",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "url": {
+              "description": "URL gives the location of the Extension server, in standard URL form (`scheme://host:port/path`). Note: Exactly one of `url` or `service` must be specified. \n The scheme must be \"https\". \n The `host` should not refer to a service running in the cluster; use the `service` field instead. \n A path is optional, and if present may be any string permissible in a URL. If a path is set it will be used as prefix to the hook-specific path. \n Attempting to use a user or basic auth e.g. \"user:password@\" is not allowed. Fragments (\"#...\") and query parameters (\"?...\") are not allowed either.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "namespaceSelector": {
+          "description": "NamespaceSelector decides whether to call the hook for an object based on whether the namespace for that object matches the selector. Defaults to the empty LabelSelector, which matches all objects.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "settings": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Settings defines key value pairs to be passed to all calls to all supported RuntimeExtensions. Note: Settings can be overridden on the ClusterClass.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "clientConfig"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ExtensionConfigStatus is the current state of the ExtensionConfig",
+      "properties": {
+        "conditions": {
+          "description": "Conditions define the current service state of the ExtensionConfig.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "handlers": {
+          "description": "Handlers defines the current ExtensionHandlers supported by an Extension.",
+          "items": {
+            "description": "ExtensionHandler specifies the details of a handler for a particular runtime hook registered by an Extension server.",
+            "properties": {
+              "failurePolicy": {
+                "description": "FailurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client. Defaults to Fail if not set.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the unique name of the ExtensionHandler.",
+                "type": "string"
+              },
+              "requestHook": {
+                "description": "RequestHook defines the versioned runtime hook which this ExtensionHandler serves.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion is the group and version of the Hook.",
+                    "type": "string"
+                  },
+                  "hook": {
+                    "description": "Hook is the name of the hook.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "apiVersion",
+                  "hook"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "timeoutSeconds": {
+                "description": "TimeoutSeconds defines the timeout duration for client calls to the ExtensionHandler. Defaults to 10 is not set.",
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "name",
+              "requestHook"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds schemas for all CRs currently defined by the [Cluster API project](https://cluster-api.sigs.k8s.io/).

CRD sources:

```
# current/main

$ kustomize build github.com/kubernetes-sigs/cluster-api/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to clusterclass_v1alpha4.json
JSON schema written to clusterclass_v1beta1.json
JSON schema written to machine_v1alpha3.json
JSON schema written to machine_v1alpha4.json
JSON schema written to machine_v1beta1.json
JSON schema written to machineset_v1alpha3.json
JSON schema written to machineset_v1alpha4.json
JSON schema written to machineset_v1beta1.json
JSON schema written to clusterresourcesetbinding_v1alpha3.json
JSON schema written to clusterresourcesetbinding_v1alpha4.json
JSON schema written to clusterresourcesetbinding_v1beta1.json
JSON schema written to clusterresourceset_v1alpha3.json
JSON schema written to clusterresourceset_v1alpha4.json
JSON schema written to clusterresourceset_v1beta1.json
JSON schema written to cluster_v1alpha3.json
JSON schema written to cluster_v1alpha4.json
JSON schema written to cluster_v1beta1.json
JSON schema written to extensionconfig_v1alpha1.json
JSON schema written to ipaddressclaim_v1alpha1.json
JSON schema written to ipaddress_v1alpha1.json
JSON schema written to machinedeployment_v1alpha3.json
JSON schema written to machinedeployment_v1alpha4.json
JSON schema written to machinedeployment_v1beta1.json
JSON schema written to machinehealthcheck_v1alpha3.json
JSON schema written to machinehealthcheck_v1alpha4.json
JSON schema written to machinehealthcheck_v1beta1.json
JSON schema written to machinepool_v1alpha3.json
JSON schema written to machinepool_v1alpha4.json
JSON schema written to machinepool_v1beta1.json

# v1alpha2 (deprecated)

$ kustomize build 'github.com/kubernetes-sigs/cluster-api/config/crd?ref=v0.2.10' | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to cluster_v1alpha2.json
JSON schema written to machinedeployment_v1alpha2.json
JSON schema written to machine_v1alpha2.json
JSON schema written to machineset_v1alpha2.json

# v1alpha1 (deprecated)

$ kustomize build 'github.com/kubernetes-sigs/cluster-api/config/crds?ref=v0.1.10' | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to cluster_v1alpha1.json
JSON schema written to machineclass_v1alpha1.json
JSON schema written to machinedeployment_v1alpha1.json
JSON schema written to machine_v1alpha1.json
JSON schema written to machineset_v1alpha1.json
```

```
$ kustomize build github.com/kubernetes-sigs/cluster-api/controlplane/kubeadm/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to kubeadmcontrolplane_v1alpha3.json
JSON schema written to kubeadmcontrolplane_v1alpha4.json
JSON schema written to kubeadmcontrolplane_v1beta1.json
JSON schema written to kubeadmcontrolplanetemplate_v1alpha4.json
JSON schema written to kubeadmcontrolplanetemplate_v1beta1.json
```

```
$ kustomize build github.com/kubernetes-sigs/cluster-api/bootstrap/kubeadm/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to kubeadmconfig_v1alpha3.json
JSON schema written to kubeadmconfig_v1alpha4.json
JSON schema written to kubeadmconfig_v1beta1.json
JSON schema written to kubeadmconfigtemplate_v1alpha3.json
JSON schema written to kubeadmconfigtemplate_v1alpha4.json
JSON schema written to kubeadmconfigtemplate_v1beta1.json
```

```
$ kustomize build github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to provider_v1alpha3.json
```

```
# current/main

$ kustomize build github.com/kubernetes-sigs/cluster-api/test/infrastructure/docker/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to dockercluster_v1alpha3.json
JSON schema written to dockercluster_v1alpha4.json
JSON schema written to dockercluster_v1beta1.json
JSON schema written to dockerclustertemplate_v1alpha4.json
JSON schema written to dockerclustertemplate_v1beta1.json
JSON schema written to dockermachinepool_v1alpha3.json
JSON schema written to dockermachinepool_v1alpha4.json
JSON schema written to dockermachinepool_v1beta1.json
JSON schema written to dockermachine_v1alpha3.json
JSON schema written to dockermachine_v1alpha4.json
JSON schema written to dockermachine_v1beta1.json
JSON schema written to dockermachinetemplate_v1alpha3.json
JSON schema written to dockermachinetemplate_v1alpha4.json
JSON schema written to dockermachinetemplate_v1beta1.json

# v1alpha2 (deprecated)

$ kustomize build 'github.com/kubernetes-retired/cluster-api-provider-docker/config/crd?ref=v0.2.1' | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to dockercluster_v1alpha2.json
JSON schema written to dockermachine_v1alpha2.json
JSON schema written to dockermachinetemplate_v1alpha2.json
```