### PR TITLE
Add cert-manager trust-manager schemas

### DIFF
--- a/trust.cert-manager.io/bundle_v1alpha1.json
+++ b/trust.cert-manager.io/bundle_v1alpha1.json
@@ -1,0 +1,209 @@
+{
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Desired state of the Bundle resource.",
+      "type": "object",
+      "required": [
+        "sources",
+        "target"
+      ],
+      "properties": {
+        "sources": {
+          "description": "Sources is a set of references to data whose data will sync to the target.",
+          "type": "array",
+          "items": {
+            "description": "BundleSource is the set of sources whose data will be appended and synced to the BundleTarget in all Namespaces.",
+            "type": "object",
+            "properties": {
+              "configMap": {
+                "description": "ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "name"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "Key is the key of the entry in the object's `data` field to be used.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the source object in the trust Namespace.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "inLine": {
+                "description": "InLine is a simple string to append as the source data.",
+                "type": "string"
+              },
+              "secret": {
+                "description": "Secret is a reference to a Secrets's `data` key, in the trust Namespace.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "name"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "Key is the key of the entry in the object's `data` field to be used.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the source object in the trust Namespace.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "useDefaultCAs": {
+                "description": "UseDefaultCAs, when true, requests the default CA bundle to be used as a source. Default CAs are available if trust-manager was installed via Helm or was otherwise set up to include a package-injecting init container by using the \"--default-package-location\" flag when starting the trust-manager controller. If default CAs were not configured at start-up, any request to use the default CAs will fail. The version of the default CA package which is used for a Bundle is stored in the defaultCAPackageVersion field of the Bundle's status field.",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "target": {
+          "description": "Target is the target location in all namespaces to sync source data to.",
+          "type": "object",
+          "properties": {
+            "configMap": {
+              "description": "ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.",
+              "type": "object",
+              "required": [
+                "key"
+              ],
+              "properties": {
+                "key": {
+                  "description": "Key is the key of the entry in the object's `data` field to be used.",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "namespaceSelector": {
+              "description": "NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.",
+              "type": "object",
+              "properties": {
+                "matchLabels": {
+                  "description": "MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status of the Bundle. This is set and managed automatically.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "List of status conditions to indicate the status of the Bundle. Known condition types are `Bundle`.",
+          "type": "array",
+          "items": {
+            "description": "BundleCondition contains condition information for a Bundle.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Bundle.",
+                "type": "integer",
+                "format": "int64"
+              },
+              "reason": {
+                "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of ('True', 'False', 'Unknown').",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of the condition, known values are (`Synced`).",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "defaultCAVersion": {
+          "description": "DefaultCAPackageVersion, if set and non-empty, indicates the version information which was retrieved when the set of default CAs was requested in the bundle source. This should only be set if useDefaultCAs was set to \"true\" on a source, and will be the same for the same version of a bundle with identical certificates.",
+          "type": "string"
+        },
+        "target": {
+          "description": "Target is the current Target that the Bundle is attempting or has completed syncing the source data to.",
+          "type": "object",
+          "properties": {
+            "configMap": {
+              "description": "ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.",
+              "type": "object",
+              "required": [
+                "key"
+              ],
+              "properties": {
+                "key": {
+                  "description": "Key is the key of the entry in the object's `data` field to be used.",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "namespaceSelector": {
+              "description": "NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.",
+              "type": "object",
+              "properties": {
+                "matchLabels": {
+                  "description": "MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This PR adds schemas for all CRs currently defined by the [trust-manager](https://cert-manager.io/docs/projects/trust-manager/) subproject of cert-manager.

CRD sources:

```
$ curl -fsSL https://raw.githubusercontent.com/cert-manager/trust-manager/main/deploy/crds/trust.cert-manager.io_bundles.yaml -o crd.yml
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to bundle_v1alpha1.json
```