### PR TITLE
Update cert-manager schemas

### DIFF
--- a/cert-manager.io/certificate_v1.json
+++ b/cert-manager.io/certificate_v1.json
@@ -1,5 +1,9 @@
 {
   "description": "A Certificate resource should be created to ensure an up to date and signed x509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`. \n The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -14,28 +18,33 @@
     },
     "spec": {
       "description": "Desired state of the Certificate resource.",
+      "type": "object",
+      "required": [
+        "issuerRef",
+        "secretName"
+      ],
       "properties": {
         "additionalOutputFormats": {
           "description": "AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option on both the controller and webhook components.",
+          "type": "array",
           "items": {
             "description": "CertificateAdditionalOutputFormat defines an additional output format of a Certificate resource. These contain supplementary data formats of the signed certificate chain and paired private key.",
-            "properties": {
-              "type": {
-                "description": "Type is the name of the format type that should be written to the Certificate's target Secret.",
-                "enum": [
-                  "DER",
-                  "CombinedPEM"
-                ],
-                "type": "string"
-              }
-            },
+            "type": "object",
             "required": [
               "type"
             ],
-            "type": "object",
+            "properties": {
+              "type": {
+                "description": "Type is the name of the format type that should be written to the Certificate's target Secret.",
+                "type": "string",
+                "enum": [
+                  "DER",
+                  "CombinedPEM"
+                ]
+              }
+            },
             "additionalProperties": false
-          },
-          "type": "array"
+          }
         },
         "commonName": {
           "description": "CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs. This value is ignored by TLS clients when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4",
@@ -43,10 +52,10 @@
         },
         "dnsNames": {
           "description": "DNSNames is a list of DNS subjectAltNames to be set on the Certificate.",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "duration": {
           "description": "The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types. If unset this defaults to 90 days. Certificate will be renewed either 2/3 through its duration or `renewBefore` period before its expiry, whichever is later. Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration",
@@ -54,10 +63,10 @@
         },
         "emailAddresses": {
           "description": "EmailAddresses is a list of email subjectAltNames to be set on the Certificate.",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "encodeUsagesInRequest": {
           "description": "EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest",
@@ -65,10 +74,10 @@
         },
         "ipAddresses": {
           "description": "IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "isCA": {
           "description": "IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.",
@@ -76,6 +85,10 @@
         },
         "issuerRef": {
           "description": "IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.",
+          "type": "object",
+          "required": [
+            "name"
+          ],
           "properties": {
             "group": {
               "description": "Group of the resource being referred to.",
@@ -90,24 +103,30 @@
               "type": "string"
             }
           },
-          "required": [
-            "name"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "keystores": {
           "description": "Keystores configures additional keystore output formats stored in the `secretName` Secret resource.",
+          "type": "object",
           "properties": {
             "jks": {
               "description": "JKS configures options for storing a JKS keystore in the `spec.secretName` Secret resource.",
+              "type": "object",
+              "required": [
+                "create",
+                "passwordSecretRef"
+              ],
               "properties": {
                 "create": {
-                  "description": "Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
+                  "description": "Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
                   "type": "boolean"
                 },
                 "passwordSecretRef": {
                   "description": "PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "key": {
                       "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -118,29 +137,29 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 }
               },
-              "required": [
-                "create",
-                "passwordSecretRef"
-              ],
-              "type": "object",
               "additionalProperties": false
             },
             "pkcs12": {
               "description": "PKCS12 configures options for storing a PKCS12 keystore in the `spec.secretName` Secret resource.",
+              "type": "object",
+              "required": [
+                "create",
+                "passwordSecretRef"
+              ],
               "properties": {
                 "create": {
-                  "description": "Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
+                  "description": "Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority",
                   "type": "boolean"
                 },
                 "passwordSecretRef": {
                   "description": "PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "key": {
                       "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -151,22 +170,12 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 }
               },
-              "required": [
-                "create",
-                "passwordSecretRef"
-              ],
-              "type": "object",
               "additionalProperties": false
             }
           },
-          "type": "object",
           "additionalProperties": false
         },
         "literalSubject": {
@@ -175,38 +184,38 @@
         },
         "privateKey": {
           "description": "Options to control private keys used for the Certificate.",
+          "type": "object",
           "properties": {
             "algorithm": {
               "description": "Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `RSA`,`Ed25519` or `ECDSA` If `algorithm` is specified and `size` is not provided, key size of 256 will be used for `ECDSA` key algorithm and key size of 2048 will be used for `RSA` key algorithm. key size is ignored when using the `Ed25519` key algorithm.",
+              "type": "string",
               "enum": [
                 "RSA",
                 "ECDSA",
                 "Ed25519"
-              ],
-              "type": "string"
+              ]
             },
             "encoding": {
               "description": "The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and PKCS#8, respectively. Defaults to `PKCS1` if not specified.",
+              "type": "string",
               "enum": [
                 "PKCS1",
                 "PKCS8"
-              ],
-              "type": "string"
+              ]
             },
             "rotationPolicy": {
               "description": "RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.",
+              "type": "string",
               "enum": [
                 "Never",
                 "Always"
-              ],
-              "type": "string"
+              ]
             },
             "size": {
               "description": "Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.",
               "type": "integer"
             }
           },
-          "type": "object",
           "additionalProperties": false
         },
         "renewBefore": {
@@ -215,8 +224,8 @@
         },
         "revisionHistoryLimit": {
           "description": "revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.",
-          "format": "int32",
-          "type": "integer"
+          "type": "integer",
+          "format": "int32"
         },
         "secretName": {
           "description": "SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.",
@@ -224,69 +233,70 @@
         },
         "secretTemplate": {
           "description": "SecretTemplate defines annotations and labels to be copied to the Certificate's Secret. Labels and annotations on the Secret will be changed as they appear on the SecretTemplate when added or removed. SecretTemplate annotations are added in conjunction with, and cannot overwrite, the base set of annotations cert-manager sets on the Certificate's Secret.",
+          "type": "object",
           "properties": {
             "annotations": {
+              "description": "Annotations is a key value map to be copied to the target Kubernetes Secret.",
+              "type": "object",
               "additionalProperties": {
                 "type": "string"
-              },
-              "description": "Annotations is a key value map to be copied to the target Kubernetes Secret.",
-              "type": "object"
+              }
             },
             "labels": {
+              "description": "Labels is a key value map to be copied to the target Kubernetes Secret.",
+              "type": "object",
               "additionalProperties": {
                 "type": "string"
-              },
-              "description": "Labels is a key value map to be copied to the target Kubernetes Secret.",
-              "type": "object"
+              }
             }
           },
-          "type": "object",
           "additionalProperties": false
         },
         "subject": {
           "description": "Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).",
+          "type": "object",
           "properties": {
             "countries": {
               "description": "Countries to be used on the Certificate.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "localities": {
               "description": "Cities to be used on the Certificate.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "organizationalUnits": {
               "description": "Organizational Units to be used on the Certificate.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "organizations": {
               "description": "Organizations to be used on the Certificate.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "postalCodes": {
               "description": "Postal codes to be used on the Certificate.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "provinces": {
               "description": "State/Provinces to be used on the Certificate.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "serialNumber": {
               "description": "Serial number to be used on the Certificate.",
@@ -294,26 +304,27 @@
             },
             "streetAddresses": {
               "description": "Street addresses to be used on the Certificate.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
-          "type": "object",
           "additionalProperties": false
         },
         "uris": {
           "description": "URIs is a list of URI subjectAltNames to be set on the Certificate.",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "usages": {
           "description": "Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.",
+          "type": "array",
           "items": {
-            "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+            "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 \n Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+            "type": "string",
             "enum": [
               "signing",
               "digital signature",
@@ -338,31 +349,31 @@
               "ocsp signing",
               "microsoft sgc",
               "netscape sgc"
-            ],
-            "type": "string"
-          },
-          "type": "array"
+            ]
+          }
         }
       },
-      "required": [
-        "issuerRef",
-        "secretName"
-      ],
-      "type": "object",
       "additionalProperties": false
     },
     "status": {
       "description": "Status of the Certificate. This is set and managed automatically.",
+      "type": "object",
       "properties": {
         "conditions": {
           "description": "List of status conditions to indicate the status of certificates. Known condition types are `Ready` and `Issuing`.",
+          "type": "array",
           "items": {
             "description": "CertificateCondition contains condition information for an Certificate.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
             "properties": {
               "lastTransitionTime": {
                 "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               "message": {
                 "description": "Message is a human readable description of the details of the last transition, complementing reason.",
@@ -370,8 +381,8 @@
               },
               "observedGeneration": {
                 "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.",
-                "format": "int64",
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "reason": {
                 "description": "Reason is a brief machine readable explanation for the condition's last transition.",
@@ -379,26 +390,20 @@
               },
               "status": {
                 "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                "type": "string",
                 "enum": [
                   "True",
                   "False",
                   "Unknown"
-                ],
-                "type": "string"
+                ]
               },
               "type": {
                 "description": "Type of the condition, known values are (`Ready`, `Issuing`).",
                 "type": "string"
               }
             },
-            "required": [
-              "status",
-              "type"
-            ],
-            "type": "object",
             "additionalProperties": false
           },
-          "type": "array",
           "x-kubernetes-list-map-keys": [
             "type"
           ],
@@ -410,8 +415,8 @@
         },
         "lastFailureTime": {
           "description": "LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.",
-          "format": "date-time",
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         },
         "nextPrivateKeySecretName": {
           "description": "The name of the Secret resource containing the private key to be used for the next certificate iteration. The keymanager controller will automatically set this field if the `Issuing` condition is set to `True`. It will automatically unset this field when the Issuing condition is not set or False.",
@@ -419,30 +424,25 @@
         },
         "notAfter": {
           "description": "The expiration time of the certificate stored in the secret named by this resource in `spec.secretName`.",
-          "format": "date-time",
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         },
         "notBefore": {
           "description": "The time after which the certificate stored in the secret named by this resource in spec.secretName is valid.",
-          "format": "date-time",
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         },
         "renewalTime": {
           "description": "RenewalTime is the time at which the certificate will be next renewed. If not set, no upcoming renewal is scheduled.",
-          "format": "date-time",
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         },
         "revision": {
           "description": "The current 'revision' of the certificate as issued. \n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field.",
           "type": "integer"
         }
       },
-      "type": "object",
       "additionalProperties": false
     }
-  },
-  "required": [
-    "spec"
-  ],
-  "type": "object"
+  }
 }

--- a/cert-manager.io/certificaterequest_v1.json
+++ b/cert-manager.io/certificaterequest_v1.json
@@ -1,5 +1,9 @@
 {
   "description": "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a one-shot resource, meaning it represents a single point in time request for a certificate and cannot be re-used.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -14,27 +18,32 @@
     },
     "spec": {
       "description": "Desired state of the CertificateRequest resource.",
+      "type": "object",
+      "required": [
+        "issuerRef",
+        "request"
+      ],
       "properties": {
         "duration": {
           "description": "The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types.",
           "type": "string"
         },
         "extra": {
+          "description": "Extra contains extra attributes of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+          "type": "object",
           "additionalProperties": {
+            "type": "array",
             "items": {
               "type": "string"
-            },
-            "type": "array"
-          },
-          "description": "Extra contains extra attributes of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
-          "type": "object"
+            }
+          }
         },
         "groups": {
           "description": "Groups contains group membership of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
+          "type": "array",
           "items": {
             "type": "string"
           },
-          "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "isCA": {
@@ -43,6 +52,10 @@
         },
         "issuerRef": {
           "description": "IssuerRef is a reference to the issuer for this CertificateRequest.  If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to `cert-manager.io` if empty.",
+          "type": "object",
+          "required": [
+            "name"
+          ],
           "properties": {
             "group": {
               "description": "Group of the resource being referred to.",
@@ -57,16 +70,12 @@
               "type": "string"
             }
           },
-          "required": [
-            "name"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "request": {
           "description": "The PEM-encoded x509 certificate signing request to be submitted to the CA for signing.",
-          "format": "byte",
-          "type": "string"
+          "type": "string",
+          "format": "byte"
         },
         "uid": {
           "description": "UID contains the uid of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
@@ -74,8 +83,10 @@
         },
         "usages": {
           "description": "Usages is the set of x509 usages that are requested for the certificate. If usages are set they SHOULD be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.",
+          "type": "array",
           "items": {
-            "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+            "description": "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 \n Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+            "type": "string",
             "enum": [
               "signing",
               "digital signature",
@@ -100,45 +111,45 @@
               "ocsp signing",
               "microsoft sgc",
               "netscape sgc"
-            ],
-            "type": "string"
-          },
-          "type": "array"
+            ]
+          }
         },
         "username": {
           "description": "Username contains the name of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.",
           "type": "string"
         }
       },
-      "required": [
-        "issuerRef",
-        "request"
-      ],
-      "type": "object",
       "additionalProperties": false
     },
     "status": {
       "description": "Status of the CertificateRequest. This is set and managed automatically.",
+      "type": "object",
       "properties": {
         "ca": {
           "description": "The PEM encoded x509 certificate of the signer, also known as the CA (Certificate Authority). This is set on a best-effort basis by different issuers. If not set, the CA is assumed to be unknown/not available.",
-          "format": "byte",
-          "type": "string"
+          "type": "string",
+          "format": "byte"
         },
         "certificate": {
           "description": "The PEM encoded x509 certificate resulting from the certificate signing request. If not set, the CertificateRequest has either not been completed or has failed. More information on failure can be found by checking the `conditions` field.",
-          "format": "byte",
-          "type": "string"
+          "type": "string",
+          "format": "byte"
         },
         "conditions": {
           "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready` and `InvalidRequest`.",
+          "type": "array",
           "items": {
             "description": "CertificateRequestCondition contains condition information for a CertificateRequest.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
             "properties": {
               "lastTransitionTime": {
                 "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               "message": {
                 "description": "Message is a human readable description of the details of the last transition, complementing reason.",
@@ -150,26 +161,20 @@
               },
               "status": {
                 "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                "type": "string",
                 "enum": [
                   "True",
                   "False",
                   "Unknown"
-                ],
-                "type": "string"
+                ]
               },
               "type": {
                 "description": "Type of the condition, known values are (`Ready`, `InvalidRequest`, `Approved`, `Denied`).",
                 "type": "string"
               }
             },
-            "required": [
-              "status",
-              "type"
-            ],
-            "type": "object",
             "additionalProperties": false
           },
-          "type": "array",
           "x-kubernetes-list-map-keys": [
             "type"
           ],
@@ -177,16 +182,11 @@
         },
         "failureTime": {
           "description": "FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.",
-          "format": "date-time",
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         }
       },
-      "type": "object",
       "additionalProperties": false
     }
-  },
-  "required": [
-    "spec"
-  ],
-  "type": "object"
+  }
 }

--- a/cert-manager.io/challenge_v1.json
+++ b/cert-manager.io/challenge_v1.json
@@ -1,5 +1,10 @@
 {
   "description": "Challenge is a type to represent a Challenge request with an ACME server",
+  "type": "object",
+  "required": [
+    "metadata",
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,6 +18,17 @@
       "type": "object"
     },
     "spec": {
+      "type": "object",
+      "required": [
+        "authorizationURL",
+        "dnsName",
+        "issuerRef",
+        "key",
+        "solver",
+        "token",
+        "type",
+        "url"
+      ],
       "properties": {
         "authorizationURL": {
           "description": "The URL to the ACME Authorization resource that this challenge is a part of.",
@@ -24,6 +40,10 @@
         },
         "issuerRef": {
           "description": "References a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Challenge will be marked as failed.",
+          "type": "object",
+          "required": [
+            "name"
+          ],
           "properties": {
             "group": {
               "description": "Group of the resource being referred to.",
@@ -38,10 +58,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "name"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "key": {
@@ -50,15 +66,26 @@
         },
         "solver": {
           "description": "Contains the domain solving configuration that should be used to solve this challenge resource.",
+          "type": "object",
           "properties": {
             "dns01": {
               "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+              "type": "object",
               "properties": {
                 "acmeDNS": {
                   "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                  "type": "object",
+                  "required": [
+                    "accountSecretRef",
+                    "host"
+                  ],
                   "properties": {
                     "accountSecretRef": {
                       "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -69,95 +96,91 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     },
                     "host": {
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "accountSecretRef",
-                    "host"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "akamai": {
                   "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
-                  "properties": {
-                    "accessTokenSecretRef": {
-                      "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
-                      "properties": {
-                        "key": {
-                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
-                          "type": "string"
-                        },
-                        "name": {
-                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "clientSecretSecretRef": {
-                      "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
-                      "properties": {
-                        "key": {
-                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
-                          "type": "string"
-                        },
-                        "name": {
-                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "clientTokenSecretRef": {
-                      "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
-                      "properties": {
-                        "key": {
-                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
-                          "type": "string"
-                        },
-                        "name": {
-                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "serviceConsumerDomain": {
-                      "type": "string"
-                    }
-                  },
+                  "type": "object",
                   "required": [
                     "accessTokenSecretRef",
                     "clientSecretSecretRef",
                     "clientTokenSecretRef",
                     "serviceConsumerDomain"
                   ],
-                  "type": "object",
+                  "properties": {
+                    "accessTokenSecretRef": {
+                      "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "clientSecretSecretRef": {
+                      "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "clientTokenSecretRef": {
+                      "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "serviceConsumerDomain": {
+                      "type": "string"
+                    }
+                  },
                   "additionalProperties": false
                 },
                 "azureDNS": {
                   "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                  "type": "object",
+                  "required": [
+                    "resourceGroupName",
+                    "subscriptionID"
+                  ],
                   "properties": {
                     "clientID": {
                       "description": "if both this and ClientSecret are left unset MSI will be used",
@@ -165,6 +188,10 @@
                     },
                     "clientSecretSecretRef": {
                       "description": "if both this and ClientID are left unset MSI will be used",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -175,21 +202,17 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     },
                     "environment": {
                       "description": "name of the Azure environment (default AzurePublicCloud)",
+                      "type": "string",
                       "enum": [
                         "AzurePublicCloud",
                         "AzureChinaCloud",
                         "AzureGermanCloud",
                         "AzureUSGovernmentCloud"
-                      ],
-                      "type": "string"
+                      ]
                     },
                     "hostedZoneName": {
                       "description": "name of the DNS zone that should be used",
@@ -197,6 +220,7 @@
                     },
                     "managedIdentity": {
                       "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                      "type": "object",
                       "properties": {
                         "clientID": {
                           "description": "client ID of the managed identity, can not be used at the same time as resourceID",
@@ -207,7 +231,6 @@
                           "type": "string"
                         }
                       },
-                      "type": "object",
                       "additionalProperties": false
                     },
                     "resourceGroupName": {
@@ -223,15 +246,14 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "resourceGroupName",
-                    "subscriptionID"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "cloudDNS": {
                   "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                  "type": "object",
+                  "required": [
+                    "project"
+                  ],
                   "properties": {
                     "hostedZoneName": {
                       "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
@@ -242,6 +264,10 @@
                     },
                     "serviceAccountSecretRef": {
                       "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -252,24 +278,21 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "project"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "cloudflare": {
                   "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                  "type": "object",
                   "properties": {
                     "apiKeySecretRef": {
                       "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -280,14 +303,14 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     },
                     "apiTokenSecretRef": {
                       "description": "API token used to authenticate with Cloudflare.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -298,10 +321,6 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     },
                     "email": {
@@ -309,22 +328,29 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "cnameStrategy": {
                   "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                  "type": "string",
                   "enum": [
                     "None",
                     "Follow"
-                  ],
-                  "type": "string"
+                  ]
                 },
                 "digitalocean": {
                   "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                  "type": "object",
+                  "required": [
+                    "tokenSecretRef"
+                  ],
                   "properties": {
                     "tokenSecretRef": {
                       "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -335,21 +361,17 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "tokenSecretRef"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "rfc2136": {
                   "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                  "type": "object",
+                  "required": [
+                    "nameserver"
+                  ],
                   "properties": {
                     "nameserver": {
                       "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1])\u00a0; port is optional. This field is required.",
@@ -365,6 +387,10 @@
                     },
                     "tsigSecretSecretRef": {
                       "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -375,21 +401,17 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "nameserver"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "route53": {
                   "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                  "type": "object",
+                  "required": [
+                    "region"
+                  ],
                   "properties": {
                     "accessKeyID": {
                       "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
@@ -397,6 +419,10 @@
                     },
                     "accessKeyIDSecretRef": {
                       "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -407,10 +433,6 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     },
                     "hostedZoneID": {
@@ -427,6 +449,10 @@
                     },
                     "secretAccessKeySecretRef": {
                       "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -437,21 +463,18 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "region"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "webhook": {
                   "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                  "type": "object",
+                  "required": [
+                    "groupName",
+                    "solverName"
+                  ],
                   "properties": {
                     "config": {
                       "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
@@ -466,89 +489,92 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "groupName",
-                    "solverName"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 }
               },
-              "type": "object",
               "additionalProperties": false
             },
             "http01": {
               "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+              "type": "object",
               "properties": {
                 "gatewayHTTPRoute": {
                   "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                  "type": "object",
                   "properties": {
                     "labels": {
+                      "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                      "type": "object",
                       "additionalProperties": {
                         "type": "string"
-                      },
-                      "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
-                      "type": "object"
+                      }
                     },
                     "parentRefs": {
-                      "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                      "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways",
+                      "type": "array",
                       "items": {
-                        "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
-                        "properties": {
-                          "group": {
-                            "default": "gateway.networking.k8s.io",
-                            "description": "Group is the group of the referent. \n Support: Core",
-                            "maxLength": 253,
-                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                            "type": "string"
-                          },
-                          "kind": {
-                            "default": "Gateway",
-                            "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
-                            "maxLength": 63,
-                            "minLength": 1,
-                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name is the name of the referent. \n Support: Core",
-                            "maxLength": 253,
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
-                            "maxLength": 63,
-                            "minLength": 1,
-                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                            "type": "string"
-                          },
-                          "sectionName": {
-                            "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
-                            "maxLength": 253,
-                            "minLength": 1,
-                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                            "type": "string"
-                          }
-                        },
+                        "description": "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid.",
+                        "type": "object",
                         "required": [
                           "name"
                         ],
-                        "type": "object",
+                        "properties": {
+                          "group": {
+                            "description": "Group is the group of the referent. When unspecified, \"gateway.networking.k8s.io\" is inferred. To set the core API group (such as for a \"Service\" kind referent), Group must be explicitly set to \"\" (empty string). \n Support: Core",
+                            "type": "string",
+                            "default": "gateway.networking.k8s.io",
+                            "maxLength": 253,
+                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                          },
+                          "kind": {
+                            "description": "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Implementation-specific (Other Resources)",
+                            "type": "string",
+                            "default": "Gateway",
+                            "maxLength": 63,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+                          },
+                          "name": {
+                            "description": "Name is the name of the referent. \n Support: Core",
+                            "type": "string",
+                            "maxLength": 253,
+                            "minLength": 1
+                          },
+                          "namespace": {
+                            "description": "Namespace is the namespace of the referent. When unspecified, this refers to the local namespace of the Route. \n Note that there are specific rules for ParentRefs which cross namespace boundaries. Cross-namespace references are only valid if they are explicitly allowed by something in the namespace they are referring to. For example: Gateway has the AllowedRoutes field, and ReferenceGrant provides a generic way to enable any other kind of cross-namespace reference. \n Support: Core",
+                            "type": "string",
+                            "maxLength": 63,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                          },
+                          "port": {
+                            "description": "Port is the network port this Route targets. It can be interpreted differently based on the type of parent resource. \n When the parent resource is a Gateway, this targets all listeners listening on the specified port that also support this kind of Route(and select this Route). It's not recommended to set `Port` unless the networking behaviors specified in a Route must apply to a specific port as opposed to a listener(s) whose port(s) may be changed. When both Port and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support other parent resources. Implementations supporting other types of parent resources MUST clearly document how/if Port is interpreted. \n For the purpose of status, an attachment is considered successful as long as the parent resource accepts it partially. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Extended \n <gateway:experimental>",
+                            "type": "integer",
+                            "format": "int32",
+                            "maximum": 65535,
+                            "minimum": 1
+                          },
+                          "sectionName": {
+                            "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name. When both Port (experimental) and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                            "type": "string",
+                            "maxLength": 253,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                          }
+                        },
                         "additionalProperties": false
-                      },
-                      "type": "array"
+                      }
                     },
                     "serviceType": {
                       "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
                       "type": "string"
                     }
                   },
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "ingress": {
                   "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                  "type": "object",
                   "properties": {
                     "class": {
                       "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
@@ -556,30 +582,30 @@
                     },
                     "ingressTemplate": {
                       "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                      "type": "object",
                       "properties": {
                         "metadata": {
                           "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                          "type": "object",
                           "properties": {
                             "annotations": {
+                              "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                              "type": "object",
                               "additionalProperties": {
                                 "type": "string"
-                              },
-                              "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
-                              "type": "object"
+                              }
                             },
                             "labels": {
+                              "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                              "type": "object",
                               "additionalProperties": {
                                 "type": "string"
-                              },
-                              "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
-                              "type": "object"
+                              }
                             }
                           },
-                          "type": "object",
                           "additionalProperties": false
                         }
                       },
-                      "type": "object",
                       "additionalProperties": false
                     },
                     "name": {
@@ -588,136 +614,66 @@
                     },
                     "podTemplate": {
                       "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                      "type": "object",
                       "properties": {
                         "metadata": {
                           "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                          "type": "object",
                           "properties": {
                             "annotations": {
+                              "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                              "type": "object",
                               "additionalProperties": {
                                 "type": "string"
-                              },
-                              "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
-                              "type": "object"
+                              }
                             },
                             "labels": {
+                              "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                              "type": "object",
                               "additionalProperties": {
                                 "type": "string"
-                              },
-                              "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
-                              "type": "object"
+                              }
                             }
                           },
-                          "type": "object",
                           "additionalProperties": false
                         },
                         "spec": {
                           "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                          "type": "object",
                           "properties": {
                             "affinity": {
                               "description": "If specified, the pod's scheduling constraints",
+                              "type": "object",
                               "properties": {
                                 "nodeAffinity": {
                                   "description": "Describes node affinity scheduling rules for the pod.",
+                                  "type": "object",
                                   "properties": {
                                     "preferredDuringSchedulingIgnoredDuringExecution": {
                                       "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                      "type": "array",
                                       "items": {
                                         "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
-                                        "properties": {
-                                          "preference": {
-                                            "description": "A node selector term, associated with the corresponding weight.",
-                                            "properties": {
-                                              "matchExpressions": {
-                                                "description": "A list of node selector requirements by node's labels.",
-                                                "items": {
-                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-                                                  "properties": {
-                                                    "key": {
-                                                      "description": "The label key that the selector applies to.",
-                                                      "type": "string"
-                                                    },
-                                                    "operator": {
-                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                      "type": "string"
-                                                    },
-                                                    "values": {
-                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-                                                      "items": {
-                                                        "type": "string"
-                                                      },
-                                                      "type": "array"
-                                                    }
-                                                  },
-                                                  "required": [
-                                                    "key",
-                                                    "operator"
-                                                  ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
-                                                },
-                                                "type": "array"
-                                              },
-                                              "matchFields": {
-                                                "description": "A list of node selector requirements by node's fields.",
-                                                "items": {
-                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-                                                  "properties": {
-                                                    "key": {
-                                                      "description": "The label key that the selector applies to.",
-                                                      "type": "string"
-                                                    },
-                                                    "operator": {
-                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                      "type": "string"
-                                                    },
-                                                    "values": {
-                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-                                                      "items": {
-                                                        "type": "string"
-                                                      },
-                                                      "type": "array"
-                                                    }
-                                                  },
-                                                  "required": [
-                                                    "key",
-                                                    "operator"
-                                                  ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
-                                                },
-                                                "type": "array"
-                                              }
-                                            },
-                                            "type": "object",
-                                            "additionalProperties": false
-                                          },
-                                          "weight": {
-                                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
-                                            "format": "int32",
-                                            "type": "integer"
-                                          }
-                                        },
+                                        "type": "object",
                                         "required": [
                                           "preference",
                                           "weight"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
-                                      "properties": {
-                                        "nodeSelectorTerms": {
-                                          "description": "Required. A list of node selector terms. The terms are ORed.",
-                                          "items": {
-                                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                        "properties": {
+                                          "preference": {
+                                            "description": "A node selector term, associated with the corresponding weight.",
+                                            "type": "object",
                                             "properties": {
                                               "matchExpressions": {
                                                 "description": "A list of node selector requirements by node's labels.",
+                                                "type": "array",
                                                 "items": {
                                                   "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
                                                   "properties": {
                                                     "key": {
                                                       "description": "The label key that the selector applies to.",
@@ -729,25 +685,25 @@
                                                     },
                                                     "values": {
                                                       "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     }
                                                   },
-                                                  "required": [
-                                                    "key",
-                                                    "operator"
-                                                  ],
-                                                  "type": "object",
                                                   "additionalProperties": false
-                                                },
-                                                "type": "array"
+                                                }
                                               },
                                               "matchFields": {
                                                 "description": "A list of node selector requirements by node's fields.",
+                                                "type": "array",
                                                 "items": {
                                                   "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
                                                   "properties": {
                                                     "key": {
                                                       "description": "The label key that the selector applies to.",
@@ -759,56 +715,150 @@
                                                     },
                                                     "values": {
                                                       "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     }
                                                   },
+                                                  "additionalProperties": false
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                      "type": "object",
+                                      "required": [
+                                        "nodeSelectorTerms"
+                                      ],
+                                      "properties": {
+                                        "nodeSelectorTerms": {
+                                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                            "type": "object",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "A list of node selector requirements by node's labels.",
+                                                "type": "array",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "type": "object",
                                                   "required": [
                                                     "key",
                                                     "operator"
                                                   ],
-                                                  "type": "object",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
                                                   "additionalProperties": false
-                                                },
-                                                "type": "array"
+                                                }
+                                              },
+                                              "matchFields": {
+                                                "description": "A list of node selector requirements by node's fields.",
+                                                "type": "array",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  "additionalProperties": false
+                                                }
                                               }
                                             },
-                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
-                                          },
-                                          "type": "array"
+                                          }
                                         }
                                       },
-                                      "required": [
-                                        "nodeSelectorTerms"
-                                      ],
-                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     }
                                   },
-                                  "type": "object",
                                   "additionalProperties": false
                                 },
                                 "podAffinity": {
                                   "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "type": "object",
                                   "properties": {
                                     "preferredDuringSchedulingIgnoredDuringExecution": {
                                       "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "type": "array",
                                       "items": {
                                         "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "type": "object",
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
                                         "properties": {
                                           "podAffinityTerm": {
                                             "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "type": "object",
+                                            "required": [
+                                              "topologyKey"
+                                            ],
                                             "properties": {
                                               "labelSelector": {
                                                 "description": "A label query over a set of resources, in this case pods.",
+                                                "type": "object",
                                                 "properties": {
                                                   "matchExpressions": {
                                                     "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "type": "array",
                                                     "items": {
                                                       "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
                                                       "properties": {
                                                         "key": {
                                                           "description": "key is the label key that the selector applies to.",
@@ -820,39 +870,40 @@
                                                         },
                                                         "values": {
                                                           "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "type": "array",
                                                           "items": {
                                                             "type": "string"
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         }
                                                       },
-                                                      "required": [
-                                                        "key",
-                                                        "operator"
-                                                      ],
-                                                      "type": "object",
                                                       "additionalProperties": false
-                                                    },
-                                                    "type": "array"
+                                                    }
                                                   },
                                                   "matchLabels": {
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object",
                                                     "additionalProperties": {
                                                       "type": "string"
-                                                    },
-                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                    "type": "object"
+                                                    }
                                                   }
                                                 },
-                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "namespaceSelector": {
                                                 "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                "type": "object",
                                                 "properties": {
                                                   "matchExpressions": {
                                                     "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "type": "array",
                                                     "items": {
                                                       "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
                                                       "properties": {
                                                         "key": {
                                                           "description": "key is the label key that the selector applies to.",
@@ -864,77 +915,73 @@
                                                         },
                                                         "values": {
                                                           "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "type": "array",
                                                           "items": {
                                                             "type": "string"
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         }
                                                       },
-                                                      "required": [
-                                                        "key",
-                                                        "operator"
-                                                      ],
-                                                      "type": "object",
                                                       "additionalProperties": false
-                                                    },
-                                                    "type": "array"
+                                                    }
                                                   },
                                                   "matchLabels": {
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object",
                                                     "additionalProperties": {
                                                       "type": "string"
-                                                    },
-                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                    "type": "object"
+                                                    }
                                                   }
                                                 },
-                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "namespaces": {
                                                 "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                },
-                                                "type": "array"
+                                                }
                                               },
                                               "topologyKey": {
                                                 "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                 "type": "string"
                                               }
                                             },
-                                            "required": [
-                                              "topologyKey"
-                                            ],
-                                            "type": "object",
                                             "additionalProperties": false
                                           },
                                           "weight": {
                                             "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-                                            "format": "int32",
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "format": "int32"
                                           }
                                         },
-                                        "required": [
-                                          "podAffinityTerm",
-                                          "weight"
-                                        ],
-                                        "type": "object",
                                         "additionalProperties": false
-                                      },
-                                      "type": "array"
+                                      }
                                     },
                                     "requiredDuringSchedulingIgnoredDuringExecution": {
                                       "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "type": "array",
                                       "items": {
                                         "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "type": "object",
+                                        "required": [
+                                          "topologyKey"
+                                        ],
                                         "properties": {
                                           "labelSelector": {
                                             "description": "A label query over a set of resources, in this case pods.",
+                                            "type": "object",
                                             "properties": {
                                               "matchExpressions": {
                                                 "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "type": "array",
                                                 "items": {
                                                   "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
                                                   "properties": {
                                                     "key": {
                                                       "description": "key is the label key that the selector applies to.",
@@ -946,39 +993,40 @@
                                                     },
                                                     "values": {
                                                       "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     }
                                                   },
-                                                  "required": [
-                                                    "key",
-                                                    "operator"
-                                                  ],
-                                                  "type": "object",
                                                   "additionalProperties": false
-                                                },
-                                                "type": "array"
+                                                }
                                               },
                                               "matchLabels": {
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object",
                                                 "additionalProperties": {
                                                   "type": "string"
-                                                },
-                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                "type": "object"
+                                                }
                                               }
                                             },
-                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
                                           },
                                           "namespaceSelector": {
                                             "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                            "type": "object",
                                             "properties": {
                                               "matchExpressions": {
                                                 "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "type": "array",
                                                 "items": {
                                                   "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
                                                   "properties": {
                                                     "key": {
                                                       "description": "key is the label key that the selector applies to.",
@@ -990,74 +1038,80 @@
                                                     },
                                                     "values": {
                                                       "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     }
                                                   },
-                                                  "required": [
-                                                    "key",
-                                                    "operator"
-                                                  ],
-                                                  "type": "object",
                                                   "additionalProperties": false
-                                                },
-                                                "type": "array"
+                                                }
                                               },
                                               "matchLabels": {
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object",
                                                 "additionalProperties": {
                                                   "type": "string"
-                                                },
-                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                "type": "object"
+                                                }
                                               }
                                             },
-                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
                                           },
                                           "namespaces": {
                                             "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                            "type": "array",
                                             "items": {
                                               "type": "string"
-                                            },
-                                            "type": "array"
+                                            }
                                           },
                                           "topologyKey": {
                                             "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "topologyKey"
-                                        ],
-                                        "type": "object",
                                         "additionalProperties": false
-                                      },
-                                      "type": "array"
+                                      }
                                     }
                                   },
-                                  "type": "object",
                                   "additionalProperties": false
                                 },
                                 "podAntiAffinity": {
                                   "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "type": "object",
                                   "properties": {
                                     "preferredDuringSchedulingIgnoredDuringExecution": {
                                       "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "type": "array",
                                       "items": {
                                         "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "type": "object",
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
                                         "properties": {
                                           "podAffinityTerm": {
                                             "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "type": "object",
+                                            "required": [
+                                              "topologyKey"
+                                            ],
                                             "properties": {
                                               "labelSelector": {
                                                 "description": "A label query over a set of resources, in this case pods.",
+                                                "type": "object",
                                                 "properties": {
                                                   "matchExpressions": {
                                                     "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "type": "array",
                                                     "items": {
                                                       "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
                                                       "properties": {
                                                         "key": {
                                                           "description": "key is the label key that the selector applies to.",
@@ -1069,39 +1123,40 @@
                                                         },
                                                         "values": {
                                                           "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "type": "array",
                                                           "items": {
                                                             "type": "string"
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         }
                                                       },
-                                                      "required": [
-                                                        "key",
-                                                        "operator"
-                                                      ],
-                                                      "type": "object",
                                                       "additionalProperties": false
-                                                    },
-                                                    "type": "array"
+                                                    }
                                                   },
                                                   "matchLabels": {
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object",
                                                     "additionalProperties": {
                                                       "type": "string"
-                                                    },
-                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                    "type": "object"
+                                                    }
                                                   }
                                                 },
-                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "namespaceSelector": {
                                                 "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                "type": "object",
                                                 "properties": {
                                                   "matchExpressions": {
                                                     "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "type": "array",
                                                     "items": {
                                                       "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
                                                       "properties": {
                                                         "key": {
                                                           "description": "key is the label key that the selector applies to.",
@@ -1113,77 +1168,73 @@
                                                         },
                                                         "values": {
                                                           "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "type": "array",
                                                           "items": {
                                                             "type": "string"
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         }
                                                       },
-                                                      "required": [
-                                                        "key",
-                                                        "operator"
-                                                      ],
-                                                      "type": "object",
                                                       "additionalProperties": false
-                                                    },
-                                                    "type": "array"
+                                                    }
                                                   },
                                                   "matchLabels": {
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object",
                                                     "additionalProperties": {
                                                       "type": "string"
-                                                    },
-                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                    "type": "object"
+                                                    }
                                                   }
                                                 },
-                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "namespaces": {
                                                 "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                },
-                                                "type": "array"
+                                                }
                                               },
                                               "topologyKey": {
                                                 "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                 "type": "string"
                                               }
                                             },
-                                            "required": [
-                                              "topologyKey"
-                                            ],
-                                            "type": "object",
                                             "additionalProperties": false
                                           },
                                           "weight": {
                                             "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-                                            "format": "int32",
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "format": "int32"
                                           }
                                         },
-                                        "required": [
-                                          "podAffinityTerm",
-                                          "weight"
-                                        ],
-                                        "type": "object",
                                         "additionalProperties": false
-                                      },
-                                      "type": "array"
+                                      }
                                     },
                                     "requiredDuringSchedulingIgnoredDuringExecution": {
                                       "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "type": "array",
                                       "items": {
                                         "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "type": "object",
+                                        "required": [
+                                          "topologyKey"
+                                        ],
                                         "properties": {
                                           "labelSelector": {
                                             "description": "A label query over a set of resources, in this case pods.",
+                                            "type": "object",
                                             "properties": {
                                               "matchExpressions": {
                                                 "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "type": "array",
                                                 "items": {
                                                   "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
                                                   "properties": {
                                                     "key": {
                                                       "description": "key is the label key that the selector applies to.",
@@ -1195,39 +1246,40 @@
                                                     },
                                                     "values": {
                                                       "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     }
                                                   },
-                                                  "required": [
-                                                    "key",
-                                                    "operator"
-                                                  ],
-                                                  "type": "object",
                                                   "additionalProperties": false
-                                                },
-                                                "type": "array"
+                                                }
                                               },
                                               "matchLabels": {
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object",
                                                 "additionalProperties": {
                                                   "type": "string"
-                                                },
-                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                "type": "object"
+                                                }
                                               }
                                             },
-                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
                                           },
                                           "namespaceSelector": {
                                             "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                            "type": "object",
                                             "properties": {
                                               "matchExpressions": {
                                                 "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "type": "array",
                                                 "items": {
                                                   "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
                                                   "properties": {
                                                     "key": {
                                                       "description": "key is the label key that the selector applies to.",
@@ -1239,66 +1291,53 @@
                                                     },
                                                     "values": {
                                                       "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     }
                                                   },
-                                                  "required": [
-                                                    "key",
-                                                    "operator"
-                                                  ],
-                                                  "type": "object",
                                                   "additionalProperties": false
-                                                },
-                                                "type": "array"
+                                                }
                                               },
                                               "matchLabels": {
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object",
                                                 "additionalProperties": {
                                                   "type": "string"
-                                                },
-                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                "type": "object"
+                                                }
                                               }
                                             },
-                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
                                           },
                                           "namespaces": {
                                             "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                            "type": "array",
                                             "items": {
                                               "type": "string"
-                                            },
-                                            "type": "array"
+                                            }
                                           },
                                           "topologyKey": {
                                             "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "topologyKey"
-                                        ],
-                                        "type": "object",
                                         "additionalProperties": false
-                                      },
-                                      "type": "array"
+                                      }
                                     }
                                   },
-                                  "type": "object",
                                   "additionalProperties": false
                                 }
                               },
-                              "type": "object",
                               "additionalProperties": false
                             },
                             "nodeSelector": {
+                              "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                              "type": "object",
                               "additionalProperties": {
                                 "type": "string"
-                              },
-                              "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
-                              "type": "object"
+                              }
                             },
                             "priorityClassName": {
                               "description": "If specified, the pod's priorityClassName.",
@@ -1310,8 +1349,10 @@
                             },
                             "tolerations": {
                               "description": "If specified, the pod's tolerations.",
+                              "type": "array",
                               "items": {
                                 "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                "type": "object",
                                 "properties": {
                                   "effect": {
                                     "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
@@ -1327,25 +1368,21 @@
                                   },
                                   "tolerationSeconds": {
                                     "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
-                                    "format": "int64",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "format": "int64"
                                   },
                                   "value": {
                                     "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
                                     "type": "string"
                                   }
                                 },
-                                "type": "object",
                                 "additionalProperties": false
-                              },
-                              "type": "array"
+                              }
                             }
                           },
-                          "type": "object",
                           "additionalProperties": false
                         }
                       },
-                      "type": "object",
                       "additionalProperties": false
                     },
                     "serviceType": {
@@ -1353,43 +1390,40 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
                   "additionalProperties": false
                 }
               },
-              "type": "object",
               "additionalProperties": false
             },
             "selector": {
               "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+              "type": "object",
               "properties": {
                 "dnsNames": {
                   "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                  "type": "array",
                   "items": {
                     "type": "string"
-                  },
-                  "type": "array"
+                  }
                 },
                 "dnsZones": {
                   "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                  "type": "array",
                   "items": {
                     "type": "string"
-                  },
-                  "type": "array"
+                  }
                 },
                 "matchLabels": {
+                  "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                  "type": "object",
                   "additionalProperties": {
                     "type": "string"
-                  },
-                  "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
-                  "type": "object"
+                  }
                 }
               },
-              "type": "object",
               "additionalProperties": false
             }
           },
-          "type": "object",
           "additionalProperties": false
         },
         "token": {
@@ -1398,11 +1432,11 @@
         },
         "type": {
           "description": "The type of ACME challenge this resource represents. One of \"HTTP-01\" or \"DNS-01\".",
+          "type": "string",
           "enum": [
             "HTTP-01",
             "DNS-01"
-          ],
-          "type": "string"
+          ]
         },
         "url": {
           "description": "The URL of the ACME Challenge resource for this challenge. This can be used to lookup details about the status of this challenge.",
@@ -1413,20 +1447,10 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "authorizationURL",
-        "dnsName",
-        "issuerRef",
-        "key",
-        "solver",
-        "token",
-        "type",
-        "url"
-      ],
-      "type": "object",
       "additionalProperties": false
     },
     "status": {
+      "type": "object",
       "properties": {
         "presented": {
           "description": "presented will be set to true if the challenge values for this challenge are currently 'presented'. This *does not* imply the self check is passing. Only that the values have been 'submitted' for the appropriate challenge mechanism (i.e. the DNS01 TXT record has been presented, or the HTTP01 configuration has been configured).",
@@ -1442,6 +1466,7 @@
         },
         "state": {
           "description": "Contains the current 'state' of the challenge. If not set, the state of the challenge is unknown.",
+          "type": "string",
           "enum": [
             "valid",
             "ready",
@@ -1450,17 +1475,10 @@
             "invalid",
             "expired",
             "errored"
-          ],
-          "type": "string"
+          ]
         }
       },
-      "type": "object",
       "additionalProperties": false
     }
-  },
-  "required": [
-    "metadata",
-    "spec"
-  ],
-  "type": "object"
+  }
 }

--- a/cert-manager.io/clusterissuer_v1.json
+++ b/cert-manager.io/clusterissuer_v1.json
@@ -1,5 +1,9 @@
 {
   "description": "A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -14,10 +18,21 @@
     },
     "spec": {
       "description": "Desired state of the ClusterIssuer resource.",
+      "type": "object",
       "properties": {
         "acme": {
           "description": "ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.",
+          "type": "object",
+          "required": [
+            "privateKeySecretRef",
+            "server"
+          ],
           "properties": {
+            "caBundle": {
+              "description": "Base64-encoded bundle of PEM CAs which can be used to validate the certificate chain presented by the ACME server. Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various kinds of security vulnerabilities. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection.",
+              "type": "string",
+              "format": "byte"
+            },
             "disableAccountKeyGeneration": {
               "description": "Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.",
               "type": "boolean"
@@ -32,15 +47,20 @@
             },
             "externalAccountBinding": {
               "description": "ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.",
+              "type": "object",
+              "required": [
+                "keyID",
+                "keySecretRef"
+              ],
               "properties": {
                 "keyAlgorithm": {
                   "description": "Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.",
+                  "type": "string",
                   "enum": [
                     "HS256",
                     "HS384",
                     "HS512"
-                  ],
-                  "type": "string"
+                  ]
                 },
                 "keyID": {
                   "description": "keyID is the ID of the CA key that the External Account is bound to.",
@@ -48,6 +68,10 @@
                 },
                 "keySecretRef": {
                   "description": "keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "key": {
                       "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -58,27 +82,22 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 }
               },
-              "required": [
-                "keyID",
-                "keySecretRef"
-              ],
-              "type": "object",
               "additionalProperties": false
             },
             "preferredChain": {
               "description": "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN",
-              "maxLength": 64,
-              "type": "string"
+              "type": "string",
+              "maxLength": 64
             },
             "privateKeySecretRef": {
               "description": "PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
               "properties": {
                 "key": {
                   "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -89,10 +108,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "name"
-              ],
-              "type": "object",
               "additionalProperties": false
             },
             "server": {
@@ -100,22 +115,34 @@
               "type": "string"
             },
             "skipTLSVerify": {
-              "description": "Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.",
+              "description": "INSECURE: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have the TLS certificate chain validated. Mutually exclusive with CABundle; prefer using CABundle to prevent various kinds of security vulnerabilities. Only enable this option in development environments. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection. Defaults to false.",
               "type": "boolean"
             },
             "solvers": {
               "description": "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+              "type": "array",
               "items": {
                 "description": "An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.",
+                "type": "object",
                 "properties": {
                   "dns01": {
                     "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                    "type": "object",
                     "properties": {
                       "acmeDNS": {
                         "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "accountSecretRef",
+                          "host"
+                        ],
                         "properties": {
                           "accountSecretRef": {
                             "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -126,95 +153,91 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "host": {
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "accountSecretRef",
-                          "host"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "akamai": {
                         "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
-                        "properties": {
-                          "accessTokenSecretRef": {
-                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
-                            "properties": {
-                              "key": {
-                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "clientSecretSecretRef": {
-                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
-                            "properties": {
-                              "key": {
-                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "clientTokenSecretRef": {
-                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
-                            "properties": {
-                              "key": {
-                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "serviceConsumerDomain": {
-                            "type": "string"
-                          }
-                        },
+                        "type": "object",
                         "required": [
                           "accessTokenSecretRef",
                           "clientSecretSecretRef",
                           "clientTokenSecretRef",
                           "serviceConsumerDomain"
                         ],
-                        "type": "object",
+                        "properties": {
+                          "accessTokenSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "clientSecretSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "clientTokenSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "serviceConsumerDomain": {
+                            "type": "string"
+                          }
+                        },
                         "additionalProperties": false
                       },
                       "azureDNS": {
                         "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "resourceGroupName",
+                          "subscriptionID"
+                        ],
                         "properties": {
                           "clientID": {
                             "description": "if both this and ClientSecret are left unset MSI will be used",
@@ -222,6 +245,10 @@
                           },
                           "clientSecretSecretRef": {
                             "description": "if both this and ClientID are left unset MSI will be used",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -232,21 +259,17 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "environment": {
                             "description": "name of the Azure environment (default AzurePublicCloud)",
+                            "type": "string",
                             "enum": [
                               "AzurePublicCloud",
                               "AzureChinaCloud",
                               "AzureGermanCloud",
                               "AzureUSGovernmentCloud"
-                            ],
-                            "type": "string"
+                            ]
                           },
                           "hostedZoneName": {
                             "description": "name of the DNS zone that should be used",
@@ -254,6 +277,7 @@
                           },
                           "managedIdentity": {
                             "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                            "type": "object",
                             "properties": {
                               "clientID": {
                                 "description": "client ID of the managed identity, can not be used at the same time as resourceID",
@@ -264,7 +288,6 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "resourceGroupName": {
@@ -280,15 +303,14 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "resourceGroupName",
-                          "subscriptionID"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "cloudDNS": {
                         "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "project"
+                        ],
                         "properties": {
                           "hostedZoneName": {
                             "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
@@ -299,6 +321,10 @@
                           },
                           "serviceAccountSecretRef": {
                             "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -309,24 +335,21 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "project"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "cloudflare": {
                         "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                        "type": "object",
                         "properties": {
                           "apiKeySecretRef": {
                             "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -337,14 +360,14 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "apiTokenSecretRef": {
                             "description": "API token used to authenticate with Cloudflare.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -355,10 +378,6 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "email": {
@@ -366,22 +385,29 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "cnameStrategy": {
                         "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                        "type": "string",
                         "enum": [
                           "None",
                           "Follow"
-                        ],
-                        "type": "string"
+                        ]
                       },
                       "digitalocean": {
                         "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "tokenSecretRef"
+                        ],
                         "properties": {
                           "tokenSecretRef": {
                             "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -392,21 +418,17 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "tokenSecretRef"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "rfc2136": {
                         "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "nameserver"
+                        ],
                         "properties": {
                           "nameserver": {
                             "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1])\u00a0; port is optional. This field is required.",
@@ -422,6 +444,10 @@
                           },
                           "tsigSecretSecretRef": {
                             "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -432,21 +458,17 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "nameserver"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "route53": {
                         "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "region"
+                        ],
                         "properties": {
                           "accessKeyID": {
                             "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
@@ -454,6 +476,10 @@
                           },
                           "accessKeyIDSecretRef": {
                             "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -464,10 +490,6 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "hostedZoneID": {
@@ -484,6 +506,10 @@
                           },
                           "secretAccessKeySecretRef": {
                             "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -494,21 +520,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "region"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "webhook": {
                         "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "groupName",
+                          "solverName"
+                        ],
                         "properties": {
                           "config": {
                             "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
@@ -523,89 +546,92 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "groupName",
-                          "solverName"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       }
                     },
-                    "type": "object",
                     "additionalProperties": false
                   },
                   "http01": {
                     "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                    "type": "object",
                     "properties": {
                       "gatewayHTTPRoute": {
                         "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                        "type": "object",
                         "properties": {
                           "labels": {
+                            "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                            "type": "object",
                             "additionalProperties": {
                               "type": "string"
-                            },
-                            "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
-                            "type": "object"
+                            }
                           },
                           "parentRefs": {
-                            "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                            "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways",
+                            "type": "array",
                             "items": {
-                              "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
-                              "properties": {
-                                "group": {
-                                  "default": "gateway.networking.k8s.io",
-                                  "description": "Group is the group of the referent. \n Support: Core",
-                                  "maxLength": 253,
-                                  "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                                  "type": "string"
-                                },
-                                "kind": {
-                                  "default": "Gateway",
-                                  "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
-                                  "maxLength": 63,
-                                  "minLength": 1,
-                                  "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
-                                  "type": "string"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the referent. \n Support: Core",
-                                  "maxLength": 253,
-                                  "minLength": 1,
-                                  "type": "string"
-                                },
-                                "namespace": {
-                                  "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
-                                  "maxLength": 63,
-                                  "minLength": 1,
-                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                                  "type": "string"
-                                },
-                                "sectionName": {
-                                  "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
-                                  "maxLength": 253,
-                                  "minLength": 1,
-                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                                  "type": "string"
-                                }
-                              },
+                              "description": "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid.",
+                              "type": "object",
                               "required": [
                                 "name"
                               ],
-                              "type": "object",
+                              "properties": {
+                                "group": {
+                                  "description": "Group is the group of the referent. When unspecified, \"gateway.networking.k8s.io\" is inferred. To set the core API group (such as for a \"Service\" kind referent), Group must be explicitly set to \"\" (empty string). \n Support: Core",
+                                  "type": "string",
+                                  "default": "gateway.networking.k8s.io",
+                                  "maxLength": 253,
+                                  "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                                },
+                                "kind": {
+                                  "description": "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Implementation-specific (Other Resources)",
+                                  "type": "string",
+                                  "default": "Gateway",
+                                  "maxLength": 63,
+                                  "minLength": 1,
+                                  "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the referent. \n Support: Core",
+                                  "type": "string",
+                                  "maxLength": 253,
+                                  "minLength": 1
+                                },
+                                "namespace": {
+                                  "description": "Namespace is the namespace of the referent. When unspecified, this refers to the local namespace of the Route. \n Note that there are specific rules for ParentRefs which cross namespace boundaries. Cross-namespace references are only valid if they are explicitly allowed by something in the namespace they are referring to. For example: Gateway has the AllowedRoutes field, and ReferenceGrant provides a generic way to enable any other kind of cross-namespace reference. \n Support: Core",
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                                },
+                                "port": {
+                                  "description": "Port is the network port this Route targets. It can be interpreted differently based on the type of parent resource. \n When the parent resource is a Gateway, this targets all listeners listening on the specified port that also support this kind of Route(and select this Route). It's not recommended to set `Port` unless the networking behaviors specified in a Route must apply to a specific port as opposed to a listener(s) whose port(s) may be changed. When both Port and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support other parent resources. Implementations supporting other types of parent resources MUST clearly document how/if Port is interpreted. \n For the purpose of status, an attachment is considered successful as long as the parent resource accepts it partially. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Extended \n <gateway:experimental>",
+                                  "type": "integer",
+                                  "format": "int32",
+                                  "maximum": 65535,
+                                  "minimum": 1
+                                },
+                                "sectionName": {
+                                  "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name. When both Port (experimental) and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                  "type": "string",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                                }
+                              },
                               "additionalProperties": false
-                            },
-                            "type": "array"
+                            }
                           },
                           "serviceType": {
                             "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
                             "type": "string"
                           }
                         },
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "ingress": {
                         "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                        "type": "object",
                         "properties": {
                           "class": {
                             "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
@@ -613,30 +639,30 @@
                           },
                           "ingressTemplate": {
                             "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                            "type": "object",
                             "properties": {
                               "metadata": {
                                 "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                "type": "object",
                                 "properties": {
                                   "annotations": {
+                                    "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
-                                    "type": "object"
+                                    }
                                   },
                                   "labels": {
+                                    "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
-                                    "type": "object"
+                                    }
                                   }
                                 },
-                                "type": "object",
                                 "additionalProperties": false
                               }
                             },
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "name": {
@@ -645,136 +671,66 @@
                           },
                           "podTemplate": {
                             "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                            "type": "object",
                             "properties": {
                               "metadata": {
                                 "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                "type": "object",
                                 "properties": {
                                   "annotations": {
+                                    "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
-                                    "type": "object"
+                                    }
                                   },
                                   "labels": {
+                                    "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
-                                    "type": "object"
+                                    }
                                   }
                                 },
-                                "type": "object",
                                 "additionalProperties": false
                               },
                               "spec": {
                                 "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                "type": "object",
                                 "properties": {
                                   "affinity": {
                                     "description": "If specified, the pod's scheduling constraints",
+                                    "type": "object",
                                     "properties": {
                                       "nodeAffinity": {
                                         "description": "Describes node affinity scheduling rules for the pod.",
+                                        "type": "object",
                                         "properties": {
                                           "preferredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                            "type": "array",
                                             "items": {
                                               "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
-                                              "properties": {
-                                                "preference": {
-                                                  "description": "A node selector term, associated with the corresponding weight.",
-                                                  "properties": {
-                                                    "matchExpressions": {
-                                                      "description": "A list of node selector requirements by node's labels.",
-                                                      "items": {
-                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-                                                        "properties": {
-                                                          "key": {
-                                                            "description": "The label key that the selector applies to.",
-                                                            "type": "string"
-                                                          },
-                                                          "operator": {
-                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                            "type": "string"
-                                                          },
-                                                          "values": {
-                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-                                                            "items": {
-                                                              "type": "string"
-                                                            },
-                                                            "type": "array"
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                      },
-                                                      "type": "array"
-                                                    },
-                                                    "matchFields": {
-                                                      "description": "A list of node selector requirements by node's fields.",
-                                                      "items": {
-                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-                                                        "properties": {
-                                                          "key": {
-                                                            "description": "The label key that the selector applies to.",
-                                                            "type": "string"
-                                                          },
-                                                          "operator": {
-                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                            "type": "string"
-                                                          },
-                                                          "values": {
-                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-                                                            "items": {
-                                                              "type": "string"
-                                                            },
-                                                            "type": "array"
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                      },
-                                                      "type": "array"
-                                                    }
-                                                  },
-                                                  "type": "object",
-                                                  "additionalProperties": false
-                                                },
-                                                "weight": {
-                                                  "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
-                                                  "format": "int32",
-                                                  "type": "integer"
-                                                }
-                                              },
+                                              "type": "object",
                                               "required": [
                                                 "preference",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
-                                            },
-                                            "type": "array"
-                                          },
-                                          "requiredDuringSchedulingIgnoredDuringExecution": {
-                                            "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
-                                            "properties": {
-                                              "nodeSelectorTerms": {
-                                                "description": "Required. A list of node selector terms. The terms are ORed.",
-                                                "items": {
-                                                  "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                              "properties": {
+                                                "preference": {
+                                                  "description": "A node selector term, associated with the corresponding weight.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "A list of node selector requirements by node's labels.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "The label key that the selector applies to.",
@@ -786,25 +742,25 @@
                                                           },
                                                           "values": {
                                                             "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchFields": {
                                                       "description": "A list of node selector requirements by node's fields.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "The label key that the selector applies to.",
@@ -816,56 +772,150 @@
                                                           },
                                                           "values": {
                                                             "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
+                                                        "additionalProperties": false
+                                                      }
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "weight": {
+                                                  "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                  "type": "integer",
+                                                  "format": "int32"
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "requiredDuringSchedulingIgnoredDuringExecution": {
+                                            "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                            "type": "object",
+                                            "required": [
+                                              "nodeSelectorTerms"
+                                            ],
+                                            "properties": {
+                                              "nodeSelectorTerms": {
+                                                "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                "type": "array",
+                                                "items": {
+                                                  "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "A list of node selector requirements by node's labels.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "The label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        },
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
+                                                    },
+                                                    "matchFields": {
+                                                      "description": "A list of node selector requirements by node's fields.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "The label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        },
+                                                        "additionalProperties": false
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
-                                                },
-                                                "type": "array"
+                                                }
                                               }
                                             },
-                                            "required": [
-                                              "nodeSelectorTerms"
-                                            ],
-                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
                                           }
                                         },
-                                        "type": "object",
                                         "additionalProperties": false
                                       },
                                       "podAffinity": {
                                         "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                        "type": "object",
                                         "properties": {
                                           "preferredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                            "type": "array",
                                             "items": {
                                               "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                              "type": "object",
+                                              "required": [
+                                                "podAffinityTerm",
+                                                "weight"
+                                              ],
                                               "properties": {
                                                 "podAffinityTerm": {
                                                   "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "topologyKey"
+                                                  ],
                                                   "properties": {
                                                     "labelSelector": {
                                                       "description": "A label query over a set of resources, in this case pods.",
+                                                      "type": "object",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "type": "array",
                                                           "items": {
                                                             "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
                                                             "properties": {
                                                               "key": {
                                                                 "description": "key is the label key that the selector applies to.",
@@ -877,39 +927,40 @@
                                                               },
                                                               "values": {
                                                                 "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "type": "array",
                                                                 "items": {
                                                                   "type": "string"
-                                                                },
-                                                                "type": "array"
+                                                                }
                                                               }
                                                             },
-                                                            "required": [
-                                                              "key",
-                                                              "operator"
-                                                            ],
-                                                            "type": "object",
                                                             "additionalProperties": false
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         },
                                                         "matchLabels": {
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object",
                                                           "additionalProperties": {
                                                             "type": "string"
-                                                          },
-                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                          "type": "object"
+                                                          }
                                                         }
                                                       },
-                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
                                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                      "type": "object",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "type": "array",
                                                           "items": {
                                                             "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
                                                             "properties": {
                                                               "key": {
                                                                 "description": "key is the label key that the selector applies to.",
@@ -921,77 +972,73 @@
                                                               },
                                                               "values": {
                                                                 "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "type": "array",
                                                                 "items": {
                                                                   "type": "string"
-                                                                },
-                                                                "type": "array"
+                                                                }
                                                               }
                                                             },
-                                                            "required": [
-                                                              "key",
-                                                              "operator"
-                                                            ],
-                                                            "type": "object",
                                                             "additionalProperties": false
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         },
                                                         "matchLabels": {
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object",
                                                           "additionalProperties": {
                                                             "type": "string"
-                                                          },
-                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                          "type": "object"
+                                                          }
                                                         }
                                                       },
-                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "topologyKey": {
                                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "topologyKey"
-                                                  ],
-                                                  "type": "object",
                                                   "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-                                                  "format": "int32",
-                                                  "type": "integer"
+                                                  "type": "integer",
+                                                  "format": "int32"
                                                 }
                                               },
-                                              "required": [
-                                                "podAffinityTerm",
-                                                "weight"
-                                              ],
-                                              "type": "object",
                                               "additionalProperties": false
-                                            },
-                                            "type": "array"
+                                            }
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                            "type": "array",
                                             "items": {
                                               "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "type": "object",
+                                              "required": [
+                                                "topologyKey"
+                                              ],
                                               "properties": {
                                                 "labelSelector": {
                                                   "description": "A label query over a set of resources, in this case pods.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "key is the label key that the selector applies to.",
@@ -1003,39 +1050,40 @@
                                                           },
                                                           "values": {
                                                             "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
                                                       "additionalProperties": {
                                                         "type": "string"
-                                                      },
-                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                      "type": "object"
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
                                                   "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "key is the label key that the selector applies to.",
@@ -1047,74 +1095,80 @@
                                                           },
                                                           "values": {
                                                             "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
                                                       "additionalProperties": {
                                                         "type": "string"
-                                                      },
-                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                      "type": "object"
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                  "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  },
-                                                  "type": "array"
+                                                  }
                                                 },
                                                 "topologyKey": {
                                                   "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "topologyKey"
-                                              ],
-                                              "type": "object",
                                               "additionalProperties": false
-                                            },
-                                            "type": "array"
+                                            }
                                           }
                                         },
-                                        "type": "object",
                                         "additionalProperties": false
                                       },
                                       "podAntiAffinity": {
                                         "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                        "type": "object",
                                         "properties": {
                                           "preferredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                            "type": "array",
                                             "items": {
                                               "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                              "type": "object",
+                                              "required": [
+                                                "podAffinityTerm",
+                                                "weight"
+                                              ],
                                               "properties": {
                                                 "podAffinityTerm": {
                                                   "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "topologyKey"
+                                                  ],
                                                   "properties": {
                                                     "labelSelector": {
                                                       "description": "A label query over a set of resources, in this case pods.",
+                                                      "type": "object",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "type": "array",
                                                           "items": {
                                                             "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
                                                             "properties": {
                                                               "key": {
                                                                 "description": "key is the label key that the selector applies to.",
@@ -1126,39 +1180,40 @@
                                                               },
                                                               "values": {
                                                                 "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "type": "array",
                                                                 "items": {
                                                                   "type": "string"
-                                                                },
-                                                                "type": "array"
+                                                                }
                                                               }
                                                             },
-                                                            "required": [
-                                                              "key",
-                                                              "operator"
-                                                            ],
-                                                            "type": "object",
                                                             "additionalProperties": false
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         },
                                                         "matchLabels": {
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object",
                                                           "additionalProperties": {
                                                             "type": "string"
-                                                          },
-                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                          "type": "object"
+                                                          }
                                                         }
                                                       },
-                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
                                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                      "type": "object",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "type": "array",
                                                           "items": {
                                                             "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
                                                             "properties": {
                                                               "key": {
                                                                 "description": "key is the label key that the selector applies to.",
@@ -1170,77 +1225,73 @@
                                                               },
                                                               "values": {
                                                                 "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "type": "array",
                                                                 "items": {
                                                                   "type": "string"
-                                                                },
-                                                                "type": "array"
+                                                                }
                                                               }
                                                             },
-                                                            "required": [
-                                                              "key",
-                                                              "operator"
-                                                            ],
-                                                            "type": "object",
                                                             "additionalProperties": false
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         },
                                                         "matchLabels": {
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object",
                                                           "additionalProperties": {
                                                             "type": "string"
-                                                          },
-                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                          "type": "object"
+                                                          }
                                                         }
                                                       },
-                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "topologyKey": {
                                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "topologyKey"
-                                                  ],
-                                                  "type": "object",
                                                   "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-                                                  "format": "int32",
-                                                  "type": "integer"
+                                                  "type": "integer",
+                                                  "format": "int32"
                                                 }
                                               },
-                                              "required": [
-                                                "podAffinityTerm",
-                                                "weight"
-                                              ],
-                                              "type": "object",
                                               "additionalProperties": false
-                                            },
-                                            "type": "array"
+                                            }
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                            "type": "array",
                                             "items": {
                                               "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "type": "object",
+                                              "required": [
+                                                "topologyKey"
+                                              ],
                                               "properties": {
                                                 "labelSelector": {
                                                   "description": "A label query over a set of resources, in this case pods.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "key is the label key that the selector applies to.",
@@ -1252,39 +1303,40 @@
                                                           },
                                                           "values": {
                                                             "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
                                                       "additionalProperties": {
                                                         "type": "string"
-                                                      },
-                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                      "type": "object"
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
                                                   "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "key is the label key that the selector applies to.",
@@ -1296,66 +1348,53 @@
                                                           },
                                                           "values": {
                                                             "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
                                                       "additionalProperties": {
                                                         "type": "string"
-                                                      },
-                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                      "type": "object"
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                  "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  },
-                                                  "type": "array"
+                                                  }
                                                 },
                                                 "topologyKey": {
                                                   "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "topologyKey"
-                                              ],
-                                              "type": "object",
                                               "additionalProperties": false
-                                            },
-                                            "type": "array"
+                                            }
                                           }
                                         },
-                                        "type": "object",
                                         "additionalProperties": false
                                       }
                                     },
-                                    "type": "object",
                                     "additionalProperties": false
                                   },
                                   "nodeSelector": {
+                                    "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
-                                    "type": "object"
+                                    }
                                   },
                                   "priorityClassName": {
                                     "description": "If specified, the pod's priorityClassName.",
@@ -1367,8 +1406,10 @@
                                   },
                                   "tolerations": {
                                     "description": "If specified, the pod's tolerations.",
+                                    "type": "array",
                                     "items": {
                                       "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                      "type": "object",
                                       "properties": {
                                         "effect": {
                                           "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
@@ -1384,25 +1425,21 @@
                                         },
                                         "tolerationSeconds": {
                                           "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
-                                          "format": "int64",
-                                          "type": "integer"
+                                          "type": "integer",
+                                          "format": "int64"
                                         },
                                         "value": {
                                           "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object",
                                       "additionalProperties": false
-                                    },
-                                    "type": "array"
+                                    }
                                   }
                                 },
-                                "type": "object",
                                 "additionalProperties": false
                               }
                             },
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "serviceType": {
@@ -1410,105 +1447,109 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
                         "additionalProperties": false
                       }
                     },
-                    "type": "object",
                     "additionalProperties": false
                   },
                   "selector": {
                     "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                    "type": "object",
                     "properties": {
                       "dnsNames": {
                         "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                        "type": "array",
                         "items": {
                           "type": "string"
-                        },
-                        "type": "array"
+                        }
                       },
                       "dnsZones": {
                         "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                        "type": "array",
                         "items": {
                           "type": "string"
-                        },
-                        "type": "array"
+                        }
                       },
                       "matchLabels": {
+                        "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                        "type": "object",
                         "additionalProperties": {
                           "type": "string"
-                        },
-                        "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
-                        "type": "object"
+                        }
                       }
                     },
-                    "type": "object",
                     "additionalProperties": false
                   }
                 },
-                "type": "object",
                 "additionalProperties": false
-              },
-              "type": "array"
+              }
             }
           },
-          "required": [
-            "privateKeySecretRef",
-            "server"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "ca": {
           "description": "CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.",
+          "type": "object",
+          "required": [
+            "secretName"
+          ],
           "properties": {
             "crlDistributionPoints": {
               "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "ocspServers": {
               "description": "The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \"http://ocsp.int-x3.letsencrypt.org\".",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "secretName": {
               "description": "SecretName is the name of the secret used to sign Certificates issued by this Issuer.",
               "type": "string"
             }
           },
-          "required": [
-            "secretName"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "selfSigned": {
           "description": "SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.",
+          "type": "object",
           "properties": {
             "crlDistributionPoints": {
               "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
-          "type": "object",
           "additionalProperties": false
         },
         "vault": {
           "description": "Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.",
+          "type": "object",
+          "required": [
+            "auth",
+            "path",
+            "server"
+          ],
           "properties": {
             "auth": {
               "description": "Auth configures how cert-manager authenticates with the Vault server.",
+              "type": "object",
               "properties": {
                 "appRole": {
                   "description": "AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.",
+                  "type": "object",
+                  "required": [
+                    "path",
+                    "roleId",
+                    "secretRef"
+                  ],
                   "properties": {
                     "path": {
                       "description": "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
@@ -1520,6 +1561,10 @@
                     },
                     "secretRef": {
                       "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1530,23 +1575,18 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "path",
-                    "roleId",
-                    "secretRef"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "kubernetes": {
                   "description": "Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.",
+                  "type": "object",
+                  "required": [
+                    "role",
+                    "secretRef"
+                  ],
                   "properties": {
                     "mountPath": {
                       "description": "The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \"/v1/auth/kubernetes\" will be used.",
@@ -1558,6 +1598,10 @@
                     },
                     "secretRef": {
                       "description": "The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1568,22 +1612,17 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "role",
-                    "secretRef"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "tokenSecretRef": {
                   "description": "TokenSecretRef authenticates with Vault by presenting a token.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "key": {
                       "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1594,20 +1633,33 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 }
               },
-              "type": "object",
               "additionalProperties": false
             },
             "caBundle": {
-              "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.",
-              "format": "byte",
-              "type": "string"
+              "description": "Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by Vault. Only used if using HTTPS to connect to Vault and ignored for HTTP connections. Mutually exclusive with CABundleSecretRef. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection.",
+              "type": "string",
+              "format": "byte"
+            },
+            "caBundleSecretRef": {
+              "description": "Reference to a Secret containing a bundle of PEM-encoded CAs to use when verifying the certificate chain presented by Vault when using HTTPS. Mutually exclusive with CABundle. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection. If no key for the Secret is specified, cert-manager will default to 'ca.crt'.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "key": {
+                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
             },
             "namespace": {
               "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
@@ -1622,22 +1674,28 @@
               "type": "string"
             }
           },
-          "required": [
-            "auth",
-            "path",
-            "server"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "venafi": {
           "description": "Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.",
+          "type": "object",
+          "required": [
+            "zone"
+          ],
           "properties": {
             "cloud": {
               "description": "Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.",
+              "type": "object",
+              "required": [
+                "apiTokenSecretRef"
+              ],
               "properties": {
                 "apiTokenSecretRef": {
                   "description": "APITokenSecretRef is a secret key selector for the Venafi Cloud API token.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "key": {
                       "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1648,10 +1706,6 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "url": {
@@ -1659,32 +1713,33 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "apiTokenSecretRef"
-              ],
-              "type": "object",
               "additionalProperties": false
             },
             "tpp": {
               "description": "TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.",
+              "type": "object",
+              "required": [
+                "credentialsRef",
+                "url"
+              ],
               "properties": {
                 "caBundle": {
-                  "description": "CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.",
-                  "format": "byte",
-                  "type": "string"
+                  "description": "Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP. If undefined, the certificate bundle in the cert-manager controller container is used to validate the chain.",
+                  "type": "string",
+                  "format": "byte"
                 },
                 "credentialsRef": {
                   "description": "CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "name": {
                       "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "url": {
@@ -1692,11 +1747,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "credentialsRef",
-                "url"
-              ],
-              "type": "object",
               "additionalProperties": false
             },
             "zone": {
@@ -1704,21 +1754,18 @@
               "type": "string"
             }
           },
-          "required": [
-            "zone"
-          ],
-          "type": "object",
           "additionalProperties": false
         }
       },
-      "type": "object",
       "additionalProperties": false
     },
     "status": {
       "description": "Status of the ClusterIssuer. This is set and managed automatically.",
+      "type": "object",
       "properties": {
         "acme": {
           "description": "ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.",
+          "type": "object",
           "properties": {
             "lastRegisteredEmail": {
               "description": "LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer",
@@ -1729,18 +1776,23 @@
               "type": "string"
             }
           },
-          "type": "object",
           "additionalProperties": false
         },
         "conditions": {
           "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.",
+          "type": "array",
           "items": {
             "description": "IssuerCondition contains condition information for an Issuer.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
             "properties": {
               "lastTransitionTime": {
                 "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               "message": {
                 "description": "Message is a human readable description of the details of the last transition, complementing reason.",
@@ -1748,8 +1800,8 @@
               },
               "observedGeneration": {
                 "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.",
-                "format": "int64",
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "reason": {
                 "description": "Reason is a brief machine readable explanation for the condition's last transition.",
@@ -1757,38 +1809,27 @@
               },
               "status": {
                 "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                "type": "string",
                 "enum": [
                   "True",
                   "False",
                   "Unknown"
-                ],
-                "type": "string"
+                ]
               },
               "type": {
                 "description": "Type of the condition, known values are (`Ready`).",
                 "type": "string"
               }
             },
-            "required": [
-              "status",
-              "type"
-            ],
-            "type": "object",
             "additionalProperties": false
           },
-          "type": "array",
           "x-kubernetes-list-map-keys": [
             "type"
           ],
           "x-kubernetes-list-type": "map"
         }
       },
-      "type": "object",
       "additionalProperties": false
     }
-  },
-  "required": [
-    "spec"
-  ],
-  "type": "object"
+  }
 }

--- a/cert-manager.io/issuer_v1.json
+++ b/cert-manager.io/issuer_v1.json
@@ -1,5 +1,9 @@
 {
   "description": "An Issuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is scoped to a single namespace and can therefore only be referenced by resources within the same namespace.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -14,10 +18,21 @@
     },
     "spec": {
       "description": "Desired state of the Issuer resource.",
+      "type": "object",
       "properties": {
         "acme": {
           "description": "ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.",
+          "type": "object",
+          "required": [
+            "privateKeySecretRef",
+            "server"
+          ],
           "properties": {
+            "caBundle": {
+              "description": "Base64-encoded bundle of PEM CAs which can be used to validate the certificate chain presented by the ACME server. Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various kinds of security vulnerabilities. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection.",
+              "type": "string",
+              "format": "byte"
+            },
             "disableAccountKeyGeneration": {
               "description": "Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.",
               "type": "boolean"
@@ -32,15 +47,20 @@
             },
             "externalAccountBinding": {
               "description": "ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.",
+              "type": "object",
+              "required": [
+                "keyID",
+                "keySecretRef"
+              ],
               "properties": {
                 "keyAlgorithm": {
                   "description": "Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.",
+                  "type": "string",
                   "enum": [
                     "HS256",
                     "HS384",
                     "HS512"
-                  ],
-                  "type": "string"
+                  ]
                 },
                 "keyID": {
                   "description": "keyID is the ID of the CA key that the External Account is bound to.",
@@ -48,6 +68,10 @@
                 },
                 "keySecretRef": {
                   "description": "keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "key": {
                       "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -58,27 +82,22 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 }
               },
-              "required": [
-                "keyID",
-                "keySecretRef"
-              ],
-              "type": "object",
               "additionalProperties": false
             },
             "preferredChain": {
               "description": "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN",
-              "maxLength": 64,
-              "type": "string"
+              "type": "string",
+              "maxLength": 64
             },
             "privateKeySecretRef": {
               "description": "PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
               "properties": {
                 "key": {
                   "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -89,10 +108,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "name"
-              ],
-              "type": "object",
               "additionalProperties": false
             },
             "server": {
@@ -100,22 +115,34 @@
               "type": "string"
             },
             "skipTLSVerify": {
-              "description": "Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.",
+              "description": "INSECURE: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have the TLS certificate chain validated. Mutually exclusive with CABundle; prefer using CABundle to prevent various kinds of security vulnerabilities. Only enable this option in development environments. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection. Defaults to false.",
               "type": "boolean"
             },
             "solvers": {
               "description": "Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/",
+              "type": "array",
               "items": {
                 "description": "An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.",
+                "type": "object",
                 "properties": {
                   "dns01": {
                     "description": "Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.",
+                    "type": "object",
                     "properties": {
                       "acmeDNS": {
                         "description": "Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "accountSecretRef",
+                          "host"
+                        ],
                         "properties": {
                           "accountSecretRef": {
                             "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -126,95 +153,91 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "host": {
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "accountSecretRef",
-                          "host"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "akamai": {
                         "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
-                        "properties": {
-                          "accessTokenSecretRef": {
-                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
-                            "properties": {
-                              "key": {
-                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "clientSecretSecretRef": {
-                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
-                            "properties": {
-                              "key": {
-                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "clientTokenSecretRef": {
-                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
-                            "properties": {
-                              "key": {
-                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "serviceConsumerDomain": {
-                            "type": "string"
-                          }
-                        },
+                        "type": "object",
                         "required": [
                           "accessTokenSecretRef",
                           "clientSecretSecretRef",
                           "clientTokenSecretRef",
                           "serviceConsumerDomain"
                         ],
-                        "type": "object",
+                        "properties": {
+                          "accessTokenSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "clientSecretSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "clientTokenSecretRef": {
+                            "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "serviceConsumerDomain": {
+                            "type": "string"
+                          }
+                        },
                         "additionalProperties": false
                       },
                       "azureDNS": {
                         "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "resourceGroupName",
+                          "subscriptionID"
+                        ],
                         "properties": {
                           "clientID": {
                             "description": "if both this and ClientSecret are left unset MSI will be used",
@@ -222,6 +245,10 @@
                           },
                           "clientSecretSecretRef": {
                             "description": "if both this and ClientID are left unset MSI will be used",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -232,21 +259,17 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "environment": {
                             "description": "name of the Azure environment (default AzurePublicCloud)",
+                            "type": "string",
                             "enum": [
                               "AzurePublicCloud",
                               "AzureChinaCloud",
                               "AzureGermanCloud",
                               "AzureUSGovernmentCloud"
-                            ],
-                            "type": "string"
+                            ]
                           },
                           "hostedZoneName": {
                             "description": "name of the DNS zone that should be used",
@@ -254,6 +277,7 @@
                           },
                           "managedIdentity": {
                             "description": "managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID",
+                            "type": "object",
                             "properties": {
                               "clientID": {
                                 "description": "client ID of the managed identity, can not be used at the same time as resourceID",
@@ -264,7 +288,6 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "resourceGroupName": {
@@ -280,15 +303,14 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "resourceGroupName",
-                          "subscriptionID"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "cloudDNS": {
                         "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "project"
+                        ],
                         "properties": {
                           "hostedZoneName": {
                             "description": "HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.",
@@ -299,6 +321,10 @@
                           },
                           "serviceAccountSecretRef": {
                             "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -309,24 +335,21 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "project"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "cloudflare": {
                         "description": "Use the Cloudflare API to manage DNS01 challenge records.",
+                        "type": "object",
                         "properties": {
                           "apiKeySecretRef": {
                             "description": "API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -337,14 +360,14 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "apiTokenSecretRef": {
                             "description": "API token used to authenticate with Cloudflare.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -355,10 +378,6 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "email": {
@@ -366,22 +385,29 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "cnameStrategy": {
                         "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
+                        "type": "string",
                         "enum": [
                           "None",
                           "Follow"
-                        ],
-                        "type": "string"
+                        ]
                       },
                       "digitalocean": {
                         "description": "Use the DigitalOcean DNS API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "tokenSecretRef"
+                        ],
                         "properties": {
                           "tokenSecretRef": {
                             "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -392,21 +418,17 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "tokenSecretRef"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "rfc2136": {
                         "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "nameserver"
+                        ],
                         "properties": {
                           "nameserver": {
                             "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1])\u00a0; port is optional. This field is required.",
@@ -422,6 +444,10 @@
                           },
                           "tsigSecretSecretRef": {
                             "description": "The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -432,21 +458,17 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "nameserver"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "route53": {
                         "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "region"
+                        ],
                         "properties": {
                           "accessKeyID": {
                             "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
@@ -454,6 +476,10 @@
                           },
                           "accessKeyIDSecretRef": {
                             "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -464,10 +490,6 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "hostedZoneID": {
@@ -484,6 +506,10 @@
                           },
                           "secretAccessKeySecretRef": {
                             "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -494,21 +520,18 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "name"
-                            ],
-                            "type": "object",
                             "additionalProperties": false
                           }
                         },
-                        "required": [
-                          "region"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "webhook": {
                         "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
+                        "type": "object",
+                        "required": [
+                          "groupName",
+                          "solverName"
+                        ],
                         "properties": {
                           "config": {
                             "description": "Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.",
@@ -523,89 +546,92 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "groupName",
-                          "solverName"
-                        ],
-                        "type": "object",
                         "additionalProperties": false
                       }
                     },
-                    "type": "object",
                     "additionalProperties": false
                   },
                   "http01": {
                     "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
+                    "type": "object",
                     "properties": {
                       "gatewayHTTPRoute": {
                         "description": "The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.",
+                        "type": "object",
                         "properties": {
                           "labels": {
+                            "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
+                            "type": "object",
                             "additionalProperties": {
                               "type": "string"
-                            },
-                            "description": "Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.",
-                            "type": "object"
+                            }
                           },
                           "parentRefs": {
-                            "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
+                            "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways",
+                            "type": "array",
                             "items": {
-                              "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
-                              "properties": {
-                                "group": {
-                                  "default": "gateway.networking.k8s.io",
-                                  "description": "Group is the group of the referent. \n Support: Core",
-                                  "maxLength": 253,
-                                  "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                                  "type": "string"
-                                },
-                                "kind": {
-                                  "default": "Gateway",
-                                  "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
-                                  "maxLength": 63,
-                                  "minLength": 1,
-                                  "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
-                                  "type": "string"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the referent. \n Support: Core",
-                                  "maxLength": 253,
-                                  "minLength": 1,
-                                  "type": "string"
-                                },
-                                "namespace": {
-                                  "description": "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core",
-                                  "maxLength": 63,
-                                  "minLength": 1,
-                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                                  "type": "string"
-                                },
-                                "sectionName": {
-                                  "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
-                                  "maxLength": 253,
-                                  "minLength": 1,
-                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
-                                  "type": "string"
-                                }
-                              },
+                              "description": "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid.",
+                              "type": "object",
                               "required": [
                                 "name"
                               ],
-                              "type": "object",
+                              "properties": {
+                                "group": {
+                                  "description": "Group is the group of the referent. When unspecified, \"gateway.networking.k8s.io\" is inferred. To set the core API group (such as for a \"Service\" kind referent), Group must be explicitly set to \"\" (empty string). \n Support: Core",
+                                  "type": "string",
+                                  "default": "gateway.networking.k8s.io",
+                                  "maxLength": 253,
+                                  "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                                },
+                                "kind": {
+                                  "description": "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Implementation-specific (Other Resources)",
+                                  "type": "string",
+                                  "default": "Gateway",
+                                  "maxLength": 63,
+                                  "minLength": 1,
+                                  "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the referent. \n Support: Core",
+                                  "type": "string",
+                                  "maxLength": 253,
+                                  "minLength": 1
+                                },
+                                "namespace": {
+                                  "description": "Namespace is the namespace of the referent. When unspecified, this refers to the local namespace of the Route. \n Note that there are specific rules for ParentRefs which cross namespace boundaries. Cross-namespace references are only valid if they are explicitly allowed by something in the namespace they are referring to. For example: Gateway has the AllowedRoutes field, and ReferenceGrant provides a generic way to enable any other kind of cross-namespace reference. \n Support: Core",
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                                },
+                                "port": {
+                                  "description": "Port is the network port this Route targets. It can be interpreted differently based on the type of parent resource. \n When the parent resource is a Gateway, this targets all listeners listening on the specified port that also support this kind of Route(and select this Route). It's not recommended to set `Port` unless the networking behaviors specified in a Route must apply to a specific port as opposed to a listener(s) whose port(s) may be changed. When both Port and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support other parent resources. Implementations supporting other types of parent resources MUST clearly document how/if Port is interpreted. \n For the purpose of status, an attachment is considered successful as long as the parent resource accepts it partially. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Extended \n <gateway:experimental>",
+                                  "type": "integer",
+                                  "format": "int32",
+                                  "maximum": 65535,
+                                  "minimum": 1
+                                },
+                                "sectionName": {
+                                  "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name. When both Port (experimental) and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                  "type": "string",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                                }
+                              },
                               "additionalProperties": false
-                            },
-                            "type": "array"
+                            }
                           },
                           "serviceType": {
                             "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
                             "type": "string"
                           }
                         },
-                        "type": "object",
                         "additionalProperties": false
                       },
                       "ingress": {
                         "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
+                        "type": "object",
                         "properties": {
                           "class": {
                             "description": "The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.",
@@ -613,30 +639,30 @@
                           },
                           "ingressTemplate": {
                             "description": "Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.",
+                            "type": "object",
                             "properties": {
                               "metadata": {
                                 "description": "ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                "type": "object",
                                 "properties": {
                                   "annotations": {
+                                    "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "Annotations that should be added to the created ACME HTTP01 solver ingress.",
-                                    "type": "object"
+                                    }
                                   },
                                   "labels": {
+                                    "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "Labels that should be added to the created ACME HTTP01 solver ingress.",
-                                    "type": "object"
+                                    }
                                   }
                                 },
-                                "type": "object",
                                 "additionalProperties": false
                               }
                             },
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "name": {
@@ -645,136 +671,66 @@
                           },
                           "podTemplate": {
                             "description": "Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.",
+                            "type": "object",
                             "properties": {
                               "metadata": {
                                 "description": "ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.",
+                                "type": "object",
                                 "properties": {
                                   "annotations": {
+                                    "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "Annotations that should be added to the create ACME HTTP01 solver pods.",
-                                    "type": "object"
+                                    }
                                   },
                                   "labels": {
+                                    "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "Labels that should be added to the created ACME HTTP01 solver pods.",
-                                    "type": "object"
+                                    }
                                   }
                                 },
-                                "type": "object",
                                 "additionalProperties": false
                               },
                               "spec": {
                                 "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
+                                "type": "object",
                                 "properties": {
                                   "affinity": {
                                     "description": "If specified, the pod's scheduling constraints",
+                                    "type": "object",
                                     "properties": {
                                       "nodeAffinity": {
                                         "description": "Describes node affinity scheduling rules for the pod.",
+                                        "type": "object",
                                         "properties": {
                                           "preferredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                            "type": "array",
                                             "items": {
                                               "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
-                                              "properties": {
-                                                "preference": {
-                                                  "description": "A node selector term, associated with the corresponding weight.",
-                                                  "properties": {
-                                                    "matchExpressions": {
-                                                      "description": "A list of node selector requirements by node's labels.",
-                                                      "items": {
-                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-                                                        "properties": {
-                                                          "key": {
-                                                            "description": "The label key that the selector applies to.",
-                                                            "type": "string"
-                                                          },
-                                                          "operator": {
-                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                            "type": "string"
-                                                          },
-                                                          "values": {
-                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-                                                            "items": {
-                                                              "type": "string"
-                                                            },
-                                                            "type": "array"
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                      },
-                                                      "type": "array"
-                                                    },
-                                                    "matchFields": {
-                                                      "description": "A list of node selector requirements by node's fields.",
-                                                      "items": {
-                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-                                                        "properties": {
-                                                          "key": {
-                                                            "description": "The label key that the selector applies to.",
-                                                            "type": "string"
-                                                          },
-                                                          "operator": {
-                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                            "type": "string"
-                                                          },
-                                                          "values": {
-                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-                                                            "items": {
-                                                              "type": "string"
-                                                            },
-                                                            "type": "array"
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                      },
-                                                      "type": "array"
-                                                    }
-                                                  },
-                                                  "type": "object",
-                                                  "additionalProperties": false
-                                                },
-                                                "weight": {
-                                                  "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
-                                                  "format": "int32",
-                                                  "type": "integer"
-                                                }
-                                              },
+                                              "type": "object",
                                               "required": [
                                                 "preference",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
-                                            },
-                                            "type": "array"
-                                          },
-                                          "requiredDuringSchedulingIgnoredDuringExecution": {
-                                            "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
-                                            "properties": {
-                                              "nodeSelectorTerms": {
-                                                "description": "Required. A list of node selector terms. The terms are ORed.",
-                                                "items": {
-                                                  "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                              "properties": {
+                                                "preference": {
+                                                  "description": "A node selector term, associated with the corresponding weight.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "A list of node selector requirements by node's labels.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "The label key that the selector applies to.",
@@ -786,25 +742,25 @@
                                                           },
                                                           "values": {
                                                             "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchFields": {
                                                       "description": "A list of node selector requirements by node's fields.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "The label key that the selector applies to.",
@@ -816,56 +772,150 @@
                                                           },
                                                           "values": {
                                                             "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
+                                                        "additionalProperties": false
+                                                      }
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
+                                                },
+                                                "weight": {
+                                                  "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                  "type": "integer",
+                                                  "format": "int32"
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "requiredDuringSchedulingIgnoredDuringExecution": {
+                                            "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                            "type": "object",
+                                            "required": [
+                                              "nodeSelectorTerms"
+                                            ],
+                                            "properties": {
+                                              "nodeSelectorTerms": {
+                                                "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                "type": "array",
+                                                "items": {
+                                                  "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "A list of node selector requirements by node's labels.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "The label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        },
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
+                                                    },
+                                                    "matchFields": {
+                                                      "description": "A list of node selector requirements by node's fields.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "The label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        },
+                                                        "additionalProperties": false
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
-                                                },
-                                                "type": "array"
+                                                }
                                               }
                                             },
-                                            "required": [
-                                              "nodeSelectorTerms"
-                                            ],
-                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
                                           }
                                         },
-                                        "type": "object",
                                         "additionalProperties": false
                                       },
                                       "podAffinity": {
                                         "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                        "type": "object",
                                         "properties": {
                                           "preferredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                            "type": "array",
                                             "items": {
                                               "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                              "type": "object",
+                                              "required": [
+                                                "podAffinityTerm",
+                                                "weight"
+                                              ],
                                               "properties": {
                                                 "podAffinityTerm": {
                                                   "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "topologyKey"
+                                                  ],
                                                   "properties": {
                                                     "labelSelector": {
                                                       "description": "A label query over a set of resources, in this case pods.",
+                                                      "type": "object",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "type": "array",
                                                           "items": {
                                                             "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
                                                             "properties": {
                                                               "key": {
                                                                 "description": "key is the label key that the selector applies to.",
@@ -877,39 +927,40 @@
                                                               },
                                                               "values": {
                                                                 "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "type": "array",
                                                                 "items": {
                                                                   "type": "string"
-                                                                },
-                                                                "type": "array"
+                                                                }
                                                               }
                                                             },
-                                                            "required": [
-                                                              "key",
-                                                              "operator"
-                                                            ],
-                                                            "type": "object",
                                                             "additionalProperties": false
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         },
                                                         "matchLabels": {
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object",
                                                           "additionalProperties": {
                                                             "type": "string"
-                                                          },
-                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                          "type": "object"
+                                                          }
                                                         }
                                                       },
-                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
                                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                      "type": "object",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "type": "array",
                                                           "items": {
                                                             "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
                                                             "properties": {
                                                               "key": {
                                                                 "description": "key is the label key that the selector applies to.",
@@ -921,77 +972,73 @@
                                                               },
                                                               "values": {
                                                                 "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "type": "array",
                                                                 "items": {
                                                                   "type": "string"
-                                                                },
-                                                                "type": "array"
+                                                                }
                                                               }
                                                             },
-                                                            "required": [
-                                                              "key",
-                                                              "operator"
-                                                            ],
-                                                            "type": "object",
                                                             "additionalProperties": false
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         },
                                                         "matchLabels": {
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object",
                                                           "additionalProperties": {
                                                             "type": "string"
-                                                          },
-                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                          "type": "object"
+                                                          }
                                                         }
                                                       },
-                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "topologyKey": {
                                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "topologyKey"
-                                                  ],
-                                                  "type": "object",
                                                   "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-                                                  "format": "int32",
-                                                  "type": "integer"
+                                                  "type": "integer",
+                                                  "format": "int32"
                                                 }
                                               },
-                                              "required": [
-                                                "podAffinityTerm",
-                                                "weight"
-                                              ],
-                                              "type": "object",
                                               "additionalProperties": false
-                                            },
-                                            "type": "array"
+                                            }
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                            "type": "array",
                                             "items": {
                                               "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "type": "object",
+                                              "required": [
+                                                "topologyKey"
+                                              ],
                                               "properties": {
                                                 "labelSelector": {
                                                   "description": "A label query over a set of resources, in this case pods.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "key is the label key that the selector applies to.",
@@ -1003,39 +1050,40 @@
                                                           },
                                                           "values": {
                                                             "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
                                                       "additionalProperties": {
                                                         "type": "string"
-                                                      },
-                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                      "type": "object"
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
                                                   "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "key is the label key that the selector applies to.",
@@ -1047,74 +1095,80 @@
                                                           },
                                                           "values": {
                                                             "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
                                                       "additionalProperties": {
                                                         "type": "string"
-                                                      },
-                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                      "type": "object"
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                  "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  },
-                                                  "type": "array"
+                                                  }
                                                 },
                                                 "topologyKey": {
                                                   "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "topologyKey"
-                                              ],
-                                              "type": "object",
                                               "additionalProperties": false
-                                            },
-                                            "type": "array"
+                                            }
                                           }
                                         },
-                                        "type": "object",
                                         "additionalProperties": false
                                       },
                                       "podAntiAffinity": {
                                         "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                        "type": "object",
                                         "properties": {
                                           "preferredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                            "type": "array",
                                             "items": {
                                               "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                              "type": "object",
+                                              "required": [
+                                                "podAffinityTerm",
+                                                "weight"
+                                              ],
                                               "properties": {
                                                 "podAffinityTerm": {
                                                   "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                  "type": "object",
+                                                  "required": [
+                                                    "topologyKey"
+                                                  ],
                                                   "properties": {
                                                     "labelSelector": {
                                                       "description": "A label query over a set of resources, in this case pods.",
+                                                      "type": "object",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "type": "array",
                                                           "items": {
                                                             "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
                                                             "properties": {
                                                               "key": {
                                                                 "description": "key is the label key that the selector applies to.",
@@ -1126,39 +1180,40 @@
                                                               },
                                                               "values": {
                                                                 "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "type": "array",
                                                                 "items": {
                                                                   "type": "string"
-                                                                },
-                                                                "type": "array"
+                                                                }
                                                               }
                                                             },
-                                                            "required": [
-                                                              "key",
-                                                              "operator"
-                                                            ],
-                                                            "type": "object",
                                                             "additionalProperties": false
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         },
                                                         "matchLabels": {
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object",
                                                           "additionalProperties": {
                                                             "type": "string"
-                                                          },
-                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                          "type": "object"
+                                                          }
                                                         }
                                                       },
-                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
                                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                      "type": "object",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                          "type": "array",
                                                           "items": {
                                                             "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "type": "object",
+                                                            "required": [
+                                                              "key",
+                                                              "operator"
+                                                            ],
                                                             "properties": {
                                                               "key": {
                                                                 "description": "key is the label key that the selector applies to.",
@@ -1170,77 +1225,73 @@
                                                               },
                                                               "values": {
                                                                 "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                "type": "array",
                                                                 "items": {
                                                                   "type": "string"
-                                                                },
-                                                                "type": "array"
+                                                                }
                                                               }
                                                             },
-                                                            "required": [
-                                                              "key",
-                                                              "operator"
-                                                            ],
-                                                            "type": "object",
                                                             "additionalProperties": false
-                                                          },
-                                                          "type": "array"
+                                                          }
                                                         },
                                                         "matchLabels": {
+                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                          "type": "object",
                                                           "additionalProperties": {
                                                             "type": "string"
-                                                          },
-                                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                          "type": "object"
+                                                          }
                                                         }
                                                       },
-                                                      "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                      "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "topologyKey": {
                                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "topologyKey"
-                                                  ],
-                                                  "type": "object",
                                                   "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-                                                  "format": "int32",
-                                                  "type": "integer"
+                                                  "type": "integer",
+                                                  "format": "int32"
                                                 }
                                               },
-                                              "required": [
-                                                "podAffinityTerm",
-                                                "weight"
-                                              ],
-                                              "type": "object",
                                               "additionalProperties": false
-                                            },
-                                            "type": "array"
+                                            }
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                            "type": "array",
                                             "items": {
                                               "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "type": "object",
+                                              "required": [
+                                                "topologyKey"
+                                              ],
                                               "properties": {
                                                 "labelSelector": {
                                                   "description": "A label query over a set of resources, in this case pods.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "key is the label key that the selector applies to.",
@@ -1252,39 +1303,40 @@
                                                           },
                                                           "values": {
                                                             "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
                                                       "additionalProperties": {
                                                         "type": "string"
-                                                      },
-                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                      "type": "object"
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
                                                   "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                  "type": "object",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
                                                       "items": {
                                                         "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
                                                         "properties": {
                                                           "key": {
                                                             "description": "key is the label key that the selector applies to.",
@@ -1296,66 +1348,53 @@
                                                           },
                                                           "values": {
                                                             "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
                                                             "items": {
                                                               "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "operator"
-                                                        ],
-                                                        "type": "object",
                                                         "additionalProperties": false
-                                                      },
-                                                      "type": "array"
+                                                      }
                                                     },
                                                     "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
                                                       "additionalProperties": {
                                                         "type": "string"
-                                                      },
-                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                      "type": "object"
+                                                      }
                                                     }
                                                   },
-                                                  "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                  "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  },
-                                                  "type": "array"
+                                                  }
                                                 },
                                                 "topologyKey": {
                                                   "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "topologyKey"
-                                              ],
-                                              "type": "object",
                                               "additionalProperties": false
-                                            },
-                                            "type": "array"
+                                            }
                                           }
                                         },
-                                        "type": "object",
                                         "additionalProperties": false
                                       }
                                     },
-                                    "type": "object",
                                     "additionalProperties": false
                                   },
                                   "nodeSelector": {
+                                    "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                    "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
-                                    },
-                                    "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
-                                    "type": "object"
+                                    }
                                   },
                                   "priorityClassName": {
                                     "description": "If specified, the pod's priorityClassName.",
@@ -1367,8 +1406,10 @@
                                   },
                                   "tolerations": {
                                     "description": "If specified, the pod's tolerations.",
+                                    "type": "array",
                                     "items": {
                                       "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                      "type": "object",
                                       "properties": {
                                         "effect": {
                                           "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
@@ -1384,25 +1425,21 @@
                                         },
                                         "tolerationSeconds": {
                                           "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
-                                          "format": "int64",
-                                          "type": "integer"
+                                          "type": "integer",
+                                          "format": "int64"
                                         },
                                         "value": {
                                           "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object",
                                       "additionalProperties": false
-                                    },
-                                    "type": "array"
+                                    }
                                   }
                                 },
-                                "type": "object",
                                 "additionalProperties": false
                               }
                             },
-                            "type": "object",
                             "additionalProperties": false
                           },
                           "serviceType": {
@@ -1410,105 +1447,109 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
                         "additionalProperties": false
                       }
                     },
-                    "type": "object",
                     "additionalProperties": false
                   },
                   "selector": {
                     "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
+                    "type": "object",
                     "properties": {
                       "dnsNames": {
                         "description": "List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                        "type": "array",
                         "items": {
                           "type": "string"
-                        },
-                        "type": "array"
+                        }
                       },
                       "dnsZones": {
                         "description": "List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.",
+                        "type": "array",
                         "items": {
                           "type": "string"
-                        },
-                        "type": "array"
+                        }
                       },
                       "matchLabels": {
+                        "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
+                        "type": "object",
                         "additionalProperties": {
                           "type": "string"
-                        },
-                        "description": "A label selector that is used to refine the set of certificate's that this challenge solver will apply to.",
-                        "type": "object"
+                        }
                       }
                     },
-                    "type": "object",
                     "additionalProperties": false
                   }
                 },
-                "type": "object",
                 "additionalProperties": false
-              },
-              "type": "array"
+              }
             }
           },
-          "required": [
-            "privateKeySecretRef",
-            "server"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "ca": {
           "description": "CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.",
+          "type": "object",
+          "required": [
+            "secretName"
+          ],
           "properties": {
             "crlDistributionPoints": {
               "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "ocspServers": {
               "description": "The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be \"http://ocsp.int-x3.letsencrypt.org\".",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             },
             "secretName": {
               "description": "SecretName is the name of the secret used to sign Certificates issued by this Issuer.",
               "type": "string"
             }
           },
-          "required": [
-            "secretName"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "selfSigned": {
           "description": "SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.",
+          "type": "object",
           "properties": {
             "crlDistributionPoints": {
               "description": "The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
-          "type": "object",
           "additionalProperties": false
         },
         "vault": {
           "description": "Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.",
+          "type": "object",
+          "required": [
+            "auth",
+            "path",
+            "server"
+          ],
           "properties": {
             "auth": {
               "description": "Auth configures how cert-manager authenticates with the Vault server.",
+              "type": "object",
               "properties": {
                 "appRole": {
                   "description": "AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.",
+                  "type": "object",
+                  "required": [
+                    "path",
+                    "roleId",
+                    "secretRef"
+                  ],
                   "properties": {
                     "path": {
                       "description": "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
@@ -1520,6 +1561,10 @@
                     },
                     "secretRef": {
                       "description": "Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1530,23 +1575,18 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "path",
-                    "roleId",
-                    "secretRef"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "kubernetes": {
                   "description": "Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.",
+                  "type": "object",
+                  "required": [
+                    "role",
+                    "secretRef"
+                  ],
                   "properties": {
                     "mountPath": {
                       "description": "The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value \"/v1/auth/kubernetes\" will be used.",
@@ -1558,6 +1598,10 @@
                     },
                     "secretRef": {
                       "description": "The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "key": {
                           "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1568,22 +1612,17 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "name"
-                      ],
-                      "type": "object",
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "role",
-                    "secretRef"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "tokenSecretRef": {
                   "description": "TokenSecretRef authenticates with Vault by presenting a token.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "key": {
                       "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1594,20 +1633,33 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 }
               },
-              "type": "object",
               "additionalProperties": false
             },
             "caBundle": {
-              "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.",
-              "format": "byte",
-              "type": "string"
+              "description": "Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by Vault. Only used if using HTTPS to connect to Vault and ignored for HTTP connections. Mutually exclusive with CABundleSecretRef. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection.",
+              "type": "string",
+              "format": "byte"
+            },
+            "caBundleSecretRef": {
+              "description": "Reference to a Secret containing a bundle of PEM-encoded CAs to use when verifying the certificate chain presented by Vault when using HTTPS. Mutually exclusive with CABundle. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection. If no key for the Secret is specified, cert-manager will default to 'ca.crt'.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "key": {
+                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
             },
             "namespace": {
               "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
@@ -1622,22 +1674,28 @@
               "type": "string"
             }
           },
-          "required": [
-            "auth",
-            "path",
-            "server"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "venafi": {
           "description": "Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.",
+          "type": "object",
+          "required": [
+            "zone"
+          ],
           "properties": {
             "cloud": {
               "description": "Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.",
+              "type": "object",
+              "required": [
+                "apiTokenSecretRef"
+              ],
               "properties": {
                 "apiTokenSecretRef": {
                   "description": "APITokenSecretRef is a secret key selector for the Venafi Cloud API token.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "key": {
                       "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -1648,10 +1706,6 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "url": {
@@ -1659,32 +1713,33 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "apiTokenSecretRef"
-              ],
-              "type": "object",
               "additionalProperties": false
             },
             "tpp": {
               "description": "TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.",
+              "type": "object",
+              "required": [
+                "credentialsRef",
+                "url"
+              ],
               "properties": {
                 "caBundle": {
-                  "description": "CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.",
-                  "format": "byte",
-                  "type": "string"
+                  "description": "Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP. If undefined, the certificate bundle in the cert-manager controller container is used to validate the chain.",
+                  "type": "string",
+                  "format": "byte"
                 },
                 "credentialsRef": {
                   "description": "CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "name": {
                       "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
                 },
                 "url": {
@@ -1692,11 +1747,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "credentialsRef",
-                "url"
-              ],
-              "type": "object",
               "additionalProperties": false
             },
             "zone": {
@@ -1704,21 +1754,18 @@
               "type": "string"
             }
           },
-          "required": [
-            "zone"
-          ],
-          "type": "object",
           "additionalProperties": false
         }
       },
-      "type": "object",
       "additionalProperties": false
     },
     "status": {
       "description": "Status of the Issuer. This is set and managed automatically.",
+      "type": "object",
       "properties": {
         "acme": {
           "description": "ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.",
+          "type": "object",
           "properties": {
             "lastRegisteredEmail": {
               "description": "LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer",
@@ -1729,18 +1776,23 @@
               "type": "string"
             }
           },
-          "type": "object",
           "additionalProperties": false
         },
         "conditions": {
           "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.",
+          "type": "array",
           "items": {
             "description": "IssuerCondition contains condition information for an Issuer.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
             "properties": {
               "lastTransitionTime": {
                 "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
-                "format": "date-time",
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
               },
               "message": {
                 "description": "Message is a human readable description of the details of the last transition, complementing reason.",
@@ -1748,8 +1800,8 @@
               },
               "observedGeneration": {
                 "description": "If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.",
-                "format": "int64",
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
               },
               "reason": {
                 "description": "Reason is a brief machine readable explanation for the condition's last transition.",
@@ -1757,38 +1809,27 @@
               },
               "status": {
                 "description": "Status of the condition, one of (`True`, `False`, `Unknown`).",
+                "type": "string",
                 "enum": [
                   "True",
                   "False",
                   "Unknown"
-                ],
-                "type": "string"
+                ]
               },
               "type": {
                 "description": "Type of the condition, known values are (`Ready`).",
                 "type": "string"
               }
             },
-            "required": [
-              "status",
-              "type"
-            ],
-            "type": "object",
             "additionalProperties": false
           },
-          "type": "array",
           "x-kubernetes-list-map-keys": [
             "type"
           ],
           "x-kubernetes-list-type": "map"
         }
       },
-      "type": "object",
       "additionalProperties": false
     }
-  },
-  "required": [
-    "spec"
-  ],
-  "type": "object"
+  }
 }

--- a/cert-manager.io/order_v1.json
+++ b/cert-manager.io/order_v1.json
@@ -1,5 +1,10 @@
 {
   "description": "Order is a type to represent an Order with an ACME server",
+  "type": "object",
+  "required": [
+    "metadata",
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,6 +18,11 @@
       "type": "object"
     },
     "spec": {
+      "type": "object",
+      "required": [
+        "issuerRef",
+        "request"
+      ],
       "properties": {
         "commonName": {
           "description": "CommonName is the common name as specified on the DER encoded CSR. If specified, this value must also be present in `dnsNames` or `ipAddresses`. This field must match the corresponding field on the DER encoded CSR.",
@@ -20,10 +30,10 @@
         },
         "dnsNames": {
           "description": "DNSNames is a list of DNS names that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "duration": {
           "description": "Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.",
@@ -31,13 +41,17 @@
         },
         "ipAddresses": {
           "description": "IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "issuerRef": {
           "description": "IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Order will be marked as failed.",
+          "type": "object",
+          "required": [
+            "name"
+          ],
           "properties": {
             "group": {
               "description": "Group of the resource being referred to.",
@@ -52,36 +66,40 @@
               "type": "string"
             }
           },
-          "required": [
-            "name"
-          ],
-          "type": "object",
           "additionalProperties": false
         },
         "request": {
           "description": "Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.",
-          "format": "byte",
-          "type": "string"
+          "type": "string",
+          "format": "byte"
         }
       },
-      "required": [
-        "issuerRef",
-        "request"
-      ],
-      "type": "object",
       "additionalProperties": false
     },
     "status": {
+      "type": "object",
       "properties": {
         "authorizations": {
           "description": "Authorizations contains data returned from the ACME server on what authorizations must be completed in order to validate the DNS names specified on the Order.",
+          "type": "array",
           "items": {
             "description": "ACMEAuthorization contains data returned from the ACME server on an authorization that must be completed in order validate a DNS name on an ACME Order resource.",
+            "type": "object",
+            "required": [
+              "url"
+            ],
             "properties": {
               "challenges": {
                 "description": "Challenges specifies the challenge types offered by the ACME server. One of these challenge types will be selected when validating the DNS name and an appropriate Challenge resource will be created to perform the ACME challenge process.",
+                "type": "array",
                 "items": {
                   "description": "Challenge specifies a challenge offered by the ACME server for an Order. An appropriate Challenge resource can be created to perform the ACME challenge process.",
+                  "type": "object",
+                  "required": [
+                    "token",
+                    "type",
+                    "url"
+                  ],
                   "properties": {
                     "token": {
                       "description": "Token is the token that must be presented for this challenge. This is used to compute the 'key' that must also be presented.",
@@ -96,15 +114,8 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "token",
-                    "type",
-                    "url"
-                  ],
-                  "type": "object",
                   "additionalProperties": false
-                },
-                "type": "array"
+                }
               },
               "identifier": {
                 "description": "Identifier is the DNS name to be validated as part of this authorization",
@@ -112,6 +123,7 @@
               },
               "initialState": {
                 "description": "InitialState is the initial state of the ACME authorization when first fetched from the ACME server. If an Authorization is already 'valid', the Order controller will not create a Challenge resource for the authorization. This will occur when working with an ACME server that enables 'authz reuse' (such as Let's Encrypt's production endpoint). If not set and 'identifier' is set, the state is assumed to be pending and a Challenge will be created.",
+                "type": "string",
                 "enum": [
                   "valid",
                   "ready",
@@ -120,8 +132,7 @@
                   "invalid",
                   "expired",
                   "errored"
-                ],
-                "type": "string"
+                ]
               },
               "url": {
                 "description": "URL is the URL of the Authorization that must be completed",
@@ -132,23 +143,18 @@
                 "type": "boolean"
               }
             },
-            "required": [
-              "url"
-            ],
-            "type": "object",
             "additionalProperties": false
-          },
-          "type": "array"
+          }
         },
         "certificate": {
           "description": "Certificate is a copy of the PEM encoded certificate for this Order. This field will be populated after the order has been successfully finalized with the ACME server, and the order has transitioned to the 'valid' state.",
-          "format": "byte",
-          "type": "string"
+          "type": "string",
+          "format": "byte"
         },
         "failureTime": {
           "description": "FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.",
-          "format": "date-time",
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         },
         "finalizeURL": {
           "description": "FinalizeURL of the Order. This is used to obtain certificates for this order once it has been completed.",
@@ -160,6 +166,7 @@
         },
         "state": {
           "description": "State contains the current state of this Order resource. States 'success' and 'expired' are 'final'",
+          "type": "string",
           "enum": [
             "valid",
             "ready",
@@ -168,21 +175,14 @@
             "invalid",
             "expired",
             "errored"
-          ],
-          "type": "string"
+          ]
         },
         "url": {
           "description": "URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.",
           "type": "string"
         }
       },
-      "type": "object",
       "additionalProperties": false
     }
-  },
-  "required": [
-    "metadata",
-    "spec"
-  ],
-  "type": "object"
+  }
 }


### PR DESCRIPTION
This PR updates the schemas for cert-manager.

Using the schemas currently shipped in this repo, manifest validation using `kubeconform` in strict mode fails when validating a `v1.ClusterIssuer` that contains the (new-ish) field `spec.vault.caBundleSecretRef`:

```
ClusterIssuer cluster-issuer is invalid: For field spec.vault: Additional property caBundleSecretRef is not allowed
```

Using the updated schemas included in this PR, validation in strict mode works as intended.

CRD sources:

```
$ curl -fsSL https://github.com/cert-manager/cert-manager/releases/download/v1.11.1-beta.0/cert-manager.crds.yaml | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to clusterissuer_v1.json
JSON schema written to challenge_v1.json
JSON schema written to certificaterequest_v1.json
JSON schema written to issuer_v1.json
JSON schema written to certificate_v1.json
JSON schema written to order_v1.json
```