### PR TITLE
Add Cluster API Provider AWS schemas

### DIFF
--- a/awsprovider.k8s.io/awsclusterproviderspec_v1alpha1.json
+++ b/awsprovider.k8s.io/awsclusterproviderspec_v1alpha1.json
@@ -1,0 +1,533 @@
+{
+  "properties": {
+    "additionalUserDataFiles": {
+      "description": "AdditionalUserDataFiles specifies extra files to be passed to all Machines' user_data upon creation.",
+      "items": {
+        "properties": {
+          "content": {
+            "description": "Content is the actual content of the file.",
+            "type": "string"
+          },
+          "owner": {
+            "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+            "type": "string"
+          },
+          "path": {
+            "description": "Path specifies the full path on disk where to store the file.",
+            "type": "string"
+          },
+          "permissions": {
+            "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "owner",
+          "permissions",
+          "content"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "type": "array"
+    },
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "caKeyPair": {
+      "description": "CAKeyPair is the key pair for ca certs.",
+      "properties": {
+        "cert": {
+          "description": "base64 encoded cert and key",
+          "format": "byte",
+          "type": "string"
+        },
+        "key": {
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cert",
+        "key"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "clusterConfiguration": {
+      "description": "ClusterConfiguration holds the cluster-wide information used during a kubeadm init call.",
+      "properties": {
+        "apiServer": {
+          "description": "APIServer contains extra settings for the API server control plane component",
+          "properties": {
+            "certSANs": {
+              "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "extraArgs": {
+              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+              "type": "object"
+            },
+            "extraVolumes": {
+              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+              "items": {
+                "properties": {
+                  "hostPath": {
+                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the volume inside the pod template.",
+                    "type": "string"
+                  },
+                  "pathType": {
+                    "description": "PathType is the type of the HostPath.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "ReadOnly controls write access to the volume",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "hostPath",
+                  "mountPath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "timeoutForControlPlane": {
+              "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "certificatesDir": {
+          "description": "CertificatesDir specifies where to store or look for all required certificates.",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "The cluster name",
+          "type": "string"
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane.",
+          "type": "string"
+        },
+        "controllerManager": {
+          "description": "ControllerManager contains extra settings for the controller manager control plane component",
+          "properties": {
+            "extraArgs": {
+              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+              "type": "object"
+            },
+            "extraVolumes": {
+              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+              "items": {
+                "properties": {
+                  "hostPath": {
+                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the volume inside the pod template.",
+                    "type": "string"
+                  },
+                  "pathType": {
+                    "description": "PathType is the type of the HostPath.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "ReadOnly controls write access to the volume",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "hostPath",
+                  "mountPath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dns": {
+          "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+          "properties": {
+            "imageRepository": {
+              "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+              "type": "string"
+            },
+            "imageTag": {
+              "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type defines the DNS add-on to be used",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "etcd": {
+          "description": "Etcd holds configuration for etcd.",
+          "properties": {
+            "external": {
+              "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+              "properties": {
+                "caFile": {
+                  "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                  "type": "string"
+                },
+                "certFile": {
+                  "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                  "type": "string"
+                },
+                "endpoints": {
+                  "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "keyFile": {
+                  "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "endpoints",
+                "caFile",
+                "certFile",
+                "keyFile"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "local": {
+              "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+              "properties": {
+                "dataDir": {
+                  "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                  "type": "string"
+                },
+                "extraArgs": {
+                  "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                  "type": "object"
+                },
+                "imageRepository": {
+                  "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                  "type": "string"
+                },
+                "imageTag": {
+                  "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                  "type": "string"
+                },
+                "peerCertSANs": {
+                  "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "serverCertSANs": {
+                  "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "dataDir"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "featureGates": {
+          "description": "FeatureGates enabled by the user.",
+          "type": "object"
+        },
+        "imageRepository": {
+          "description": "ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/kubernetes-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "kubernetesVersion": {
+          "description": "KubernetesVersion is the target version of the control plane.",
+          "type": "string"
+        },
+        "networking": {
+          "description": "Networking holds configuration for the networking topology of the cluster.",
+          "properties": {
+            "dnsDomain": {
+              "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+              "type": "string"
+            },
+            "podSubnet": {
+              "description": "PodSubnet is the subnet used by pods.",
+              "type": "string"
+            },
+            "serviceSubnet": {
+              "description": "ServiceSubnet is the subnet used by k8s services. Defaults to \"10.96.0.0/12\".",
+              "type": "string"
+            }
+          },
+          "required": [
+            "serviceSubnet",
+            "podSubnet",
+            "dnsDomain"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "scheduler": {
+          "description": "Scheduler contains extra settings for the scheduler control plane component",
+          "properties": {
+            "extraArgs": {
+              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+              "type": "object"
+            },
+            "extraVolumes": {
+              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+              "items": {
+                "properties": {
+                  "hostPath": {
+                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the volume inside the pod template.",
+                    "type": "string"
+                  },
+                  "pathType": {
+                    "description": "PathType is the type of the HostPath.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "ReadOnly controls write access to the volume",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "hostPath",
+                  "mountPath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "useHyperKubeImage": {
+          "description": "UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "etcd",
+        "networking",
+        "kubernetesVersion",
+        "controlPlaneEndpoint",
+        "dns",
+        "certificatesDir",
+        "imageRepository"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "etcdCAKeyPair": {
+      "description": "EtcdCAKeyPair is the key pair for etcd.",
+      "properties": {
+        "cert": {
+          "description": "base64 encoded cert and key",
+          "format": "byte",
+          "type": "string"
+        },
+        "key": {
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cert",
+        "key"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "frontProxyCAKeyPair": {
+      "description": "FrontProxyCAKeyPair is the key pair for FrontProxyKeyPair.",
+      "properties": {
+        "cert": {
+          "description": "base64 encoded cert and key",
+          "format": "byte",
+          "type": "string"
+        },
+        "key": {
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cert",
+        "key"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "networkSpec": {
+      "description": "NetworkSpec encapsulates all things related to AWS network.",
+      "properties": {
+        "subnets": {
+          "description": "Subnets configuration.",
+          "items": {
+            "properties": {
+              "availabilityZone": {
+                "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                "type": "string"
+              },
+              "cidrBlock": {
+                "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                "type": "string"
+              },
+              "id": {
+                "description": "ID defines a unique identifier to reference this resource.",
+                "type": "string"
+              },
+              "isPublic": {
+                "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                "type": "boolean"
+              },
+              "natGatewayId": {
+                "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                "type": "string"
+              },
+              "routeTableId": {
+                "description": "RouteTableID is the routing table id associated with the subnet.",
+                "type": "string"
+              },
+              "tags": {
+                "description": "Tags is a collection of tags describing the resource.",
+                "type": "object"
+              }
+            },
+            "required": [
+              "isPublic",
+              "routeTableId"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "vpc": {
+          "description": "VPC configuration.",
+          "properties": {
+            "cidrBlock": {
+              "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+              "type": "string"
+            },
+            "id": {
+              "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+              "type": "string"
+            },
+            "internetGatewayId": {
+              "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+              "type": "string"
+            },
+            "tags": {
+              "description": "Tags is a collection of tags describing the resource.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "region": {
+      "description": "The AWS Region the cluster lives in.",
+      "type": "string"
+    },
+    "saKeyPair": {
+      "description": "SAKeyPair is the service account key pair.",
+      "properties": {
+        "cert": {
+          "description": "base64 encoded cert and key",
+          "format": "byte",
+          "type": "string"
+        },
+        "key": {
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cert",
+        "key"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "sshKeyName": {
+      "description": "SSHKeyName is the name of the ssh key to attach to the bastion host.",
+      "type": "string"
+    }
+  }
+}

--- a/awsprovider.k8s.io/awsclusterproviderstatus_v1alpha1.json
+++ b/awsprovider.k8s.io/awsclusterproviderstatus_v1alpha1.json
@@ -1,0 +1,209 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "bastion": {
+      "properties": {
+        "ebsOptimized": {
+          "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+          "type": "boolean"
+        },
+        "enaSupport": {
+          "description": "Specifies whether enhanced networking with ENA is enabled.",
+          "type": "boolean"
+        },
+        "iamProfile": {
+          "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "imageId": {
+          "description": "The ID of the AMI used to launch the instance.",
+          "type": "string"
+        },
+        "instanceState": {
+          "description": "The current state of the instance.",
+          "type": "string"
+        },
+        "keyName": {
+          "description": "The name of the SSH key pair.",
+          "type": "string"
+        },
+        "privateIp": {
+          "description": "The private IPv4 address assigned to the instance.",
+          "type": "string"
+        },
+        "publicIp": {
+          "description": "The public IPv4 address assigned to the instance, if applicable.",
+          "type": "string"
+        },
+        "rootDeviceSize": {
+          "description": "Specifies size (in Gi) of the root storage device",
+          "format": "int64",
+          "type": "integer"
+        },
+        "securityGroupIds": {
+          "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "subnetId": {
+          "description": "The ID of the subnet of the instance.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "The tags associated with the instance.",
+          "type": "object"
+        },
+        "type": {
+          "description": "The instance type.",
+          "type": "string"
+        },
+        "userData": {
+          "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "network": {
+      "properties": {
+        "apiServerElb": {
+          "description": "APIServerELB is the Kubernetes api server classic load balancer.",
+          "properties": {
+            "attributes": {
+              "description": "Attributes defines extra attributes associated with the load balancer.",
+              "properties": {
+                "idleTimeout": {
+                  "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dnsName": {
+              "description": "DNSName is the dns name of the load balancer.",
+              "type": "string"
+            },
+            "healthChecks": {
+              "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+              "properties": {
+                "healthyThreshold": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "interval": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "target": {
+                  "type": "string"
+                },
+                "timeout": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "unhealthyThreshold": {
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "target",
+                "interval",
+                "timeout",
+                "healthyThreshold",
+                "unhealthyThreshold"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "listeners": {
+              "description": "Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+              "items": {
+                "properties": {
+                  "instancePort": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "instanceProtocol": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "protocol",
+                  "port",
+                  "instanceProtocol",
+                  "instancePort"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+              "type": "string"
+            },
+            "scheme": {
+              "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+              "type": "string"
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "subnetIds": {
+              "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "tags": {
+              "description": "Tags is a map of tags associated with the load balancer.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "securityGroups": {
+          "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+}

--- a/awsprovider.k8s.io/awsmachineproviderspec_v1alpha1.json
+++ b/awsprovider.k8s.io/awsmachineproviderspec_v1alpha1.json
@@ -1,0 +1,454 @@
+{
+  "properties": {
+    "additionalSecurityGroups": {
+      "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+      "items": {
+        "properties": {
+          "arn": {
+            "description": "ARN of resource",
+            "type": "string"
+          },
+          "filters": {
+            "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+            "items": {
+              "properties": {
+                "name": {
+                  "description": "Name of the filter. Filter names are case-sensitive.",
+                  "type": "string"
+                },
+                "values": {
+                  "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "name",
+                "values"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "ID of resource",
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "type": "array"
+    },
+    "additionalTags": {
+      "description": "AdditionalTags is the set of tags to add to an instance, in addition to the ones added by default by the actuator. These tags are additive. The actuator will ensure these tags are present, but will not remove any other tags that may exist on the instance.",
+      "type": "object"
+    },
+    "additionalUserDataFiles": {
+      "description": "AdditionalUserDataFiles specifies extra files to be passed to user_data upon creation.",
+      "items": {
+        "properties": {
+          "content": {
+            "description": "Content is the actual content of the file.",
+            "type": "string"
+          },
+          "owner": {
+            "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+            "type": "string"
+          },
+          "path": {
+            "description": "Path specifies the full path on disk where to store the file.",
+            "type": "string"
+          },
+          "permissions": {
+            "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "owner",
+          "permissions",
+          "content"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "type": "array"
+    },
+    "ami": {
+      "description": "AMI is the reference to the AMI from which to create the machine instance.",
+      "properties": {
+        "arn": {
+          "description": "ARN of resource",
+          "type": "string"
+        },
+        "filters": {
+          "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Name of the filter. Filter names are case-sensitive.",
+                "type": "string"
+              },
+              "values": {
+                "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name",
+              "values"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "id": {
+          "description": "ID of resource",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "availabilityZone": {
+      "description": "AvailabilityZone is references the AWS availability zone to use for this instance. If multiple subnets are matched for the availability zone, the first one return is picked.",
+      "type": "string"
+    },
+    "iamInstanceProfile": {
+      "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+      "type": "string"
+    },
+    "imageLookupOrg": {
+      "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+      "type": "string"
+    },
+    "instanceType": {
+      "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+      "type": "string"
+    },
+    "keyName": {
+      "description": "KeyName is the name of the SSH key to install on the instance.",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "kubeadmConfiguration": {
+      "description": "KubeadmConfiguration holds the kubeadm configuration options",
+      "properties": {
+        "init": {
+          "description": "InitConfiguration is used to customize any kubeadm init configuration parameters.",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+              "type": "string"
+            },
+            "bootstrapTokens": {
+              "description": "BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature",
+              "items": {
+                "properties": {
+                  "description": {
+                    "description": "Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.",
+                    "type": "string"
+                  },
+                  "expires": {
+                    "description": "Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "groups": {
+                    "description": "Groups specifies the extra groups that this token will authenticate as when/if used for authentication",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "token": {
+                    "description": "Token is used for establishing bidirectional trust between nodes and masters. Used for joining nodes in the cluster.",
+                    "type": "object"
+                  },
+                  "ttl": {
+                    "description": "TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.",
+                    "type": "string"
+                  },
+                  "usages": {
+                    "description": "Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "token"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "localAPIEndpoint": {
+              "description": "LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.",
+              "properties": {
+                "advertiseAddress": {
+                  "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                  "type": "string"
+                },
+                "bindPort": {
+                  "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "advertiseAddress",
+                "bindPort"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeRegistration": {
+              "description": "NodeRegistration holds fields that relate to registering the new master node to the cluster",
+              "properties": {
+                "criSocket": {
+                  "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                  "type": "string"
+                },
+                "kubeletExtraArgs": {
+                  "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm joi\u0144` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                  "type": "string"
+                },
+                "taints": {
+                  "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your master node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "join": {
+          "description": "JoinConfiguration is used to customize any kubeadm join configuration parameters.",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+              "type": "string"
+            },
+            "caCertPath": {
+              "description": "CACertPath is the path to the SSL certificate authority used to secure comunications between node and master. Defaults to \"/etc/kubernetes/pki/ca.crt\".",
+              "type": "string"
+            },
+            "controlPlane": {
+              "description": "ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.",
+              "properties": {
+                "localAPIEndpoint": {
+                  "description": "LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.",
+                  "properties": {
+                    "advertiseAddress": {
+                      "description": "AdvertiseAddress sets the IP address for the API server to advertise.",
+                      "type": "string"
+                    },
+                    "bindPort": {
+                      "description": "BindPort sets the secure port for the API Server to bind to. Defaults to 6443.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "advertiseAddress",
+                    "bindPort"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "discovery": {
+              "description": "Discovery specifies the options for the kubelet to use during the TLS Bootstrap process",
+              "properties": {
+                "bootstrapToken": {
+                  "description": "BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive",
+                  "properties": {
+                    "apiServerEndpoint": {
+                      "description": "APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.",
+                      "type": "string"
+                    },
+                    "caCertHashes": {
+                      "description": "CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as \"<type>:<value>\", where the only currently supported type is \"sha256\". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "token": {
+                      "description": "Token is a token used to validate cluster information fetched from the master.",
+                      "type": "string"
+                    },
+                    "unsafeSkipCAVerification": {
+                      "description": "UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the master.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "token",
+                    "unsafeSkipCAVerification"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "file": {
+                  "description": "File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive",
+                  "properties": {
+                    "kubeConfigPath": {
+                      "description": "KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kubeConfigPath"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "timeout": {
+                  "description": "Timeout modifies the discovery timeout",
+                  "type": "string"
+                },
+                "tlsBootstrapToken": {
+                  "description": "TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "tlsBootstrapToken"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "nodeRegistration": {
+              "description": "NodeRegistration holds fields that relate to registering the new master node to the cluster",
+              "properties": {
+                "criSocket": {
+                  "description": "CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use",
+                  "type": "string"
+                },
+                "kubeletExtraArgs": {
+                  "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm joi\u0144` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.",
+                  "type": "string"
+                },
+                "taints": {
+                  "description": "Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=\"\"'}. If you don't want to taint your master node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.",
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "nodeRegistration",
+            "caCertPath",
+            "discovery"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "publicIP": {
+      "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+      "type": "boolean"
+    },
+    "rootDeviceSize": {
+      "description": "RootDeviceSize is the size of the root volume.",
+      "format": "int64",
+      "type": "integer"
+    },
+    "subnet": {
+      "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+      "properties": {
+        "arn": {
+          "description": "ARN of resource",
+          "type": "string"
+        },
+        "filters": {
+          "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Name of the filter. Filter names are case-sensitive.",
+                "type": "string"
+              },
+              "values": {
+                "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name",
+              "values"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "id": {
+          "description": "ID of resource",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+}

--- a/awsprovider.k8s.io/awsmachineproviderstatus_v1alpha1.json
+++ b/awsprovider.k8s.io/awsmachineproviderstatus_v1alpha1.json
@@ -1,0 +1,67 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "conditions": {
+      "description": "Conditions is a set of conditions associated with the Machine to indicate errors or other status",
+      "items": {
+        "properties": {
+          "lastProbeTime": {
+            "description": "LastProbeTime is the last time we probed the condition.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastTransitionTime": {
+            "description": "LastTransitionTime is the last time the condition transitioned from one status to another.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "message": {
+            "description": "Message is a human-readable message indicating details about last transition.",
+            "type": "string"
+          },
+          "reason": {
+            "description": "Reason is a unique, one-word, CamelCase reason for the condition's last transition.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status is the status of the condition.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Type is the type of the condition.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "status",
+          "lastProbeTime",
+          "lastTransitionTime",
+          "reason",
+          "message"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "type": "array"
+    },
+    "instanceID": {
+      "description": "InstanceID is the instance ID of the machine created in AWS",
+      "type": "string"
+    },
+    "instanceState": {
+      "description": "InstanceState is the state of the AWS instance for this machine",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}

--- a/bootstrap.cluster.x-k8s.io/eksconfig_v1alpha3.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfig_v1alpha3.json
@@ -1,0 +1,99 @@
+{
+  "description": "EKSConfig is the Schema for the eksconfigs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "EKSConfigSpec defines the desired state of EKSConfig",
+      "properties": {
+        "kubeletExtraArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Passes the kubelet args into the EKS bootstrap script",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "EKSConfigStatus defines the observed state of EKSConfig",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the EKSConfig.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "dataSecretName": {
+          "description": "DataSecretName is the name of the secret that stores the bootstrap data script.",
+          "type": "string"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set on non-retryable errors",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set on non-retryable errors",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready indicates the BootstrapData secret is ready to be consumed",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/eksconfig_v1alpha4.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfig_v1alpha4.json
@@ -1,0 +1,99 @@
+{
+  "description": "EKSConfig is the Schema for the eksconfigs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "EKSConfigSpec defines the desired state of EKSConfig",
+      "properties": {
+        "kubeletExtraArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Passes the kubelet args into the EKS bootstrap script",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "EKSConfigStatus defines the observed state of EKSConfig",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the EKSConfig.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "dataSecretName": {
+          "description": "DataSecretName is the name of the secret that stores the bootstrap data script.",
+          "type": "string"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set on non-retryable errors",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set on non-retryable errors",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready indicates the BootstrapData secret is ready to be consumed",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/eksconfig_v1beta1.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfig_v1beta1.json
@@ -1,0 +1,143 @@
+{
+  "description": "EKSConfig is the schema for the Amazon EKS Machine Bootstrap Configuration API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "EKSConfigSpec defines the desired state of Amazon EKS Bootstrap Configuration.",
+      "properties": {
+        "apiRetryAttempts": {
+          "description": "APIRetryAttempts is the number of retry attempts for AWS API call.",
+          "type": "integer"
+        },
+        "containerRuntime": {
+          "description": "ContainerRuntime specify the container runtime to use when bootstrapping EKS.",
+          "type": "string"
+        },
+        "dnsClusterIP": {
+          "description": "DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
+          "type": "string"
+        },
+        "dockerConfigJson": {
+          "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI. This is expected to be a json string.",
+          "type": "string"
+        },
+        "kubeletExtraArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "KubeletExtraArgs passes the specified kubelet args into the Amazon EKS machine bootstrap script",
+          "type": "object"
+        },
+        "pauseContainer": {
+          "description": "PauseContainer allows customization of the pause container to use.",
+          "properties": {
+            "accountNumber": {
+              "description": "AccountNumber is the AWS account number to pull the pause container from.",
+              "type": "string"
+            },
+            "version": {
+              "description": "Version is the tag of the pause container to use.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "accountNumber",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceIPV6Cidr": {
+          "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then the ip family will be set to ipv6.",
+          "type": "string"
+        },
+        "useMaxPods": {
+          "description": "UseMaxPods  sets --max-pods for the kubelet when true.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "EKSConfigStatus defines the observed state of the Amazon EKS Bootstrap Configuration.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the EKSConfig.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "dataSecretName": {
+          "description": "DataSecretName is the name of the secret that stores the bootstrap data script.",
+          "type": "string"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set on non-retryable errors",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set on non-retryable errors",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready indicates the BootstrapData secret is ready to be consumed",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/eksconfig_v1beta2.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfig_v1beta2.json
@@ -1,0 +1,433 @@
+{
+  "description": "EKSConfig is the schema for the Amazon EKS Machine Bootstrap Configuration API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "EKSConfigSpec defines the desired state of Amazon EKS Bootstrap Configuration.",
+      "properties": {
+        "apiRetryAttempts": {
+          "description": "APIRetryAttempts is the number of retry attempts for AWS API call.",
+          "type": "integer"
+        },
+        "boostrapCommandOverride": {
+          "description": "BootstrapCommandOverride allows you to override the bootstrap command to use for EKS nodes.",
+          "type": "string"
+        },
+        "containerRuntime": {
+          "description": "ContainerRuntime specify the container runtime to use when bootstrapping EKS.",
+          "type": "string"
+        },
+        "diskSetup": {
+          "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+          "properties": {
+            "filesystems": {
+              "description": "Filesystems specifies the list of file systems to setup.",
+              "items": {
+                "description": "Filesystem defines the file systems to be created.",
+                "properties": {
+                  "device": {
+                    "description": "Device specifies the device name",
+                    "type": "string"
+                  },
+                  "extraOpts": {
+                    "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "filesystem": {
+                    "description": "Filesystem specifies the file system type.",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                    "type": "string"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                    "type": "boolean"
+                  },
+                  "partition": {
+                    "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "device",
+                  "filesystem",
+                  "label"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "partitions": {
+              "description": "Partitions specifies the list of the partitions to setup.",
+              "items": {
+                "description": "Partition defines how to create and layout a partition.",
+                "properties": {
+                  "device": {
+                    "description": "Device is the name of the device.",
+                    "type": "string"
+                  },
+                  "layout": {
+                    "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                    "type": "boolean"
+                  },
+                  "overwrite": {
+                    "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                    "type": "boolean"
+                  },
+                  "tableType": {
+                    "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "device",
+                  "layout"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dnsClusterIP": {
+          "description": "DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
+          "type": "string"
+        },
+        "dockerConfigJson": {
+          "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI. This is expected to be a json string.",
+          "type": "string"
+        },
+        "files": {
+          "description": "Files specifies extra files to be passed to user_data upon creation.",
+          "items": {
+            "description": "File defines the input for generating write_files in cloud-init.",
+            "properties": {
+              "append": {
+                "description": "Append specifies whether to append Content to existing file if Path exists.",
+                "type": "boolean"
+              },
+              "content": {
+                "description": "Content is the actual content of the file.",
+                "type": "string"
+              },
+              "contentFrom": {
+                "description": "ContentFrom is a referenced source of content to populate the file.",
+                "properties": {
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this file.",
+                    "properties": {
+                      "key": {
+                        "description": "Key is the key in the secret's data map for this value.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "secret"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "encoding": {
+                "description": "Encoding specifies the encoding of the file contents.",
+                "enum": [
+                  "base64",
+                  "gzip",
+                  "gzip+base64"
+                ],
+                "type": "string"
+              },
+              "owner": {
+                "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                "type": "string"
+              },
+              "path": {
+                "description": "Path specifies the full path on disk where to store the file.",
+                "type": "string"
+              },
+              "permissions": {
+                "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "kubeletExtraArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "KubeletExtraArgs passes the specified kubelet args into the Amazon EKS machine bootstrap script",
+          "type": "object"
+        },
+        "mounts": {
+          "description": "Mounts specifies a list of mount points to be setup.",
+          "items": {
+            "description": "MountPoints defines input for generated mounts in cloud-init.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "ntp": {
+          "description": "NTP specifies NTP configuration",
+          "properties": {
+            "enabled": {
+              "description": "Enabled specifies whether NTP should be enabled",
+              "type": "boolean"
+            },
+            "servers": {
+              "description": "Servers specifies which NTP servers to use",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "pauseContainer": {
+          "description": "PauseContainer allows customization of the pause container to use.",
+          "properties": {
+            "accountNumber": {
+              "description": "AccountNumber is the AWS account number to pull the pause container from.",
+              "type": "string"
+            },
+            "version": {
+              "description": "Version is the tag of the pause container to use.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "accountNumber",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "postBootstrapCommands": {
+          "description": "PostBootstrapCommands specifies extra commands to run after bootstrapping nodes to the cluster",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "preBootstrapCommands": {
+          "description": "PreBootstrapCommands specifies extra commands to run before bootstrapping nodes to the cluster",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "serviceIPV6Cidr": {
+          "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then the ip family will be set to ipv6.",
+          "type": "string"
+        },
+        "useMaxPods": {
+          "description": "UseMaxPods  sets --max-pods for the kubelet when true.",
+          "type": "boolean"
+        },
+        "users": {
+          "description": "Users specifies extra users to add",
+          "items": {
+            "description": "User defines the input for a generated user in cloud-init.",
+            "properties": {
+              "gecos": {
+                "description": "Gecos specifies the gecos to use for the user",
+                "type": "string"
+              },
+              "groups": {
+                "description": "Groups specifies the additional groups for the user",
+                "type": "string"
+              },
+              "homeDir": {
+                "description": "HomeDir specifies the home directory to use for the user",
+                "type": "string"
+              },
+              "inactive": {
+                "description": "Inactive specifies whether to mark the user as inactive",
+                "type": "boolean"
+              },
+              "lockPassword": {
+                "description": "LockPassword specifies if password login should be disabled",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Name specifies the username",
+                "type": "string"
+              },
+              "passwd": {
+                "description": "Passwd specifies a hashed password for the user",
+                "type": "string"
+              },
+              "passwdFrom": {
+                "description": "PasswdFrom is a referenced source of passwd to populate the passwd.",
+                "properties": {
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this password.",
+                    "properties": {
+                      "key": {
+                        "description": "Key is the key in the secret's data map for this value.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "secret"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "primaryGroup": {
+                "description": "PrimaryGroup specifies the primary group for the user",
+                "type": "string"
+              },
+              "shell": {
+                "description": "Shell specifies the user's shell",
+                "type": "string"
+              },
+              "sshAuthorizedKeys": {
+                "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "sudo": {
+                "description": "Sudo specifies a sudo role for the user",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "EKSConfigStatus defines the observed state of the Amazon EKS Bootstrap Configuration.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the EKSConfig.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "dataSecretName": {
+          "description": "DataSecretName is the name of the secret that stores the bootstrap data script.",
+          "type": "string"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set on non-retryable errors",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set on non-retryable errors",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready indicates the BootstrapData secret is ready to be consumed",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1alpha3.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1alpha3.json
@@ -1,0 +1,48 @@
+{
+  "description": "EKSConfigTemplate is the Schema for the eksconfigtemplates API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "EKSConfigTemplateSpec defines the desired state of EKSConfigTemplate",
+      "properties": {
+        "template": {
+          "description": "EKSConfigTemplateResource defines the Template structure",
+          "properties": {
+            "spec": {
+              "description": "EKSConfigSpec defines the desired state of EKSConfig",
+              "properties": {
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Passes the kubelet args into the EKS bootstrap script",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1alpha4.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1alpha4.json
@@ -1,0 +1,48 @@
+{
+  "description": "EKSConfigTemplate is the Schema for the eksconfigtemplates API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "EKSConfigTemplateSpec defines the desired state of EKSConfigTemplate",
+      "properties": {
+        "template": {
+          "description": "EKSConfigTemplateResource defines the Template structure",
+          "properties": {
+            "spec": {
+              "description": "EKSConfigSpec defines the desired state of EKSConfig",
+              "properties": {
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Passes the kubelet args into the EKS bootstrap script",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta1.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta1.json
@@ -1,0 +1,91 @@
+{
+  "description": "EKSConfigTemplate is the Amazon EKS Bootstrap Configuration Template API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "EKSConfigTemplateSpec defines the desired state of templated EKSConfig Amazon EKS Bootstrap Configuration resources.",
+      "properties": {
+        "template": {
+          "description": "EKSConfigTemplateResource defines the Template structure.",
+          "properties": {
+            "spec": {
+              "description": "EKSConfigSpec defines the desired state of Amazon EKS Bootstrap Configuration.",
+              "properties": {
+                "apiRetryAttempts": {
+                  "description": "APIRetryAttempts is the number of retry attempts for AWS API call.",
+                  "type": "integer"
+                },
+                "containerRuntime": {
+                  "description": "ContainerRuntime specify the container runtime to use when bootstrapping EKS.",
+                  "type": "string"
+                },
+                "dnsClusterIP": {
+                  "description": "DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
+                  "type": "string"
+                },
+                "dockerConfigJson": {
+                  "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI. This is expected to be a json string.",
+                  "type": "string"
+                },
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "KubeletExtraArgs passes the specified kubelet args into the Amazon EKS machine bootstrap script",
+                  "type": "object"
+                },
+                "pauseContainer": {
+                  "description": "PauseContainer allows customization of the pause container to use.",
+                  "properties": {
+                    "accountNumber": {
+                      "description": "AccountNumber is the AWS account number to pull the pause container from.",
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Version is the tag of the pause container to use.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "accountNumber",
+                    "version"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "serviceIPV6Cidr": {
+                  "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then the ip family will be set to ipv6.",
+                  "type": "string"
+                },
+                "useMaxPods": {
+                  "description": "UseMaxPods  sets --max-pods for the kubelet when true.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta2.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta2.json
@@ -1,0 +1,381 @@
+{
+  "description": "EKSConfigTemplate is the Amazon EKS Bootstrap Configuration Template API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "EKSConfigTemplateSpec defines the desired state of templated EKSConfig Amazon EKS Bootstrap Configuration resources.",
+      "properties": {
+        "template": {
+          "description": "EKSConfigTemplateResource defines the Template structure.",
+          "properties": {
+            "spec": {
+              "description": "EKSConfigSpec defines the desired state of Amazon EKS Bootstrap Configuration.",
+              "properties": {
+                "apiRetryAttempts": {
+                  "description": "APIRetryAttempts is the number of retry attempts for AWS API call.",
+                  "type": "integer"
+                },
+                "boostrapCommandOverride": {
+                  "description": "BootstrapCommandOverride allows you to override the bootstrap command to use for EKS nodes.",
+                  "type": "string"
+                },
+                "containerRuntime": {
+                  "description": "ContainerRuntime specify the container runtime to use when bootstrapping EKS.",
+                  "type": "string"
+                },
+                "diskSetup": {
+                  "description": "DiskSetup specifies options for the creation of partition tables and file systems on devices.",
+                  "properties": {
+                    "filesystems": {
+                      "description": "Filesystems specifies the list of file systems to setup.",
+                      "items": {
+                        "description": "Filesystem defines the file systems to be created.",
+                        "properties": {
+                          "device": {
+                            "description": "Device specifies the device name",
+                            "type": "string"
+                          },
+                          "extraOpts": {
+                            "description": "ExtraOpts defined extra options to add to the command for creating the file system.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "filesystem": {
+                            "description": "Filesystem specifies the file system type.",
+                            "type": "string"
+                          },
+                          "label": {
+                            "description": "Label specifies the file system label to be used. If set to None, no label is used.",
+                            "type": "string"
+                          },
+                          "overwrite": {
+                            "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                            "type": "boolean"
+                          },
+                          "partition": {
+                            "description": "Partition specifies the partition to use. The valid options are: \"auto|any\", \"auto\", \"any\", \"none\", and <NUM>, where NUM is the actual partition number.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "device",
+                          "filesystem",
+                          "label"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "partitions": {
+                      "description": "Partitions specifies the list of the partitions to setup.",
+                      "items": {
+                        "description": "Partition defines how to create and layout a partition.",
+                        "properties": {
+                          "device": {
+                            "description": "Device is the name of the device.",
+                            "type": "string"
+                          },
+                          "layout": {
+                            "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                            "type": "boolean"
+                          },
+                          "overwrite": {
+                            "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                            "type": "boolean"
+                          },
+                          "tableType": {
+                            "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "device",
+                          "layout"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dnsClusterIP": {
+                  "description": "DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
+                  "type": "string"
+                },
+                "dockerConfigJson": {
+                  "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI. This is expected to be a json string.",
+                  "type": "string"
+                },
+                "files": {
+                  "description": "Files specifies extra files to be passed to user_data upon creation.",
+                  "items": {
+                    "description": "File defines the input for generating write_files in cloud-init.",
+                    "properties": {
+                      "append": {
+                        "description": "Append specifies whether to append Content to existing file if Path exists.",
+                        "type": "boolean"
+                      },
+                      "content": {
+                        "description": "Content is the actual content of the file.",
+                        "type": "string"
+                      },
+                      "contentFrom": {
+                        "description": "ContentFrom is a referenced source of content to populate the file.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents a secret that should populate this file.",
+                            "properties": {
+                              "key": {
+                                "description": "Key is the key in the secret's data map for this value.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "secret"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "encoding": {
+                        "description": "Encoding specifies the encoding of the file contents.",
+                        "enum": [
+                          "base64",
+                          "gzip",
+                          "gzip+base64"
+                        ],
+                        "type": "string"
+                      },
+                      "owner": {
+                        "description": "Owner specifies the ownership of the file, e.g. \"root:root\".",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path specifies the full path on disk where to store the file.",
+                        "type": "string"
+                      },
+                      "permissions": {
+                        "description": "Permissions specifies the permissions to assign to the file, e.g. \"0640\".",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kubeletExtraArgs": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "KubeletExtraArgs passes the specified kubelet args into the Amazon EKS machine bootstrap script",
+                  "type": "object"
+                },
+                "mounts": {
+                  "description": "Mounts specifies a list of mount points to be setup.",
+                  "items": {
+                    "description": "MountPoints defines input for generated mounts in cloud-init.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "type": "array"
+                },
+                "ntp": {
+                  "description": "NTP specifies NTP configuration",
+                  "properties": {
+                    "enabled": {
+                      "description": "Enabled specifies whether NTP should be enabled",
+                      "type": "boolean"
+                    },
+                    "servers": {
+                      "description": "Servers specifies which NTP servers to use",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "pauseContainer": {
+                  "description": "PauseContainer allows customization of the pause container to use.",
+                  "properties": {
+                    "accountNumber": {
+                      "description": "AccountNumber is the AWS account number to pull the pause container from.",
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Version is the tag of the pause container to use.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "accountNumber",
+                    "version"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "postBootstrapCommands": {
+                  "description": "PostBootstrapCommands specifies extra commands to run after bootstrapping nodes to the cluster",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "preBootstrapCommands": {
+                  "description": "PreBootstrapCommands specifies extra commands to run before bootstrapping nodes to the cluster",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "serviceIPV6Cidr": {
+                  "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then the ip family will be set to ipv6.",
+                  "type": "string"
+                },
+                "useMaxPods": {
+                  "description": "UseMaxPods  sets --max-pods for the kubelet when true.",
+                  "type": "boolean"
+                },
+                "users": {
+                  "description": "Users specifies extra users to add",
+                  "items": {
+                    "description": "User defines the input for a generated user in cloud-init.",
+                    "properties": {
+                      "gecos": {
+                        "description": "Gecos specifies the gecos to use for the user",
+                        "type": "string"
+                      },
+                      "groups": {
+                        "description": "Groups specifies the additional groups for the user",
+                        "type": "string"
+                      },
+                      "homeDir": {
+                        "description": "HomeDir specifies the home directory to use for the user",
+                        "type": "string"
+                      },
+                      "inactive": {
+                        "description": "Inactive specifies whether to mark the user as inactive",
+                        "type": "boolean"
+                      },
+                      "lockPassword": {
+                        "description": "LockPassword specifies if password login should be disabled",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name specifies the username",
+                        "type": "string"
+                      },
+                      "passwd": {
+                        "description": "Passwd specifies a hashed password for the user",
+                        "type": "string"
+                      },
+                      "passwdFrom": {
+                        "description": "PasswdFrom is a referenced source of passwd to populate the passwd.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents a secret that should populate this password.",
+                            "properties": {
+                              "key": {
+                                "description": "Key is the key in the secret's data map for this value.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret in the KubeadmBootstrapConfig's namespace to use.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "secret"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "primaryGroup": {
+                        "description": "PrimaryGroup specifies the primary group for the user",
+                        "type": "string"
+                      },
+                      "shell": {
+                        "description": "Shell specifies the user's shell",
+                        "type": "string"
+                      },
+                      "sshAuthorizedKeys": {
+                        "description": "SSHAuthorizedKeys specifies a list of ssh authorized keys for the user",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "sudo": {
+                        "description": "Sudo specifies a sudo role for the user",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1alpha3.json
+++ b/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1alpha3.json
@@ -1,0 +1,1083 @@
+{
+  "description": "AWSManagedControlPlane is the Schema for the awsmanagedcontrolplanes API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedControlPlaneSpec defines the desired state of AWSManagedControlPlane",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "addons": {
+          "description": "Addons defines the EKS addons to enable with the EKS cluster.",
+          "items": {
+            "description": "Addon represents a EKS addon",
+            "properties": {
+              "conflictResolution": {
+                "default": "none",
+                "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+                "enum": [
+                  "overwrite",
+                  "none"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the addon",
+                "minLength": 2,
+                "type": "string"
+              },
+              "serviceAccountRoleARN": {
+                "description": "ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version is the version of the addon to use",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "associateOIDCProvider": {
+          "default": false,
+          "description": "AssociateOIDCProvider can be enabled to automatically create an identity provider for the controller for use with IAM roles for service accounts",
+          "type": "boolean"
+        },
+        "bastion": {
+          "description": "Bastion contains options to configure the bastion host.",
+          "properties": {
+            "allowedCIDRBlocks": {
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "type": "string"
+            },
+            "disableIngressRules": {
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "type": "boolean"
+            },
+            "instanceType": {
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "disableVPCCNI": {
+          "default": false,
+          "description": "DisableVPCCNI indicates that the Amazon VPC CNI should be disabled. With EKS clusters the Amazon VPC CNI is automatically installed into the cluster. For clusters where you want to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI should be deleted. You cannot set this to true if you are using the Amazon VPC CNI addon.",
+          "type": "boolean"
+        },
+        "eksClusterName": {
+          "description": "EKSClusterName allows you to specify the name of the EKS cluster in AWS. If you don't specify a name then a default name will be created based on the namespace and name of the managed control plane.",
+          "type": "string"
+        },
+        "encryptionConfig": {
+          "description": "EncryptionConfig specifies the encryption configuration for the cluster",
+          "properties": {
+            "provider": {
+              "description": "Provider specifies the ARN or alias of the CMK (in AWS KMS)",
+              "type": "string"
+            },
+            "resources": {
+              "description": "Resources specifies the resources to be encrypted",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "endpointAccess": {
+          "description": "Endpoints specifies access to this cluster's control plane endpoints",
+          "properties": {
+            "private": {
+              "description": "Private points VPC-internal control plane access to the private endpoint",
+              "type": "boolean"
+            },
+            "public": {
+              "description": "Public controls whether control plane endpoints are publicly accessible",
+              "type": "boolean"
+            },
+            "publicCIDRs": {
+              "description": "PublicCIDRs specifies which blocks can access the public endpoint",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "iamAuthenticatorConfig": {
+          "description": "IAMAuthenticatorConfig allows the specification of any additional user or role mappings for use when generating the aws-iam-authenticator configuration. If this is nil the default configuration is still generated for the cluster.",
+          "properties": {
+            "mapRoles": {
+              "description": "RoleMappings is a list of role mappings",
+              "items": {
+                "description": "RoleMapping represents a mapping from a IAM role to Kubernetes users and groups",
+                "properties": {
+                  "groups": {
+                    "description": "Groups is a list of kubernetes RBAC groups",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "rolearn": {
+                    "description": "RoleARN is the AWS ARN for the role to map",
+                    "minLength": 31,
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "UserName is a kubernetes RBAC user subject",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "groups",
+                  "rolearn",
+                  "username"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "mapUsers": {
+              "description": "UserMappings is a list of user mappings",
+              "items": {
+                "description": "UserMapping represents a mapping from an IAM user to Kubernetes users and groups",
+                "properties": {
+                  "groups": {
+                    "description": "Groups is a list of kubernetes RBAC groups",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "userarn": {
+                    "description": "UserARN is the AWS ARN for the user to map",
+                    "minLength": 31,
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "UserName is a kubernetes RBAC user subject",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "groups",
+                  "userarn",
+                  "username"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a identity to be used when reconciling the managed control plane.",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "type": "string"
+        },
+        "logging": {
+          "description": "Logging specifies which EKS Cluster logs should be enabled. Entries for each of the enabled logs will be sent to CloudWatch",
+          "properties": {
+            "apiServer": {
+              "default": false,
+              "description": "APIServer indicates if the Kubernetes API Server log (kube-apiserver) shoulkd be enabled",
+              "type": "boolean"
+            },
+            "audit": {
+              "default": false,
+              "description": "Audit indicates if the Kubernetes API audit log should be enabled",
+              "type": "boolean"
+            },
+            "authenticator": {
+              "default": false,
+              "description": "Authenticator indicates if the iam authenticator log should be enabled",
+              "type": "boolean"
+            },
+            "controllerManager": {
+              "default": false,
+              "description": "ControllerManager indicates if the controller manager (kube-controller-manager) log should be enabled",
+              "type": "boolean"
+            },
+            "scheduler": {
+              "default": false,
+              "description": "Scheduler indicates if the Kubernetes scheduler (kube-scheduler) log should be enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "apiServer",
+            "audit",
+            "authenticator",
+            "controllerManager",
+            "scheduler"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "networkSpec": {
+          "description": "NetworkSpec encapsulates all things related to AWS network.",
+          "properties": {
+            "cni": {
+              "description": "CNI configuration",
+              "properties": {
+                "cniIngressRules": {
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "items": {
+                    "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "fromPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                        "type": "string"
+                      },
+                      "toPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "fromPort",
+                      "protocol",
+                      "toPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupOverrides": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "type": "object"
+            },
+            "subnets": {
+              "description": "Subnets configuration.",
+              "items": {
+                "description": "SubnetSpec configures an AWS Subnet.",
+                "properties": {
+                  "availabilityZone": {
+                    "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                    "type": "string"
+                  },
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "isPublic": {
+                    "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                    "type": "boolean"
+                  },
+                  "natGatewayId": {
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "routeTableId": {
+                    "description": "RouteTableID is the routing table id associated with the subnet.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a collection of tags describing the resource.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vpc": {
+              "description": "VPC configuration.",
+              "properties": {
+                "availabilityZoneSelection": {
+                  "default": "Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "enum": [
+                    "Ordered",
+                    "Random"
+                  ],
+                  "type": "string"
+                },
+                "availabilityZoneUsageLimit": {
+                  "default": 3,
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                  "type": "string"
+                },
+                "internetGatewayId": {
+                  "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "roleAdditionalPolicies": {
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to the control plane role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role that gives EKS permission to make API calls. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "minLength": 2,
+          "type": "string"
+        },
+        "secondaryCidrBlock": {
+          "description": "SecondaryCidrBlock is the additional CIDR range to use for pod IPs. Must be within the 100.64.0.0/10 or 198.19.0.0/16 range.",
+          "type": "string"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        },
+        "tokenMethod": {
+          "default": "iam-authenticator",
+          "description": "TokenMethod is used to specify the method for obtaining a client token for communicating with EKS iam-authenticator - obtains a client token using iam-authentictor aws-cli - obtains a client token using the AWS CLI Defaults to iam-authenticator",
+          "enum": [
+            "iam-authenticator",
+            "aws-cli"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version. If no version number is supplied then the latest version of Kubernetes that EKS supports will be used.",
+          "minLength": 2,
+          "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.?$",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedControlPlaneStatus defines the observed state of AWSManagedControlPlane",
+      "properties": {
+        "addons": {
+          "description": "Addons holds the current status of the EKS addons",
+          "items": {
+            "description": "AddonState represents the state of an addon",
+            "properties": {
+              "arn": {
+                "description": "ARN is the AWS ARN of the addon",
+                "type": "string"
+              },
+              "createdAt": {
+                "description": "CreatedAt is the date and time the addon was created at",
+                "format": "date-time",
+                "type": "string"
+              },
+              "issues": {
+                "description": "Issues is a list of issue associated with the addon",
+                "items": {
+                  "description": "AddonIssue represents an issue with an addon",
+                  "properties": {
+                    "code": {
+                      "description": "Code is the issue code",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Message is the textual description of the issue",
+                      "type": "string"
+                    },
+                    "resourceIds": {
+                      "description": "ResourceIDs is a list of resource ids for the issue",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "modifiedAt": {
+                "description": "ModifiedAt is the date and time the addon was last modified",
+                "format": "date-time",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the addon",
+                "type": "string"
+              },
+              "serviceAccountRoleARN": {
+                "description": "ServiceAccountRoleArn is the ARN of the IAM role used for the service account",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the status of the addon",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version is the version of the addon to use",
+                "type": "string"
+              }
+            },
+            "required": [
+              "arn",
+              "name",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bastion": {
+          "description": "Bastion holds details of the instance that is used as a bastion jump box",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the AWS instance associated addresses.",
+              "items": {
+                "description": "MachineAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The machine address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "availabilityZone": {
+              "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "ebsOptimized": {
+              "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+              "type": "boolean"
+            },
+            "enaSupport": {
+              "description": "Specifies whether enhanced networking with ENA is enabled.",
+              "type": "boolean"
+            },
+            "iamProfile": {
+              "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "imageId": {
+              "description": "The ID of the AMI used to launch the instance.",
+              "type": "string"
+            },
+            "instanceState": {
+              "description": "The current state of the instance.",
+              "type": "string"
+            },
+            "networkInterfaces": {
+              "description": "Specifies ENIs attached to instance",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonRootVolumes": {
+              "description": "Configuration options for the non root storage volumes.",
+              "items": {
+                "description": "Volume encapsulates the configuration options for the storage device",
+                "properties": {
+                  "deviceName": {
+                    "description": "Device name",
+                    "type": "string"
+                  },
+                  "encrypted": {
+                    "description": "Encrypted is whether the volume should be encrypted or not.",
+                    "type": "boolean"
+                  },
+                  "encryptionKey": {
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "type": "string"
+                  },
+                  "iops": {
+                    "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "format": "int64",
+                    "minimum": 8,
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "privateIp": {
+              "description": "The private IPv4 address assigned to the instance.",
+              "type": "string"
+            },
+            "publicIp": {
+              "description": "The public IPv4 address assigned to the instance, if applicable.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "Configuration options for the root storage volume.",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions option for configuring instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "The name of the SSH key pair.",
+              "type": "string"
+            },
+            "subnetId": {
+              "description": "The ID of the subnet of the instance.",
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The tags associated with the instance.",
+              "type": "object"
+            },
+            "tenancy": {
+              "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The instance type.",
+              "type": "string"
+            },
+            "userData": {
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions specifies the cpnditions for the managed control plane",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "externalManagedControlPlane": {
+          "default": true,
+          "description": "ExternalManagedControlPlane indicates to cluster-api that the control plane is managed by an external service such as AKS, EKS, GKE, etc.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains specifies a list fo available availability zones that can be used",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "initialized": {
+          "description": "Initialized denotes whether or not the control plane has the uploaded kubernetes config-map.",
+          "type": "boolean"
+        },
+        "network": {
+          "description": "Networks holds details about the AWS networking resources used by the control plane",
+          "properties": {
+            "apiServerElb": {
+              "description": "APIServerELB is the Kubernetes api server classic load balancer.",
+              "properties": {
+                "attributes": {
+                  "description": "Attributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an AWS security group.",
+                "properties": {
+                  "id": {
+                    "description": "ID is a unique identifier.",
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is the inbound rules associated with the security group.",
+                    "items": {
+                      "description": "IngressRule defines an AWS ingress rule for security groups.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fromPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "sourceSecurityGroupIds": {
+                          "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "toPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "fromPort",
+                        "protocol",
+                        "toPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the security group name.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a map of tags associated with the security group.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oidcProvider": {
+          "description": "OIDCProvider holds the status of the identity provider for this cluster",
+          "properties": {
+            "arn": {
+              "description": "ARN holds the ARN of the provider",
+              "type": "string"
+            },
+            "trustPolicy": {
+              "description": "TrustPolicy contains the boilerplate IAM trust policy to use for IRSA",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the AWSManagedControlPlane API Server is ready to receive requests and that the VPC infra is ready.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1alpha4.json
+++ b/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1alpha4.json
@@ -1,0 +1,1164 @@
+{
+  "description": "AWSManagedControlPlane is the Schema for the awsmanagedcontrolplanes API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedControlPlaneSpec defines the desired state of AWSManagedControlPlane",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "addons": {
+          "description": "Addons defines the EKS addons to enable with the EKS cluster.",
+          "items": {
+            "description": "Addon represents a EKS addon",
+            "properties": {
+              "conflictResolution": {
+                "default": "none",
+                "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+                "enum": [
+                  "overwrite",
+                  "none"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the addon",
+                "minLength": 2,
+                "type": "string"
+              },
+              "serviceAccountRoleARN": {
+                "description": "ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version is the version of the addon to use",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "associateOIDCProvider": {
+          "default": false,
+          "description": "AssociateOIDCProvider can be enabled to automatically create an identity provider for the controller for use with IAM roles for service accounts",
+          "type": "boolean"
+        },
+        "bastion": {
+          "description": "Bastion contains options to configure the bastion host.",
+          "properties": {
+            "allowedCIDRBlocks": {
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "type": "string"
+            },
+            "disableIngressRules": {
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "type": "boolean"
+            },
+            "instanceType": {
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "disableVPCCNI": {
+          "default": false,
+          "description": "DisableVPCCNI indicates that the Amazon VPC CNI should be disabled. With EKS clusters the Amazon VPC CNI is automatically installed into the cluster. For clusters where you want to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI should be deleted. You cannot set this to true if you are using the Amazon VPC CNI addon.",
+          "type": "boolean"
+        },
+        "eksClusterName": {
+          "description": "EKSClusterName allows you to specify the name of the EKS cluster in AWS. If you don't specify a name then a default name will be created based on the namespace and name of the managed control plane.",
+          "type": "string"
+        },
+        "encryptionConfig": {
+          "description": "EncryptionConfig specifies the encryption configuration for the cluster",
+          "properties": {
+            "provider": {
+              "description": "Provider specifies the ARN or alias of the CMK (in AWS KMS)",
+              "type": "string"
+            },
+            "resources": {
+              "description": "Resources specifies the resources to be encrypted",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "endpointAccess": {
+          "description": "Endpoints specifies access to this cluster's control plane endpoints",
+          "properties": {
+            "private": {
+              "description": "Private points VPC-internal control plane access to the private endpoint",
+              "type": "boolean"
+            },
+            "public": {
+              "description": "Public controls whether control plane endpoints are publicly accessible",
+              "type": "boolean"
+            },
+            "publicCIDRs": {
+              "description": "PublicCIDRs specifies which blocks can access the public endpoint",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "iamAuthenticatorConfig": {
+          "description": "IAMAuthenticatorConfig allows the specification of any additional user or role mappings for use when generating the aws-iam-authenticator configuration. If this is nil the default configuration is still generated for the cluster.",
+          "properties": {
+            "mapRoles": {
+              "description": "RoleMappings is a list of role mappings",
+              "items": {
+                "description": "RoleMapping represents a mapping from a IAM role to Kubernetes users and groups",
+                "properties": {
+                  "groups": {
+                    "description": "Groups is a list of kubernetes RBAC groups",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "rolearn": {
+                    "description": "RoleARN is the AWS ARN for the role to map",
+                    "minLength": 31,
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "UserName is a kubernetes RBAC user subject",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "groups",
+                  "rolearn",
+                  "username"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "mapUsers": {
+              "description": "UserMappings is a list of user mappings",
+              "items": {
+                "description": "UserMapping represents a mapping from an IAM user to Kubernetes users and groups",
+                "properties": {
+                  "groups": {
+                    "description": "Groups is a list of kubernetes RBAC groups",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "userarn": {
+                    "description": "UserARN is the AWS ARN for the user to map",
+                    "minLength": 31,
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "UserName is a kubernetes RBAC user subject",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "groups",
+                  "userarn",
+                  "username"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a identity to be used when reconciling the managed control plane.",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "type": "string"
+        },
+        "logging": {
+          "description": "Logging specifies which EKS Cluster logs should be enabled. Entries for each of the enabled logs will be sent to CloudWatch",
+          "properties": {
+            "apiServer": {
+              "default": false,
+              "description": "APIServer indicates if the Kubernetes API Server log (kube-apiserver) shoulkd be enabled",
+              "type": "boolean"
+            },
+            "audit": {
+              "default": false,
+              "description": "Audit indicates if the Kubernetes API audit log should be enabled",
+              "type": "boolean"
+            },
+            "authenticator": {
+              "default": false,
+              "description": "Authenticator indicates if the iam authenticator log should be enabled",
+              "type": "boolean"
+            },
+            "controllerManager": {
+              "default": false,
+              "description": "ControllerManager indicates if the controller manager (kube-controller-manager) log should be enabled",
+              "type": "boolean"
+            },
+            "scheduler": {
+              "default": false,
+              "description": "Scheduler indicates if the Kubernetes scheduler (kube-scheduler) log should be enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "apiServer",
+            "audit",
+            "authenticator",
+            "controllerManager",
+            "scheduler"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "network": {
+          "description": "NetworkSpec encapsulates all things related to AWS network.",
+          "properties": {
+            "cni": {
+              "description": "CNI configuration",
+              "properties": {
+                "cniIngressRules": {
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "items": {
+                    "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "fromPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                        "type": "string"
+                      },
+                      "toPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "fromPort",
+                      "protocol",
+                      "toPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupOverrides": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "type": "object"
+            },
+            "subnets": {
+              "description": "Subnets configuration.",
+              "items": {
+                "description": "SubnetSpec configures an AWS Subnet.",
+                "properties": {
+                  "availabilityZone": {
+                    "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                    "type": "string"
+                  },
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "isPublic": {
+                    "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                    "type": "boolean"
+                  },
+                  "natGatewayId": {
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "routeTableId": {
+                    "description": "RouteTableID is the routing table id associated with the subnet.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a collection of tags describing the resource.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vpc": {
+              "description": "VPC configuration.",
+              "properties": {
+                "availabilityZoneSelection": {
+                  "default": "Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "enum": [
+                    "Ordered",
+                    "Random"
+                  ],
+                  "type": "string"
+                },
+                "availabilityZoneUsageLimit": {
+                  "default": 3,
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                  "type": "string"
+                },
+                "internetGatewayId": {
+                  "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oidcIdentityProviderConfig": {
+          "description": "IdentityProviderconfig is used to specify the oidc provider config to be attached with this eks cluster",
+          "properties": {
+            "clientId": {
+              "description": "This is also known as audience. The ID for the client application that makes authentication requests to the OpenID identity provider.",
+              "type": "string"
+            },
+            "groupsClaim": {
+              "description": "The JWT claim that the provider uses to return your groups.",
+              "type": "string"
+            },
+            "groupsPrefix": {
+              "description": "The prefix that is prepended to group claims to prevent clashes with existing names (such as system: groups). For example, the valueoidc: will create group names like oidc:engineering and oidc:infra.",
+              "type": "string"
+            },
+            "identityProviderConfigName": {
+              "description": "The name of the OIDC provider configuration. \n IdentityProviderConfigName is a required field",
+              "type": "string"
+            },
+            "issuerUrl": {
+              "description": "The URL of the OpenID identity provider that allows the API server to discover public signing keys for verifying tokens. The URL must begin with https:// and should correspond to the iss claim in the provider's OIDC ID tokens. Per the OIDC standard, path components are allowed but query parameters are not. Typically the URL consists of only a hostname, like https://server.example.org or https://example.com. This URL should point to the level below .well-known/openid-configuration and must be publicly accessible over the internet.",
+              "type": "string"
+            },
+            "requiredClaims": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The key value pairs that describe required claims in the identity token. If set, each claim is verified to be present in the token with a matching value. For the maximum number of claims that you can require, see Amazon EKS service quotas (https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) in the Amazon EKS User Guide.",
+              "type": "object"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "tags to apply to oidc identity provider association",
+              "type": "object"
+            },
+            "usernameClaim": {
+              "description": "The JSON Web Token (JWT) claim to use as the username. The default is sub, which is expected to be a unique identifier of the end user. You can choose other claims, such as email or name, depending on the OpenID identity provider. Claims other than email are prefixed with the issuer URL to prevent naming clashes with other plug-ins.",
+              "type": "string"
+            },
+            "usernamePrefix": {
+              "description": "The prefix that is prepended to username claims to prevent clashes with existing names. If you do not provide this field, and username is a value other than email, the prefix defaults to issuerurl#. You can use the value - to disable all prefixing.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "roleAdditionalPolicies": {
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to the control plane role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role that gives EKS permission to make API calls. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "minLength": 2,
+          "type": "string"
+        },
+        "secondaryCidrBlock": {
+          "description": "SecondaryCidrBlock is the additional CIDR range to use for pod IPs. Must be within the 100.64.0.0/10 or 198.19.0.0/16 range.",
+          "type": "string"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        },
+        "tokenMethod": {
+          "default": "iam-authenticator",
+          "description": "TokenMethod is used to specify the method for obtaining a client token for communicating with EKS iam-authenticator - obtains a client token using iam-authentictor aws-cli - obtains a client token using the AWS CLI Defaults to iam-authenticator",
+          "enum": [
+            "iam-authenticator",
+            "aws-cli"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version. If no version number is supplied then the latest version of Kubernetes that EKS supports will be used.",
+          "minLength": 2,
+          "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.?$",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedControlPlaneStatus defines the observed state of AWSManagedControlPlane",
+      "properties": {
+        "addons": {
+          "description": "Addons holds the current status of the EKS addons",
+          "items": {
+            "description": "AddonState represents the state of an addon",
+            "properties": {
+              "arn": {
+                "description": "ARN is the AWS ARN of the addon",
+                "type": "string"
+              },
+              "createdAt": {
+                "description": "CreatedAt is the date and time the addon was created at",
+                "format": "date-time",
+                "type": "string"
+              },
+              "issues": {
+                "description": "Issues is a list of issue associated with the addon",
+                "items": {
+                  "description": "AddonIssue represents an issue with an addon",
+                  "properties": {
+                    "code": {
+                      "description": "Code is the issue code",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Message is the textual description of the issue",
+                      "type": "string"
+                    },
+                    "resourceIds": {
+                      "description": "ResourceIDs is a list of resource ids for the issue",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "modifiedAt": {
+                "description": "ModifiedAt is the date and time the addon was last modified",
+                "format": "date-time",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the addon",
+                "type": "string"
+              },
+              "serviceAccountRoleARN": {
+                "description": "ServiceAccountRoleArn is the ARN of the IAM role used for the service account",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the status of the addon",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version is the version of the addon to use",
+                "type": "string"
+              }
+            },
+            "required": [
+              "arn",
+              "name",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bastion": {
+          "description": "Bastion holds details of the instance that is used as a bastion jump box",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the AWS instance associated addresses.",
+              "items": {
+                "description": "MachineAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The machine address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "availabilityZone": {
+              "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "ebsOptimized": {
+              "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+              "type": "boolean"
+            },
+            "enaSupport": {
+              "description": "Specifies whether enhanced networking with ENA is enabled.",
+              "type": "boolean"
+            },
+            "iamProfile": {
+              "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "imageId": {
+              "description": "The ID of the AMI used to launch the instance.",
+              "type": "string"
+            },
+            "instanceState": {
+              "description": "The current state of the instance.",
+              "type": "string"
+            },
+            "networkInterfaces": {
+              "description": "Specifies ENIs attached to instance",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonRootVolumes": {
+              "description": "Configuration options for the non root storage volumes.",
+              "items": {
+                "description": "Volume encapsulates the configuration options for the storage device",
+                "properties": {
+                  "deviceName": {
+                    "description": "Device name",
+                    "type": "string"
+                  },
+                  "encrypted": {
+                    "description": "Encrypted is whether the volume should be encrypted or not.",
+                    "type": "boolean"
+                  },
+                  "encryptionKey": {
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "type": "string"
+                  },
+                  "iops": {
+                    "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "format": "int64",
+                    "minimum": 8,
+                    "type": "integer"
+                  },
+                  "throughput": {
+                    "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "privateIp": {
+              "description": "The private IPv4 address assigned to the instance.",
+              "type": "string"
+            },
+            "publicIp": {
+              "description": "The public IPv4 address assigned to the instance, if applicable.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "Configuration options for the root storage volume.",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions option for configuring instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "The name of the SSH key pair.",
+              "type": "string"
+            },
+            "subnetId": {
+              "description": "The ID of the subnet of the instance.",
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The tags associated with the instance.",
+              "type": "object"
+            },
+            "tenancy": {
+              "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The instance type.",
+              "type": "string"
+            },
+            "userData": {
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "type": "string"
+            },
+            "volumeIDs": {
+              "description": "IDs of the instance's volumes",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions specifies the cpnditions for the managed control plane",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "externalManagedControlPlane": {
+          "default": true,
+          "description": "ExternalManagedControlPlane indicates to cluster-api that the control plane is managed by an external service such as AKS, EKS, GKE, etc.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains specifies a list fo available availability zones that can be used",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "identityProviderStatus": {
+          "description": "IdentityProviderStatus holds the status for associated identity provider",
+          "properties": {
+            "arn": {
+              "description": "ARN holds the ARN of associated identity provider",
+              "type": "string"
+            },
+            "status": {
+              "description": "Status holds current status of associated identity provider",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "initialized": {
+          "description": "Initialized denotes whether or not the control plane has the uploaded kubernetes config-map.",
+          "type": "boolean"
+        },
+        "networkStatus": {
+          "description": "Networks holds details about the AWS networking resources used by the control plane",
+          "properties": {
+            "apiServerElb": {
+              "description": "APIServerELB is the Kubernetes api server classic load balancer.",
+              "properties": {
+                "attributes": {
+                  "description": "Attributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an AWS security group.",
+                "properties": {
+                  "id": {
+                    "description": "ID is a unique identifier.",
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is the inbound rules associated with the security group.",
+                    "items": {
+                      "description": "IngressRule defines an AWS ingress rule for security groups.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fromPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "sourceSecurityGroupIds": {
+                          "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "toPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "fromPort",
+                        "protocol",
+                        "toPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the security group name.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a map of tags associated with the security group.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oidcProvider": {
+          "description": "OIDCProvider holds the status of the identity provider for this cluster",
+          "properties": {
+            "arn": {
+              "description": "ARN holds the ARN of the provider",
+              "type": "string"
+            },
+            "trustPolicy": {
+              "description": "TrustPolicy contains the boilerplate IAM trust policy to use for IRSA",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the AWSManagedControlPlane API Server is ready to receive requests and that the VPC infra is ready.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta1.json
+++ b/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta1.json
@@ -1,0 +1,1496 @@
+{
+  "description": "AWSManagedControlPlane is the schema for the Amazon EKS Managed Control Plane API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedControlPlaneSpec defines the desired state of an Amazon EKS Cluster.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "addons": {
+          "description": "Addons defines the EKS addons to enable with the EKS cluster.",
+          "items": {
+            "description": "Addon represents a EKS addon.",
+            "properties": {
+              "conflictResolution": {
+                "default": "none",
+                "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+                "enum": [
+                  "overwrite",
+                  "none"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the addon",
+                "minLength": 2,
+                "type": "string"
+              },
+              "serviceAccountRoleARN": {
+                "description": "ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version is the version of the addon to use",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "associateOIDCProvider": {
+          "default": false,
+          "description": "AssociateOIDCProvider can be enabled to automatically create an identity provider for the controller for use with IAM roles for service accounts",
+          "type": "boolean"
+        },
+        "bastion": {
+          "description": "Bastion contains options to configure the bastion host.",
+          "properties": {
+            "allowedCIDRBlocks": {
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "type": "string"
+            },
+            "disableIngressRules": {
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "type": "boolean"
+            },
+            "instanceType": {
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "disableVPCCNI": {
+          "default": false,
+          "description": "DisableVPCCNI indicates that the Amazon VPC CNI should be disabled. With EKS clusters the Amazon VPC CNI is automatically installed into the cluster. For clusters where you want to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI should be deleted. You cannot set this to true if you are using the Amazon VPC CNI addon.",
+          "type": "boolean"
+        },
+        "eksClusterName": {
+          "description": "EKSClusterName allows you to specify the name of the EKS cluster in AWS. If you don't specify a name then a default name will be created based on the namespace and name of the managed control plane.",
+          "type": "string"
+        },
+        "encryptionConfig": {
+          "description": "EncryptionConfig specifies the encryption configuration for the cluster",
+          "properties": {
+            "provider": {
+              "description": "Provider specifies the ARN or alias of the CMK (in AWS KMS)",
+              "type": "string"
+            },
+            "resources": {
+              "description": "Resources specifies the resources to be encrypted",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "endpointAccess": {
+          "description": "Endpoints specifies access to this cluster's control plane endpoints",
+          "properties": {
+            "private": {
+              "description": "Private points VPC-internal control plane access to the private endpoint",
+              "type": "boolean"
+            },
+            "public": {
+              "description": "Public controls whether control plane endpoints are publicly accessible",
+              "type": "boolean"
+            },
+            "publicCIDRs": {
+              "description": "PublicCIDRs specifies which blocks can access the public endpoint",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "iamAuthenticatorConfig": {
+          "description": "IAMAuthenticatorConfig allows the specification of any additional user or role mappings for use when generating the aws-iam-authenticator configuration. If this is nil the default configuration is still generated for the cluster.",
+          "properties": {
+            "mapRoles": {
+              "description": "RoleMappings is a list of role mappings",
+              "items": {
+                "description": "RoleMapping represents a mapping from a IAM role to Kubernetes users and groups.",
+                "properties": {
+                  "groups": {
+                    "description": "Groups is a list of kubernetes RBAC groups",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "rolearn": {
+                    "description": "RoleARN is the AWS ARN for the role to map",
+                    "minLength": 31,
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "UserName is a kubernetes RBAC user subject",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "groups",
+                  "rolearn",
+                  "username"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "mapUsers": {
+              "description": "UserMappings is a list of user mappings",
+              "items": {
+                "description": "UserMapping represents a mapping from an IAM user to Kubernetes users and groups.",
+                "properties": {
+                  "groups": {
+                    "description": "Groups is a list of kubernetes RBAC groups",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "userarn": {
+                    "description": "UserARN is the AWS ARN for the user to map",
+                    "minLength": 31,
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "UserName is a kubernetes RBAC user subject",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "groups",
+                  "userarn",
+                  "username"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a identity to be used when reconciling the managed control plane.",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "type": "string"
+        },
+        "kubeProxy": {
+          "description": "KubeProxy defines managed attributes of the kube-proxy daemonset",
+          "properties": {
+            "disable": {
+              "default": false,
+              "description": "Disable set to true indicates that kube-proxy should be disabled. With EKS clusters kube-proxy is automatically installed into the cluster. For clusters where you want to use kube-proxy functionality that is provided with an alternate CNI, this option provides a way to specify that the kube-proxy daemonset should be deleted. You cannot set this to true if you are using the Amazon kube-proxy addon.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logging": {
+          "description": "Logging specifies which EKS Cluster logs should be enabled. Entries for each of the enabled logs will be sent to CloudWatch",
+          "properties": {
+            "apiServer": {
+              "default": false,
+              "description": "APIServer indicates if the Kubernetes API Server log (kube-apiserver) shoulkd be enabled",
+              "type": "boolean"
+            },
+            "audit": {
+              "default": false,
+              "description": "Audit indicates if the Kubernetes API audit log should be enabled",
+              "type": "boolean"
+            },
+            "authenticator": {
+              "default": false,
+              "description": "Authenticator indicates if the iam authenticator log should be enabled",
+              "type": "boolean"
+            },
+            "controllerManager": {
+              "default": false,
+              "description": "ControllerManager indicates if the controller manager (kube-controller-manager) log should be enabled",
+              "type": "boolean"
+            },
+            "scheduler": {
+              "default": false,
+              "description": "Scheduler indicates if the Kubernetes scheduler (kube-scheduler) log should be enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "apiServer",
+            "audit",
+            "authenticator",
+            "controllerManager",
+            "scheduler"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "network": {
+          "description": "NetworkSpec encapsulates all things related to AWS network.",
+          "properties": {
+            "cni": {
+              "description": "CNI configuration",
+              "properties": {
+                "cniIngressRules": {
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "items": {
+                    "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "fromPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                        "type": "string"
+                      },
+                      "toPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "fromPort",
+                      "protocol",
+                      "toPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupOverrides": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "type": "object"
+            },
+            "subnets": {
+              "description": "Subnets configuration.",
+              "items": {
+                "description": "SubnetSpec configures an AWS Subnet.",
+                "properties": {
+                  "availabilityZone": {
+                    "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                    "type": "string"
+                  },
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "ipv6CidrBlock": {
+                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "type": "string"
+                  },
+                  "isIpv6": {
+                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "type": "boolean"
+                  },
+                  "isPublic": {
+                    "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                    "type": "boolean"
+                  },
+                  "natGatewayId": {
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "routeTableId": {
+                    "description": "RouteTableID is the routing table id associated with the subnet.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a collection of tags describing the resource.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "id"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "vpc": {
+              "description": "VPC configuration.",
+              "properties": {
+                "availabilityZoneSelection": {
+                  "default": "Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "enum": [
+                    "Ordered",
+                    "Random"
+                  ],
+                  "type": "string"
+                },
+                "availabilityZoneUsageLimit": {
+                  "default": 3,
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                  "type": "string"
+                },
+                "internetGatewayId": {
+                  "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                  "type": "string"
+                },
+                "ipv6": {
+                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                  "properties": {
+                    "cidrBlock": {
+                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                      "type": "string"
+                    },
+                    "egressOnlyInternetGatewayId": {
+                      "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
+                      "type": "string"
+                    },
+                    "poolId": {
+                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oidcIdentityProviderConfig": {
+          "description": "IdentityProviderconfig is used to specify the oidc provider config to be attached with this eks cluster",
+          "properties": {
+            "clientId": {
+              "description": "This is also known as audience. The ID for the client application that makes authentication requests to the OpenID identity provider.",
+              "type": "string"
+            },
+            "groupsClaim": {
+              "description": "The JWT claim that the provider uses to return your groups.",
+              "type": "string"
+            },
+            "groupsPrefix": {
+              "description": "The prefix that is prepended to group claims to prevent clashes with existing names (such as system: groups). For example, the valueoidc: will create group names like oidc:engineering and oidc:infra.",
+              "type": "string"
+            },
+            "identityProviderConfigName": {
+              "description": "The name of the OIDC provider configuration. \n IdentityProviderConfigName is a required field",
+              "type": "string"
+            },
+            "issuerUrl": {
+              "description": "The URL of the OpenID identity provider that allows the API server to discover public signing keys for verifying tokens. The URL must begin with https:// and should correspond to the iss claim in the provider's OIDC ID tokens. Per the OIDC standard, path components are allowed but query parameters are not. Typically the URL consists of only a hostname, like https://server.example.org or https://example.com. This URL should point to the level below .well-known/openid-configuration and must be publicly accessible over the internet.",
+              "type": "string"
+            },
+            "requiredClaims": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The key value pairs that describe required claims in the identity token. If set, each claim is verified to be present in the token with a matching value. For the maximum number of claims that you can require, see Amazon EKS service quotas (https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) in the Amazon EKS User Guide.",
+              "type": "object"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "tags to apply to oidc identity provider association",
+              "type": "object"
+            },
+            "usernameClaim": {
+              "description": "The JSON Web Token (JWT) claim to use as the username. The default is sub, which is expected to be a unique identifier of the end user. You can choose other claims, such as email or name, depending on the OpenID identity provider. Claims other than email are prefixed with the issuer URL to prevent naming clashes with other plug-ins.",
+              "type": "string"
+            },
+            "usernamePrefix": {
+              "description": "The prefix that is prepended to username claims to prevent clashes with existing names. If you do not provide this field, and username is a value other than email, the prefix defaults to issuerurl#. You can use the value - to disable all prefixing.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "roleAdditionalPolicies": {
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to the control plane role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role that gives EKS permission to make API calls. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "minLength": 2,
+          "type": "string"
+        },
+        "secondaryCidrBlock": {
+          "description": "SecondaryCidrBlock is the additional CIDR range to use for pod IPs. Must be within the 100.64.0.0/10 or 198.19.0.0/16 range.",
+          "type": "string"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        },
+        "tokenMethod": {
+          "default": "iam-authenticator",
+          "description": "TokenMethod is used to specify the method for obtaining a client token for communicating with EKS iam-authenticator - obtains a client token using iam-authentictor aws-cli - obtains a client token using the AWS CLI Defaults to iam-authenticator",
+          "enum": [
+            "iam-authenticator",
+            "aws-cli"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version. If no version number is supplied then the latest version of Kubernetes that EKS supports will be used.",
+          "minLength": 2,
+          "pattern": "^v?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.?(\\.0|[1-9][0-9]*)?$",
+          "type": "string"
+        },
+        "vpcCni": {
+          "description": "VpcCni is used to set configuration options for the VPC CNI plugin",
+          "properties": {
+            "env": {
+              "description": "Env defines a list of environment variables to apply to the `aws-node` DaemonSet",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedControlPlaneStatus defines the observed state of an Amazon EKS Cluster.",
+      "properties": {
+        "addons": {
+          "description": "Addons holds the current status of the EKS addons",
+          "items": {
+            "description": "AddonState represents the state of an addon.",
+            "properties": {
+              "arn": {
+                "description": "ARN is the AWS ARN of the addon",
+                "type": "string"
+              },
+              "createdAt": {
+                "description": "CreatedAt is the date and time the addon was created at",
+                "format": "date-time",
+                "type": "string"
+              },
+              "issues": {
+                "description": "Issues is a list of issue associated with the addon",
+                "items": {
+                  "description": "AddonIssue represents an issue with an addon.",
+                  "properties": {
+                    "code": {
+                      "description": "Code is the issue code",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Message is the textual description of the issue",
+                      "type": "string"
+                    },
+                    "resourceIds": {
+                      "description": "ResourceIDs is a list of resource ids for the issue",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "modifiedAt": {
+                "description": "ModifiedAt is the date and time the addon was last modified",
+                "format": "date-time",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the addon",
+                "type": "string"
+              },
+              "serviceAccountRoleARN": {
+                "description": "ServiceAccountRoleArn is the ARN of the IAM role used for the service account",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the status of the addon",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version is the version of the addon to use",
+                "type": "string"
+              }
+            },
+            "required": [
+              "arn",
+              "name",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bastion": {
+          "description": "Bastion holds details of the instance that is used as a bastion jump box",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the AWS instance associated addresses.",
+              "items": {
+                "description": "MachineAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The machine address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "availabilityZone": {
+              "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "ebsOptimized": {
+              "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+              "type": "boolean"
+            },
+            "enaSupport": {
+              "description": "Specifies whether enhanced networking with ENA is enabled.",
+              "type": "boolean"
+            },
+            "iamProfile": {
+              "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "imageId": {
+              "description": "The ID of the AMI used to launch the instance.",
+              "type": "string"
+            },
+            "instanceMetadataOptions": {
+              "description": "InstanceMetadataOptions is the metadata options for the EC2 instance.",
+              "properties": {
+                "httpEndpoint": {
+                  "default": "enabled",
+                  "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                },
+                "httpPutResponseHopLimit": {
+                  "default": 1,
+                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+                  "format": "int64",
+                  "maximum": 64,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "httpTokens": {
+                  "default": "required",
+                  "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+                  "enum": [
+                    "optional",
+                    "required"
+                  ],
+                  "type": "string"
+                },
+                "instanceMetadataTags": {
+                  "default": "disabled",
+                  "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "instanceState": {
+              "description": "The current state of the instance.",
+              "type": "string"
+            },
+            "networkInterfaces": {
+              "description": "Specifies ENIs attached to instance",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonRootVolumes": {
+              "description": "Configuration options for the non root storage volumes.",
+              "items": {
+                "description": "Volume encapsulates the configuration options for the storage device.",
+                "properties": {
+                  "deviceName": {
+                    "description": "Device name",
+                    "type": "string"
+                  },
+                  "encrypted": {
+                    "description": "Encrypted is whether the volume should be encrypted or not.",
+                    "type": "boolean"
+                  },
+                  "encryptionKey": {
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "type": "string"
+                  },
+                  "iops": {
+                    "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "format": "int64",
+                    "minimum": 8,
+                    "type": "integer"
+                  },
+                  "throughput": {
+                    "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "privateIp": {
+              "description": "The private IPv4 address assigned to the instance.",
+              "type": "string"
+            },
+            "publicIp": {
+              "description": "The public IPv4 address assigned to the instance, if applicable.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "Configuration options for the root storage volume.",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions option for configuring instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "The name of the SSH key pair.",
+              "type": "string"
+            },
+            "subnetId": {
+              "description": "The ID of the subnet of the instance.",
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The tags associated with the instance.",
+              "type": "object"
+            },
+            "tenancy": {
+              "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The instance type.",
+              "type": "string"
+            },
+            "userData": {
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "type": "string"
+            },
+            "volumeIDs": {
+              "description": "IDs of the instance's volumes",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions specifies the cpnditions for the managed control plane",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "externalManagedControlPlane": {
+          "default": true,
+          "description": "ExternalManagedControlPlane indicates to cluster-api that the control plane is managed by an external service such as AKS, EKS, GKE, etc.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains specifies a list fo available availability zones that can be used",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "identityProviderStatus": {
+          "description": "IdentityProviderStatus holds the status for associated identity provider",
+          "properties": {
+            "arn": {
+              "description": "ARN holds the ARN of associated identity provider",
+              "type": "string"
+            },
+            "status": {
+              "description": "Status holds current status of associated identity provider",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "initialized": {
+          "description": "Initialized denotes whether or not the control plane has the uploaded kubernetes config-map.",
+          "type": "boolean"
+        },
+        "networkStatus": {
+          "description": "Networks holds details about the AWS networking resources used by the control plane",
+          "properties": {
+            "apiServerElb": {
+              "description": "APIServerELB is the Kubernetes api server load balancer.",
+              "properties": {
+                "arn": {
+                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly to define and get it.",
+                  "type": "string"
+                },
+                "attributes": {
+                  "description": "ClassicElbAttributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "elbAttributes": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ELBAttributes defines extra attributes associated with v2 load balancers.",
+                  "type": "object"
+                },
+                "elbListeners": {
+                  "description": "ELBListeners is an array of listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "Listener defines an AWS network load balancer listener.",
+                    "properties": {
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "targetGroup": {
+                        "description": "TargetGroupSpec specifies target group settings for a given listener. This is created first, and the ARN is then passed to the listener.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the TargetGroup. Must be unique over the same group of listeners.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "Port is the exposed port",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "description": "ELBProtocol defines listener protocols for a load balancer.",
+                            "enum": [
+                              "tcp",
+                              "tls",
+                              "upd"
+                            ],
+                            "type": "string"
+                          },
+                          "targetGroupHealthCheck": {
+                            "description": "HealthCheck is the elb health check associated with the load balancer.",
+                            "properties": {
+                              "intervalSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "type": "string"
+                              },
+                              "thresholdCount": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vpcId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "port",
+                          "protocol",
+                          "vpcId"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "port",
+                      "protocol",
+                      "targetGroup"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "ClassicELBListeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "loadBalancerType": {
+                  "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+                  "enum": [
+                    "classic",
+                    "elb",
+                    "alb",
+                    "nlb"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an AWS security group.",
+                "properties": {
+                  "id": {
+                    "description": "ID is a unique identifier.",
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is the inbound rules associated with the security group.",
+                    "items": {
+                      "description": "IngressRule defines an AWS ingress rule for security groups.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fromPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "ipv6CidrBlocks": {
+                          "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "sourceSecurityGroupIds": {
+                          "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "toPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "fromPort",
+                        "protocol",
+                        "toPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the security group name.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a map of tags associated with the security group.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oidcProvider": {
+          "description": "OIDCProvider holds the status of the identity provider for this cluster",
+          "properties": {
+            "arn": {
+              "description": "ARN holds the ARN of the provider",
+              "type": "string"
+            },
+            "trustPolicy": {
+              "description": "TrustPolicy contains the boilerplate IAM trust policy to use for IRSA",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the AWSManagedControlPlane API Server is ready to receive requests and that the VPC infra is ready.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta2.json
+++ b/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta2.json
@@ -1,0 +1,1496 @@
+{
+  "description": "AWSManagedControlPlane is the schema for the Amazon EKS Managed Control Plane API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedControlPlaneSpec defines the desired state of an Amazon EKS Cluster.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "addons": {
+          "description": "Addons defines the EKS addons to enable with the EKS cluster.",
+          "items": {
+            "description": "Addon represents a EKS addon.",
+            "properties": {
+              "conflictResolution": {
+                "default": "overwrite",
+                "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+                "enum": [
+                  "overwrite",
+                  "none"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the addon",
+                "minLength": 2,
+                "type": "string"
+              },
+              "serviceAccountRoleARN": {
+                "description": "ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version is the version of the addon to use",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "associateOIDCProvider": {
+          "default": false,
+          "description": "AssociateOIDCProvider can be enabled to automatically create an identity provider for the controller for use with IAM roles for service accounts",
+          "type": "boolean"
+        },
+        "bastion": {
+          "description": "Bastion contains options to configure the bastion host.",
+          "properties": {
+            "allowedCIDRBlocks": {
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "type": "string"
+            },
+            "disableIngressRules": {
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "type": "boolean"
+            },
+            "instanceType": {
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "eksClusterName": {
+          "description": "EKSClusterName allows you to specify the name of the EKS cluster in AWS. If you don't specify a name then a default name will be created based on the namespace and name of the managed control plane.",
+          "type": "string"
+        },
+        "encryptionConfig": {
+          "description": "EncryptionConfig specifies the encryption configuration for the cluster",
+          "properties": {
+            "provider": {
+              "description": "Provider specifies the ARN or alias of the CMK (in AWS KMS)",
+              "type": "string"
+            },
+            "resources": {
+              "description": "Resources specifies the resources to be encrypted",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "endpointAccess": {
+          "description": "Endpoints specifies access to this cluster's control plane endpoints",
+          "properties": {
+            "private": {
+              "description": "Private points VPC-internal control plane access to the private endpoint",
+              "type": "boolean"
+            },
+            "public": {
+              "description": "Public controls whether control plane endpoints are publicly accessible",
+              "type": "boolean"
+            },
+            "publicCIDRs": {
+              "description": "PublicCIDRs specifies which blocks can access the public endpoint",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "iamAuthenticatorConfig": {
+          "description": "IAMAuthenticatorConfig allows the specification of any additional user or role mappings for use when generating the aws-iam-authenticator configuration. If this is nil the default configuration is still generated for the cluster.",
+          "properties": {
+            "mapRoles": {
+              "description": "RoleMappings is a list of role mappings",
+              "items": {
+                "description": "RoleMapping represents a mapping from a IAM role to Kubernetes users and groups.",
+                "properties": {
+                  "groups": {
+                    "description": "Groups is a list of kubernetes RBAC groups",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "rolearn": {
+                    "description": "RoleARN is the AWS ARN for the role to map",
+                    "minLength": 31,
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "UserName is a kubernetes RBAC user subject",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "groups",
+                  "rolearn",
+                  "username"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "mapUsers": {
+              "description": "UserMappings is a list of user mappings",
+              "items": {
+                "description": "UserMapping represents a mapping from an IAM user to Kubernetes users and groups.",
+                "properties": {
+                  "groups": {
+                    "description": "Groups is a list of kubernetes RBAC groups",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "userarn": {
+                    "description": "UserARN is the AWS ARN for the user to map",
+                    "minLength": 31,
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "UserName is a kubernetes RBAC user subject",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "groups",
+                  "userarn",
+                  "username"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a identity to be used when reconciling the managed control plane.",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "type": "string"
+        },
+        "kubeProxy": {
+          "description": "KubeProxy defines managed attributes of the kube-proxy daemonset",
+          "properties": {
+            "disable": {
+              "default": false,
+              "description": "Disable set to true indicates that kube-proxy should be disabled. With EKS clusters kube-proxy is automatically installed into the cluster. For clusters where you want to use kube-proxy functionality that is provided with an alternate CNI, this option provides a way to specify that the kube-proxy daemonset should be deleted. You cannot set this to true if you are using the Amazon kube-proxy addon.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logging": {
+          "description": "Logging specifies which EKS Cluster logs should be enabled. Entries for each of the enabled logs will be sent to CloudWatch",
+          "properties": {
+            "apiServer": {
+              "default": false,
+              "description": "APIServer indicates if the Kubernetes API Server log (kube-apiserver) shoulkd be enabled",
+              "type": "boolean"
+            },
+            "audit": {
+              "default": false,
+              "description": "Audit indicates if the Kubernetes API audit log should be enabled",
+              "type": "boolean"
+            },
+            "authenticator": {
+              "default": false,
+              "description": "Authenticator indicates if the iam authenticator log should be enabled",
+              "type": "boolean"
+            },
+            "controllerManager": {
+              "default": false,
+              "description": "ControllerManager indicates if the controller manager (kube-controller-manager) log should be enabled",
+              "type": "boolean"
+            },
+            "scheduler": {
+              "default": false,
+              "description": "Scheduler indicates if the Kubernetes scheduler (kube-scheduler) log should be enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "apiServer",
+            "audit",
+            "authenticator",
+            "controllerManager",
+            "scheduler"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "network": {
+          "description": "NetworkSpec encapsulates all things related to AWS network.",
+          "properties": {
+            "cni": {
+              "description": "CNI configuration",
+              "properties": {
+                "cniIngressRules": {
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "items": {
+                    "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "fromPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                        "type": "string"
+                      },
+                      "toPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "fromPort",
+                      "protocol",
+                      "toPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupOverrides": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "type": "object"
+            },
+            "subnets": {
+              "description": "Subnets configuration.",
+              "items": {
+                "description": "SubnetSpec configures an AWS Subnet.",
+                "properties": {
+                  "availabilityZone": {
+                    "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                    "type": "string"
+                  },
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "ipv6CidrBlock": {
+                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "type": "string"
+                  },
+                  "isIpv6": {
+                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "type": "boolean"
+                  },
+                  "isPublic": {
+                    "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                    "type": "boolean"
+                  },
+                  "natGatewayId": {
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "routeTableId": {
+                    "description": "RouteTableID is the routing table id associated with the subnet.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a collection of tags describing the resource.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "id"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "vpc": {
+              "description": "VPC configuration.",
+              "properties": {
+                "availabilityZoneSelection": {
+                  "default": "Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "enum": [
+                    "Ordered",
+                    "Random"
+                  ],
+                  "type": "string"
+                },
+                "availabilityZoneUsageLimit": {
+                  "default": 3,
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                  "type": "string"
+                },
+                "internetGatewayId": {
+                  "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                  "type": "string"
+                },
+                "ipv6": {
+                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                  "properties": {
+                    "cidrBlock": {
+                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                      "type": "string"
+                    },
+                    "egressOnlyInternetGatewayId": {
+                      "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
+                      "type": "string"
+                    },
+                    "poolId": {
+                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oidcIdentityProviderConfig": {
+          "description": "IdentityProviderconfig is used to specify the oidc provider config to be attached with this eks cluster",
+          "properties": {
+            "clientId": {
+              "description": "This is also known as audience. The ID for the client application that makes authentication requests to the OpenID identity provider.",
+              "type": "string"
+            },
+            "groupsClaim": {
+              "description": "The JWT claim that the provider uses to return your groups.",
+              "type": "string"
+            },
+            "groupsPrefix": {
+              "description": "The prefix that is prepended to group claims to prevent clashes with existing names (such as system: groups). For example, the valueoidc: will create group names like oidc:engineering and oidc:infra.",
+              "type": "string"
+            },
+            "identityProviderConfigName": {
+              "description": "The name of the OIDC provider configuration. \n IdentityProviderConfigName is a required field",
+              "type": "string"
+            },
+            "issuerUrl": {
+              "description": "The URL of the OpenID identity provider that allows the API server to discover public signing keys for verifying tokens. The URL must begin with https:// and should correspond to the iss claim in the provider's OIDC ID tokens. Per the OIDC standard, path components are allowed but query parameters are not. Typically the URL consists of only a hostname, like https://server.example.org or https://example.com. This URL should point to the level below .well-known/openid-configuration and must be publicly accessible over the internet.",
+              "type": "string"
+            },
+            "requiredClaims": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The key value pairs that describe required claims in the identity token. If set, each claim is verified to be present in the token with a matching value. For the maximum number of claims that you can require, see Amazon EKS service quotas (https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) in the Amazon EKS User Guide.",
+              "type": "object"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "tags to apply to oidc identity provider association",
+              "type": "object"
+            },
+            "usernameClaim": {
+              "description": "The JSON Web Token (JWT) claim to use as the username. The default is sub, which is expected to be a unique identifier of the end user. You can choose other claims, such as email or name, depending on the OpenID identity provider. Claims other than email are prefixed with the issuer URL to prevent naming clashes with other plug-ins.",
+              "type": "string"
+            },
+            "usernamePrefix": {
+              "description": "The prefix that is prepended to username claims to prevent clashes with existing names. If you do not provide this field, and username is a value other than email, the prefix defaults to issuerurl#. You can use the value - to disable all prefixing.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "roleAdditionalPolicies": {
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to the control plane role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role that gives EKS permission to make API calls. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "minLength": 2,
+          "type": "string"
+        },
+        "secondaryCidrBlock": {
+          "description": "SecondaryCidrBlock is the additional CIDR range to use for pod IPs. Must be within the 100.64.0.0/10 or 198.19.0.0/16 range.",
+          "type": "string"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        },
+        "tokenMethod": {
+          "default": "iam-authenticator",
+          "description": "TokenMethod is used to specify the method for obtaining a client token for communicating with EKS iam-authenticator - obtains a client token using iam-authentictor aws-cli - obtains a client token using the AWS CLI Defaults to iam-authenticator",
+          "enum": [
+            "iam-authenticator",
+            "aws-cli"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version. If no version number is supplied then the latest version of Kubernetes that EKS supports will be used.",
+          "minLength": 2,
+          "pattern": "^v?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.?(\\.0|[1-9][0-9]*)?$",
+          "type": "string"
+        },
+        "vpcCni": {
+          "description": "VpcCni is used to set configuration options for the VPC CNI plugin",
+          "properties": {
+            "disable": {
+              "default": false,
+              "description": "Disable indicates that the Amazon VPC CNI should be disabled. With EKS clusters the Amazon VPC CNI is automatically installed into the cluster. For clusters where you want to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI should be deleted. You cannot set this to true if you are using the Amazon VPC CNI addon.",
+              "type": "boolean"
+            },
+            "env": {
+              "description": "Env defines a list of environment variables to apply to the `aws-node` DaemonSet",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedControlPlaneStatus defines the observed state of an Amazon EKS Cluster.",
+      "properties": {
+        "addons": {
+          "description": "Addons holds the current status of the EKS addons",
+          "items": {
+            "description": "AddonState represents the state of an addon.",
+            "properties": {
+              "arn": {
+                "description": "ARN is the AWS ARN of the addon",
+                "type": "string"
+              },
+              "createdAt": {
+                "description": "CreatedAt is the date and time the addon was created at",
+                "format": "date-time",
+                "type": "string"
+              },
+              "issues": {
+                "description": "Issues is a list of issue associated with the addon",
+                "items": {
+                  "description": "AddonIssue represents an issue with an addon.",
+                  "properties": {
+                    "code": {
+                      "description": "Code is the issue code",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Message is the textual description of the issue",
+                      "type": "string"
+                    },
+                    "resourceIds": {
+                      "description": "ResourceIDs is a list of resource ids for the issue",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "modifiedAt": {
+                "description": "ModifiedAt is the date and time the addon was last modified",
+                "format": "date-time",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the addon",
+                "type": "string"
+              },
+              "serviceAccountRoleARN": {
+                "description": "ServiceAccountRoleArn is the ARN of the IAM role used for the service account",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the status of the addon",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version is the version of the addon to use",
+                "type": "string"
+              }
+            },
+            "required": [
+              "arn",
+              "name",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bastion": {
+          "description": "Bastion holds details of the instance that is used as a bastion jump box",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the AWS instance associated addresses.",
+              "items": {
+                "description": "MachineAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The machine address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "availabilityZone": {
+              "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "ebsOptimized": {
+              "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+              "type": "boolean"
+            },
+            "enaSupport": {
+              "description": "Specifies whether enhanced networking with ENA is enabled.",
+              "type": "boolean"
+            },
+            "iamProfile": {
+              "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "imageId": {
+              "description": "The ID of the AMI used to launch the instance.",
+              "type": "string"
+            },
+            "instanceMetadataOptions": {
+              "description": "InstanceMetadataOptions is the metadata options for the EC2 instance.",
+              "properties": {
+                "httpEndpoint": {
+                  "default": "enabled",
+                  "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                },
+                "httpPutResponseHopLimit": {
+                  "default": 1,
+                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+                  "format": "int64",
+                  "maximum": 64,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "httpTokens": {
+                  "default": "required",
+                  "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+                  "enum": [
+                    "optional",
+                    "required"
+                  ],
+                  "type": "string"
+                },
+                "instanceMetadataTags": {
+                  "default": "disabled",
+                  "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "instanceState": {
+              "description": "The current state of the instance.",
+              "type": "string"
+            },
+            "networkInterfaces": {
+              "description": "Specifies ENIs attached to instance",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonRootVolumes": {
+              "description": "Configuration options for the non root storage volumes.",
+              "items": {
+                "description": "Volume encapsulates the configuration options for the storage device.",
+                "properties": {
+                  "deviceName": {
+                    "description": "Device name",
+                    "type": "string"
+                  },
+                  "encrypted": {
+                    "description": "Encrypted is whether the volume should be encrypted or not.",
+                    "type": "boolean"
+                  },
+                  "encryptionKey": {
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "type": "string"
+                  },
+                  "iops": {
+                    "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "format": "int64",
+                    "minimum": 8,
+                    "type": "integer"
+                  },
+                  "throughput": {
+                    "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "privateIp": {
+              "description": "The private IPv4 address assigned to the instance.",
+              "type": "string"
+            },
+            "publicIp": {
+              "description": "The public IPv4 address assigned to the instance, if applicable.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "Configuration options for the root storage volume.",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions option for configuring instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "The name of the SSH key pair.",
+              "type": "string"
+            },
+            "subnetId": {
+              "description": "The ID of the subnet of the instance.",
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The tags associated with the instance.",
+              "type": "object"
+            },
+            "tenancy": {
+              "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The instance type.",
+              "type": "string"
+            },
+            "userData": {
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "type": "string"
+            },
+            "volumeIDs": {
+              "description": "IDs of the instance's volumes",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions specifies the cpnditions for the managed control plane",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "externalManagedControlPlane": {
+          "default": true,
+          "description": "ExternalManagedControlPlane indicates to cluster-api that the control plane is managed by an external service such as AKS, EKS, GKE, etc.",
+          "type": "boolean"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains specifies a list fo available availability zones that can be used",
+          "type": "object"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.",
+          "type": "string"
+        },
+        "identityProviderStatus": {
+          "description": "IdentityProviderStatus holds the status for associated identity provider",
+          "properties": {
+            "arn": {
+              "description": "ARN holds the ARN of associated identity provider",
+              "type": "string"
+            },
+            "status": {
+              "description": "Status holds current status of associated identity provider",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "initialized": {
+          "description": "Initialized denotes whether or not the control plane has the uploaded kubernetes config-map.",
+          "type": "boolean"
+        },
+        "networkStatus": {
+          "description": "Networks holds details about the AWS networking resources used by the control plane",
+          "properties": {
+            "apiServerElb": {
+              "description": "APIServerELB is the Kubernetes api server load balancer.",
+              "properties": {
+                "arn": {
+                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly to define and get it.",
+                  "type": "string"
+                },
+                "attributes": {
+                  "description": "ClassicElbAttributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "elbAttributes": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ELBAttributes defines extra attributes associated with v2 load balancers.",
+                  "type": "object"
+                },
+                "elbListeners": {
+                  "description": "ELBListeners is an array of listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "Listener defines an AWS network load balancer listener.",
+                    "properties": {
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "targetGroup": {
+                        "description": "TargetGroupSpec specifies target group settings for a given listener. This is created first, and the ARN is then passed to the listener.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the TargetGroup. Must be unique over the same group of listeners.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "Port is the exposed port",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "description": "ELBProtocol defines listener protocols for a load balancer.",
+                            "enum": [
+                              "tcp",
+                              "tls",
+                              "upd"
+                            ],
+                            "type": "string"
+                          },
+                          "targetGroupHealthCheck": {
+                            "description": "HealthCheck is the elb health check associated with the load balancer.",
+                            "properties": {
+                              "intervalSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "type": "string"
+                              },
+                              "thresholdCount": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vpcId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "port",
+                          "protocol",
+                          "vpcId"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "port",
+                      "protocol",
+                      "targetGroup"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "ClassicELBListeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "loadBalancerType": {
+                  "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+                  "enum": [
+                    "classic",
+                    "elb",
+                    "alb",
+                    "nlb"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an AWS security group.",
+                "properties": {
+                  "id": {
+                    "description": "ID is a unique identifier.",
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is the inbound rules associated with the security group.",
+                    "items": {
+                      "description": "IngressRule defines an AWS ingress rule for security groups.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fromPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "ipv6CidrBlocks": {
+                          "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "sourceSecurityGroupIds": {
+                          "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "toPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "fromPort",
+                        "protocol",
+                        "toPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the security group name.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a map of tags associated with the security group.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oidcProvider": {
+          "description": "OIDCProvider holds the status of the identity provider for this cluster",
+          "properties": {
+            "arn": {
+              "description": "ARN holds the ARN of the provider",
+              "type": "string"
+            },
+            "trustPolicy": {
+              "description": "TrustPolicy contains the boilerplate IAM trust policy to use for IRSA",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the AWSManagedControlPlane API Server is ready to receive requests and that the VPC infra is ready.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awscluster_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/awscluster_v1alpha2.json
@@ -1,0 +1,474 @@
+{
+  "description": "AWSCluster is the Schema for the awsclusters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSClusterSpec defines the desired state of AWSCluster",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "controlPlaneLoadBalancer": {
+          "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior",
+          "properties": {
+            "scheme": {
+              "description": "Scheme sets the scheme of the load balancer (defaults to Internet-facing)",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "disableBastionHost": {
+          "description": "DisableBastionHost is an optional configuration field to prevent the creation of a bastion host instance.",
+          "type": "boolean"
+        },
+        "networkSpec": {
+          "description": "NetworkSpec encapsulates all things related to AWS network.",
+          "properties": {
+            "subnets": {
+              "description": "Subnets configuration.",
+              "items": {
+                "description": "SubnetSpec configures an AWS Subnet.",
+                "properties": {
+                  "availabilityZone": {
+                    "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                    "type": "string"
+                  },
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "isPublic": {
+                    "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                    "type": "boolean"
+                  },
+                  "natGatewayId": {
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "routeTableId": {
+                    "description": "RouteTableID is the routing table id associated with the subnet.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a collection of tags describing the resource.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vpc": {
+              "description": "VPC configuration.",
+              "properties": {
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                  "type": "string"
+                },
+                "internetGatewayId": {
+                  "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the bastion host.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSClusterStatus defines the observed state of AWSCluster",
+      "properties": {
+        "apiEndpoints": {
+          "description": "APIEndpoints represents the endpoints to communicate with the control plane.",
+          "items": {
+            "description": "APIEndpoint represents a reachable Kubernetes API endpoint.",
+            "properties": {
+              "host": {
+                "description": "The hostname on which the API server is serving.",
+                "type": "string"
+              },
+              "port": {
+                "description": "The port on which the API server is serving.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "host",
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bastion": {
+          "description": "Instance describes an AWS instance.",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the AWS instance associated addresses.",
+              "items": {
+                "description": "MachineAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The machine address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "ebsOptimized": {
+              "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+              "type": "boolean"
+            },
+            "enaSupport": {
+              "description": "Specifies whether enhanced networking with ENA is enabled.",
+              "type": "boolean"
+            },
+            "iamProfile": {
+              "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "imageId": {
+              "description": "The ID of the AMI used to launch the instance.",
+              "type": "string"
+            },
+            "instanceState": {
+              "description": "The current state of the instance.",
+              "type": "string"
+            },
+            "networkInterfaces": {
+              "description": "Specifies ENIs attached to instance",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "privateIp": {
+              "description": "The private IPv4 address assigned to the instance.",
+              "type": "string"
+            },
+            "publicIp": {
+              "description": "The public IPv4 address assigned to the instance, if applicable.",
+              "type": "string"
+            },
+            "rootDeviceSize": {
+              "description": "Specifies size (in Gi) of the root storage device",
+              "format": "int64",
+              "type": "integer"
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "sshKeyName": {
+              "description": "The name of the SSH key pair.",
+              "type": "string"
+            },
+            "subnetId": {
+              "description": "The ID of the subnet of the instance.",
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The tags associated with the instance.",
+              "type": "object"
+            },
+            "type": {
+              "description": "The instance type.",
+              "type": "string"
+            },
+            "userData": {
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "network": {
+          "description": "Network encapsulates AWS networking resources.",
+          "properties": {
+            "apiServerElb": {
+              "description": "APIServerELB is the Kubernetes api server classic load balancer.",
+              "properties": {
+                "attributes": {
+                  "description": "Attributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an AWS security group.",
+                "properties": {
+                  "id": {
+                    "description": "ID is a unique identifier.",
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is the inbound rules associated with the security group.",
+                    "items": {
+                      "description": "IngressRule defines an AWS ingress rule for security groups.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fromPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "sourceSecurityGroupIds": {
+                          "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "toPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "fromPort",
+                        "protocol",
+                        "toPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the security group name.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a map of tags associated with the security group.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awscluster_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awscluster_v1alpha3.json
@@ -1,0 +1,785 @@
+{
+  "description": "AWSCluster is the Schema for the awsclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSClusterSpec defines the desired state of AWSCluster.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "bastion": {
+          "description": "Bastion contains options to configure the bastion host.",
+          "properties": {
+            "allowedCIDRBlocks": {
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "type": "string"
+            },
+            "disableIngressRules": {
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "type": "boolean"
+            },
+            "instanceType": {
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneLoadBalancer": {
+          "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "crossZoneLoadBalancing": {
+              "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+              "type": "boolean"
+            },
+            "scheme": {
+              "default": "internet-facing",
+              "description": "Scheme sets the scheme of the load balancer (defaults to internet-facing)",
+              "enum": [
+                "internet-facing",
+                "Internet-facing",
+                "internal"
+              ],
+              "type": "string"
+            },
+            "subnets": {
+              "description": "Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "type": "string"
+        },
+        "networkSpec": {
+          "description": "NetworkSpec encapsulates all things related to AWS network.",
+          "properties": {
+            "cni": {
+              "description": "CNI configuration",
+              "properties": {
+                "cniIngressRules": {
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "items": {
+                    "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "fromPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                        "type": "string"
+                      },
+                      "toPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "fromPort",
+                      "protocol",
+                      "toPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupOverrides": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "type": "object"
+            },
+            "subnets": {
+              "description": "Subnets configuration.",
+              "items": {
+                "description": "SubnetSpec configures an AWS Subnet.",
+                "properties": {
+                  "availabilityZone": {
+                    "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                    "type": "string"
+                  },
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "isPublic": {
+                    "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                    "type": "boolean"
+                  },
+                  "natGatewayId": {
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "routeTableId": {
+                    "description": "RouteTableID is the routing table id associated with the subnet.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a collection of tags describing the resource.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vpc": {
+              "description": "VPC configuration.",
+              "properties": {
+                "availabilityZoneSelection": {
+                  "default": "Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "enum": [
+                    "Ordered",
+                    "Random"
+                  ],
+                  "type": "string"
+                },
+                "availabilityZoneUsageLimit": {
+                  "default": 3,
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                  "type": "string"
+                },
+                "internetGatewayId": {
+                  "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSClusterStatus defines the observed state of AWSCluster.",
+      "properties": {
+        "bastion": {
+          "description": "Instance describes an AWS instance.",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the AWS instance associated addresses.",
+              "items": {
+                "description": "MachineAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The machine address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "availabilityZone": {
+              "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "ebsOptimized": {
+              "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+              "type": "boolean"
+            },
+            "enaSupport": {
+              "description": "Specifies whether enhanced networking with ENA is enabled.",
+              "type": "boolean"
+            },
+            "iamProfile": {
+              "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "imageId": {
+              "description": "The ID of the AMI used to launch the instance.",
+              "type": "string"
+            },
+            "instanceState": {
+              "description": "The current state of the instance.",
+              "type": "string"
+            },
+            "networkInterfaces": {
+              "description": "Specifies ENIs attached to instance",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonRootVolumes": {
+              "description": "Configuration options for the non root storage volumes.",
+              "items": {
+                "description": "Volume encapsulates the configuration options for the storage device",
+                "properties": {
+                  "deviceName": {
+                    "description": "Device name",
+                    "type": "string"
+                  },
+                  "encrypted": {
+                    "description": "Encrypted is whether the volume should be encrypted or not.",
+                    "type": "boolean"
+                  },
+                  "encryptionKey": {
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "type": "string"
+                  },
+                  "iops": {
+                    "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "format": "int64",
+                    "minimum": 8,
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "privateIp": {
+              "description": "The private IPv4 address assigned to the instance.",
+              "type": "string"
+            },
+            "publicIp": {
+              "description": "The public IPv4 address assigned to the instance, if applicable.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "Configuration options for the root storage volume.",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions option for configuring instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "The name of the SSH key pair.",
+              "type": "string"
+            },
+            "subnetId": {
+              "description": "The ID of the subnet of the instance.",
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The tags associated with the instance.",
+              "type": "object"
+            },
+            "tenancy": {
+              "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The instance type.",
+              "type": "string"
+            },
+            "userData": {
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions provide observations of the operational state of a Cluster API resource.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of FailureDomains.",
+          "type": "object"
+        },
+        "network": {
+          "description": "Network encapsulates AWS networking resources.",
+          "properties": {
+            "apiServerElb": {
+              "description": "APIServerELB is the Kubernetes api server classic load balancer.",
+              "properties": {
+                "attributes": {
+                  "description": "Attributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an AWS security group.",
+                "properties": {
+                  "id": {
+                    "description": "ID is a unique identifier.",
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is the inbound rules associated with the security group.",
+                    "items": {
+                      "description": "IngressRule defines an AWS ingress rule for security groups.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fromPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "sourceSecurityGroupIds": {
+                          "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "toPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "fromPort",
+                        "protocol",
+                        "toPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the security group name.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a map of tags associated with the security group.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awscluster_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awscluster_v1alpha4.json
@@ -1,0 +1,802 @@
+{
+  "description": "AWSCluster is the Schema for the awsclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSClusterSpec defines the desired state of AWSCluster",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "bastion": {
+          "description": "Bastion contains options to configure the bastion host.",
+          "properties": {
+            "allowedCIDRBlocks": {
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "type": "string"
+            },
+            "disableIngressRules": {
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "type": "boolean"
+            },
+            "instanceType": {
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneLoadBalancer": {
+          "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "crossZoneLoadBalancing": {
+              "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+              "type": "boolean"
+            },
+            "scheme": {
+              "default": "internet-facing",
+              "description": "Scheme sets the scheme of the load balancer (defaults to internet-facing)",
+              "enum": [
+                "internet-facing",
+                "Internet-facing",
+                "internal"
+              ],
+              "type": "string"
+            },
+            "subnets": {
+              "description": "Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "type": "string"
+        },
+        "network": {
+          "description": "NetworkSpec encapsulates all things related to AWS network.",
+          "properties": {
+            "cni": {
+              "description": "CNI configuration",
+              "properties": {
+                "cniIngressRules": {
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "items": {
+                    "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "fromPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                        "type": "string"
+                      },
+                      "toPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "fromPort",
+                      "protocol",
+                      "toPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupOverrides": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "type": "object"
+            },
+            "subnets": {
+              "description": "Subnets configuration.",
+              "items": {
+                "description": "SubnetSpec configures an AWS Subnet.",
+                "properties": {
+                  "availabilityZone": {
+                    "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                    "type": "string"
+                  },
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "isPublic": {
+                    "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                    "type": "boolean"
+                  },
+                  "natGatewayId": {
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "routeTableId": {
+                    "description": "RouteTableID is the routing table id associated with the subnet.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a collection of tags describing the resource.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vpc": {
+              "description": "VPC configuration.",
+              "properties": {
+                "availabilityZoneSelection": {
+                  "default": "Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "enum": [
+                    "Ordered",
+                    "Random"
+                  ],
+                  "type": "string"
+                },
+                "availabilityZoneUsageLimit": {
+                  "default": 3,
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                  "type": "string"
+                },
+                "internetGatewayId": {
+                  "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSClusterStatus defines the observed state of AWSCluster",
+      "properties": {
+        "bastion": {
+          "description": "Instance describes an AWS instance.",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the AWS instance associated addresses.",
+              "items": {
+                "description": "MachineAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The machine address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "availabilityZone": {
+              "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "ebsOptimized": {
+              "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+              "type": "boolean"
+            },
+            "enaSupport": {
+              "description": "Specifies whether enhanced networking with ENA is enabled.",
+              "type": "boolean"
+            },
+            "iamProfile": {
+              "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "imageId": {
+              "description": "The ID of the AMI used to launch the instance.",
+              "type": "string"
+            },
+            "instanceState": {
+              "description": "The current state of the instance.",
+              "type": "string"
+            },
+            "networkInterfaces": {
+              "description": "Specifies ENIs attached to instance",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonRootVolumes": {
+              "description": "Configuration options for the non root storage volumes.",
+              "items": {
+                "description": "Volume encapsulates the configuration options for the storage device",
+                "properties": {
+                  "deviceName": {
+                    "description": "Device name",
+                    "type": "string"
+                  },
+                  "encrypted": {
+                    "description": "Encrypted is whether the volume should be encrypted or not.",
+                    "type": "boolean"
+                  },
+                  "encryptionKey": {
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "type": "string"
+                  },
+                  "iops": {
+                    "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "format": "int64",
+                    "minimum": 8,
+                    "type": "integer"
+                  },
+                  "throughput": {
+                    "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "privateIp": {
+              "description": "The private IPv4 address assigned to the instance.",
+              "type": "string"
+            },
+            "publicIp": {
+              "description": "The public IPv4 address assigned to the instance, if applicable.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "Configuration options for the root storage volume.",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions option for configuring instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "The name of the SSH key pair.",
+              "type": "string"
+            },
+            "subnetId": {
+              "description": "The ID of the subnet of the instance.",
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The tags associated with the instance.",
+              "type": "object"
+            },
+            "tenancy": {
+              "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The instance type.",
+              "type": "string"
+            },
+            "userData": {
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "type": "string"
+            },
+            "volumeIDs": {
+              "description": "IDs of the instance's volumes",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions provide observations of the operational state of a Cluster API resource.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of FailureDomains.",
+          "type": "object"
+        },
+        "networkStatus": {
+          "description": "NetworkStatus encapsulates AWS networking resources.",
+          "properties": {
+            "apiServerElb": {
+              "description": "APIServerELB is the Kubernetes api server classic load balancer.",
+              "properties": {
+                "attributes": {
+                  "description": "Attributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an AWS security group.",
+                "properties": {
+                  "id": {
+                    "description": "ID is a unique identifier.",
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is the inbound rules associated with the security group.",
+                    "items": {
+                      "description": "IngressRule defines an AWS ingress rule for security groups.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fromPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "sourceSecurityGroupIds": {
+                          "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "toPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "fromPort",
+                        "protocol",
+                        "toPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the security group name.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a map of tags associated with the security group.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awscluster_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awscluster_v1beta1.json
@@ -1,0 +1,876 @@
+{
+  "description": "AWSCluster is the schema for Amazon EC2 based Kubernetes Cluster API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSClusterSpec defines the desired state of an EC2-based Kubernetes cluster.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "bastion": {
+          "description": "Bastion contains options to configure the bastion host.",
+          "properties": {
+            "allowedCIDRBlocks": {
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "type": "string"
+            },
+            "disableIngressRules": {
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "type": "boolean"
+            },
+            "instanceType": {
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneLoadBalancer": {
+          "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "crossZoneLoadBalancing": {
+              "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+              "type": "boolean"
+            },
+            "healthCheckProtocol": {
+              "description": "HealthCheckProtocol sets the protocol type for classic ELB health check target default value is ClassicELBProtocolSSL",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once set, the value cannot be changed.",
+              "maxLength": 32,
+              "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
+              "type": "string"
+            },
+            "scheme": {
+              "default": "internet-facing",
+              "description": "Scheme sets the scheme of the load balancer (defaults to internet-facing)",
+              "enum": [
+                "internet-facing",
+                "internal"
+              ],
+              "type": "string"
+            },
+            "subnets": {
+              "description": "Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "type": "string"
+        },
+        "network": {
+          "description": "NetworkSpec encapsulates all things related to AWS network.",
+          "properties": {
+            "cni": {
+              "description": "CNI configuration",
+              "properties": {
+                "cniIngressRules": {
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "items": {
+                    "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "fromPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                        "type": "string"
+                      },
+                      "toPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "fromPort",
+                      "protocol",
+                      "toPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupOverrides": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "type": "object"
+            },
+            "subnets": {
+              "description": "Subnets configuration.",
+              "items": {
+                "description": "SubnetSpec configures an AWS Subnet.",
+                "properties": {
+                  "availabilityZone": {
+                    "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                    "type": "string"
+                  },
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "ipv6CidrBlock": {
+                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "type": "string"
+                  },
+                  "isIpv6": {
+                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "type": "boolean"
+                  },
+                  "isPublic": {
+                    "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                    "type": "boolean"
+                  },
+                  "natGatewayId": {
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "routeTableId": {
+                    "description": "RouteTableID is the routing table id associated with the subnet.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a collection of tags describing the resource.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vpc": {
+              "description": "VPC configuration.",
+              "properties": {
+                "availabilityZoneSelection": {
+                  "default": "Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "enum": [
+                    "Ordered",
+                    "Random"
+                  ],
+                  "type": "string"
+                },
+                "availabilityZoneUsageLimit": {
+                  "default": 3,
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                  "type": "string"
+                },
+                "internetGatewayId": {
+                  "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                  "type": "string"
+                },
+                "ipv6": {
+                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                  "properties": {
+                    "cidrBlock": {
+                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                      "type": "string"
+                    },
+                    "egressOnlyInternetGatewayId": {
+                      "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
+                      "type": "string"
+                    },
+                    "poolId": {
+                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "s3Bucket": {
+          "description": "S3Bucket contains options to configure a supporting S3 bucket for this cluster - currently used for nodes requiring Ignition (https://coreos.github.io/ignition/) for bootstrapping (requires BootstrapFormatIgnition feature flag to be enabled).",
+          "properties": {
+            "controlPlaneIAMInstanceProfile": {
+              "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed to read control-plane node bootstrap data from S3 Bucket.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name defines name of S3 Bucket to be created.",
+              "maxLength": 63,
+              "minLength": 3,
+              "pattern": "^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
+              "type": "string"
+            },
+            "nodesIAMInstanceProfiles": {
+              "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read worker nodes bootstrap data from S3 Bucket.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "controlPlaneIAMInstanceProfile",
+            "name",
+            "nodesIAMInstanceProfiles"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSClusterStatus defines the observed state of AWSCluster.",
+      "properties": {
+        "bastion": {
+          "description": "Instance describes an AWS instance.",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the AWS instance associated addresses.",
+              "items": {
+                "description": "MachineAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The machine address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "availabilityZone": {
+              "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "ebsOptimized": {
+              "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+              "type": "boolean"
+            },
+            "enaSupport": {
+              "description": "Specifies whether enhanced networking with ENA is enabled.",
+              "type": "boolean"
+            },
+            "iamProfile": {
+              "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "imageId": {
+              "description": "The ID of the AMI used to launch the instance.",
+              "type": "string"
+            },
+            "instanceState": {
+              "description": "The current state of the instance.",
+              "type": "string"
+            },
+            "networkInterfaces": {
+              "description": "Specifies ENIs attached to instance",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonRootVolumes": {
+              "description": "Configuration options for the non root storage volumes.",
+              "items": {
+                "description": "Volume encapsulates the configuration options for the storage device.",
+                "properties": {
+                  "deviceName": {
+                    "description": "Device name",
+                    "type": "string"
+                  },
+                  "encrypted": {
+                    "description": "Encrypted is whether the volume should be encrypted or not.",
+                    "type": "boolean"
+                  },
+                  "encryptionKey": {
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "type": "string"
+                  },
+                  "iops": {
+                    "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "format": "int64",
+                    "minimum": 8,
+                    "type": "integer"
+                  },
+                  "throughput": {
+                    "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "privateIp": {
+              "description": "The private IPv4 address assigned to the instance.",
+              "type": "string"
+            },
+            "publicIp": {
+              "description": "The public IPv4 address assigned to the instance, if applicable.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "Configuration options for the root storage volume.",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions option for configuring instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "The name of the SSH key pair.",
+              "type": "string"
+            },
+            "subnetId": {
+              "description": "The ID of the subnet of the instance.",
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The tags associated with the instance.",
+              "type": "object"
+            },
+            "tenancy": {
+              "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The instance type.",
+              "type": "string"
+            },
+            "userData": {
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "type": "string"
+            },
+            "volumeIDs": {
+              "description": "IDs of the instance's volumes",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions provide observations of the operational state of a Cluster API resource.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of FailureDomains.",
+          "type": "object"
+        },
+        "networkStatus": {
+          "description": "NetworkStatus encapsulates AWS networking resources.",
+          "properties": {
+            "apiServerElb": {
+              "description": "APIServerELB is the Kubernetes api server classic load balancer.",
+              "properties": {
+                "attributes": {
+                  "description": "Attributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "Listeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ClassicELBProtocol defines listener protocols for a classic load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an AWS security group.",
+                "properties": {
+                  "id": {
+                    "description": "ID is a unique identifier.",
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is the inbound rules associated with the security group.",
+                    "items": {
+                      "description": "IngressRule defines an AWS ingress rule for security groups.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fromPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "ipv6CidrBlocks": {
+                          "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "sourceSecurityGroupIds": {
+                          "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "toPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "fromPort",
+                        "protocol",
+                        "toPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the security group name.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a map of tags associated with the security group.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awscluster_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awscluster_v1beta2.json
@@ -1,0 +1,1051 @@
+{
+  "description": "AWSCluster is the schema for Amazon EC2 based Kubernetes Cluster API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSClusterSpec defines the desired state of an EC2-based Kubernetes cluster.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "bastion": {
+          "description": "Bastion contains options to configure the bastion host.",
+          "properties": {
+            "allowedCIDRBlocks": {
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "type": "string"
+            },
+            "disableIngressRules": {
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "type": "boolean"
+            },
+            "instanceType": {
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneLoadBalancer": {
+          "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "crossZoneLoadBalancing": {
+              "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+              "type": "boolean"
+            },
+            "disableHostsRewrite": {
+              "description": "DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts file of each instance. This is by default, false.",
+              "type": "boolean"
+            },
+            "healthCheckProtocol": {
+              "description": "HealthCheckProtocol sets the protocol type for ELB health check target default value is ELBProtocolSSL",
+              "type": "string"
+            },
+            "loadBalancerType": {
+              "default": "classic",
+              "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+              "enum": [
+                "classic",
+                "elb",
+                "alb",
+                "nlb"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once set, the value cannot be changed.",
+              "maxLength": 32,
+              "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
+              "type": "string"
+            },
+            "preserveClientIP": {
+              "description": "PreserveClientIP lets the user control if preservation of client ips must be retained or not. If this is enabled 6443 will be opened to 0.0.0.0/0.",
+              "type": "boolean"
+            },
+            "scheme": {
+              "default": "internet-facing",
+              "description": "Scheme sets the scheme of the load balancer (defaults to internet-facing)",
+              "enum": [
+                "internet-facing",
+                "internal"
+              ],
+              "type": "string"
+            },
+            "subnets": {
+              "description": "Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "type": "string"
+        },
+        "network": {
+          "description": "NetworkSpec encapsulates all things related to AWS network.",
+          "properties": {
+            "cni": {
+              "description": "CNI configuration",
+              "properties": {
+                "cniIngressRules": {
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "items": {
+                    "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "fromPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                        "type": "string"
+                      },
+                      "toPort": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "fromPort",
+                      "protocol",
+                      "toPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupOverrides": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "type": "object"
+            },
+            "subnets": {
+              "description": "Subnets configuration.",
+              "items": {
+                "description": "SubnetSpec configures an AWS Subnet.",
+                "properties": {
+                  "availabilityZone": {
+                    "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                    "type": "string"
+                  },
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "ipv6CidrBlock": {
+                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "type": "string"
+                  },
+                  "isIpv6": {
+                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "type": "boolean"
+                  },
+                  "isPublic": {
+                    "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                    "type": "boolean"
+                  },
+                  "natGatewayId": {
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "routeTableId": {
+                    "description": "RouteTableID is the routing table id associated with the subnet.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a collection of tags describing the resource.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "id"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "vpc": {
+              "description": "VPC configuration.",
+              "properties": {
+                "availabilityZoneSelection": {
+                  "default": "Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "enum": [
+                    "Ordered",
+                    "Random"
+                  ],
+                  "type": "string"
+                },
+                "availabilityZoneUsageLimit": {
+                  "default": 3,
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                  "type": "string"
+                },
+                "internetGatewayId": {
+                  "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                  "type": "string"
+                },
+                "ipv6": {
+                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                  "properties": {
+                    "cidrBlock": {
+                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                      "type": "string"
+                    },
+                    "egressOnlyInternetGatewayId": {
+                      "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
+                      "type": "string"
+                    },
+                    "poolId": {
+                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "s3Bucket": {
+          "description": "S3Bucket contains options to configure a supporting S3 bucket for this cluster - currently used for nodes requiring Ignition (https://coreos.github.io/ignition/) for bootstrapping (requires BootstrapFormatIgnition feature flag to be enabled).",
+          "properties": {
+            "controlPlaneIAMInstanceProfile": {
+              "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed to read control-plane node bootstrap data from S3 Bucket.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name defines name of S3 Bucket to be created.",
+              "maxLength": 63,
+              "minLength": 3,
+              "pattern": "^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
+              "type": "string"
+            },
+            "nodesIAMInstanceProfiles": {
+              "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read worker nodes bootstrap data from S3 Bucket.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "controlPlaneIAMInstanceProfile",
+            "name",
+            "nodesIAMInstanceProfiles"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSClusterStatus defines the observed state of AWSCluster.",
+      "properties": {
+        "bastion": {
+          "description": "Instance describes an AWS instance.",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the AWS instance associated addresses.",
+              "items": {
+                "description": "MachineAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The machine address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "availabilityZone": {
+              "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "ebsOptimized": {
+              "description": "Indicates whether the instance is optimized for Amazon EBS I/O.",
+              "type": "boolean"
+            },
+            "enaSupport": {
+              "description": "Specifies whether enhanced networking with ENA is enabled.",
+              "type": "boolean"
+            },
+            "iamProfile": {
+              "description": "The name of the IAM instance profile associated with the instance, if applicable.",
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "imageId": {
+              "description": "The ID of the AMI used to launch the instance.",
+              "type": "string"
+            },
+            "instanceMetadataOptions": {
+              "description": "InstanceMetadataOptions is the metadata options for the EC2 instance.",
+              "properties": {
+                "httpEndpoint": {
+                  "default": "enabled",
+                  "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                },
+                "httpPutResponseHopLimit": {
+                  "default": 1,
+                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+                  "format": "int64",
+                  "maximum": 64,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "httpTokens": {
+                  "default": "required",
+                  "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+                  "enum": [
+                    "optional",
+                    "required"
+                  ],
+                  "type": "string"
+                },
+                "instanceMetadataTags": {
+                  "default": "disabled",
+                  "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "instanceState": {
+              "description": "The current state of the instance.",
+              "type": "string"
+            },
+            "networkInterfaces": {
+              "description": "Specifies ENIs attached to instance",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonRootVolumes": {
+              "description": "Configuration options for the non root storage volumes.",
+              "items": {
+                "description": "Volume encapsulates the configuration options for the storage device.",
+                "properties": {
+                  "deviceName": {
+                    "description": "Device name",
+                    "type": "string"
+                  },
+                  "encrypted": {
+                    "description": "Encrypted is whether the volume should be encrypted or not.",
+                    "type": "boolean"
+                  },
+                  "encryptionKey": {
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "type": "string"
+                  },
+                  "iops": {
+                    "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "format": "int64",
+                    "minimum": 8,
+                    "type": "integer"
+                  },
+                  "throughput": {
+                    "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": {
+                    "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "privateIp": {
+              "description": "The private IPv4 address assigned to the instance.",
+              "type": "string"
+            },
+            "publicIp": {
+              "description": "The public IPv4 address assigned to the instance, if applicable.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "Configuration options for the root storage volume.",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroupIds": {
+              "description": "SecurityGroupIDs are one or more security group IDs this instance belongs to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions option for configuring instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "The name of the SSH key pair.",
+              "type": "string"
+            },
+            "subnetId": {
+              "description": "The ID of the subnet of the instance.",
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "The tags associated with the instance.",
+              "type": "object"
+            },
+            "tenancy": {
+              "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The instance type.",
+              "type": "string"
+            },
+            "userData": {
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "type": "string"
+            },
+            "volumeIDs": {
+              "description": "IDs of the instance's volumes",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions provide observations of the operational state of a Cluster API resource.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of FailureDomains.",
+          "type": "object"
+        },
+        "networkStatus": {
+          "description": "NetworkStatus encapsulates AWS networking resources.",
+          "properties": {
+            "apiServerElb": {
+              "description": "APIServerELB is the Kubernetes api server load balancer.",
+              "properties": {
+                "arn": {
+                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly to define and get it.",
+                  "type": "string"
+                },
+                "attributes": {
+                  "description": "ClassicElbAttributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "elbAttributes": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ELBAttributes defines extra attributes associated with v2 load balancers.",
+                  "type": "object"
+                },
+                "elbListeners": {
+                  "description": "ELBListeners is an array of listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "Listener defines an AWS network load balancer listener.",
+                    "properties": {
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "targetGroup": {
+                        "description": "TargetGroupSpec specifies target group settings for a given listener. This is created first, and the ARN is then passed to the listener.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the TargetGroup. Must be unique over the same group of listeners.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "Port is the exposed port",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "description": "ELBProtocol defines listener protocols for a load balancer.",
+                            "enum": [
+                              "tcp",
+                              "tls",
+                              "upd"
+                            ],
+                            "type": "string"
+                          },
+                          "targetGroupHealthCheck": {
+                            "description": "HealthCheck is the elb health check associated with the load balancer.",
+                            "properties": {
+                              "intervalSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "type": "string"
+                              },
+                              "thresholdCount": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vpcId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "port",
+                          "protocol",
+                          "vpcId"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "port",
+                      "protocol",
+                      "targetGroup"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "ClassicELBListeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "loadBalancerType": {
+                  "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+                  "enum": [
+                    "classic",
+                    "elb",
+                    "alb",
+                    "nlb"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an AWS security group.",
+                "properties": {
+                  "id": {
+                    "description": "ID is a unique identifier.",
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is the inbound rules associated with the security group.",
+                    "items": {
+                      "description": "IngressRule defines an AWS ingress rule for security groups.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "fromPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "ipv6CidrBlocks": {
+                          "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "sourceSecurityGroupIds": {
+                          "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "toPort": {
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "fromPort",
+                        "protocol",
+                        "toPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "Name is the security group name.",
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags is a map of tags associated with the security group.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1alpha3.json
@@ -1,0 +1,84 @@
+{
+  "description": "AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API It is used to grant access to use Cluster API Provider AWS Controller credentials.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterControllerIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty AllowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1alpha4.json
@@ -1,0 +1,84 @@
+{
+  "description": "AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API It is used to grant access to use Cluster API Provider AWS Controller credentials.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterControllerIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta1.json
@@ -1,0 +1,85 @@
+{
+  "description": "AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API It is used to grant access to use Cluster API Provider AWS Controller credentials.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterControllerIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta2.json
@@ -1,0 +1,85 @@
+{
+  "description": "AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API It is used to grant access to use Cluster API Provider AWS Controller credentials.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterControllerIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1alpha3.json
@@ -1,0 +1,142 @@
+{
+  "description": "AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API It is used to assume a role using the provided sourceRef.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterRoleIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty AllowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "durationSeconds": {
+          "description": "The duration, in seconds, of the role session before it is renewed.",
+          "format": "int32",
+          "maximum": 43200,
+          "minimum": 900,
+          "type": "integer"
+        },
+        "externalID": {
+          "description": "A unique identifier that might be required when you assume a role in another account. If the administrator of the account to which the role belongs provided you with an external ID, then provide that value in the ExternalId parameter. This value can be any string, such as a passphrase or account number. A cross-account role is usually set up to trust everyone in an account. Therefore, the administrator of the trusting account might send an external ID to the administrator of the trusted account. That way, only someone with the ID can assume the role, rather than everyone in the account. For more information about the external ID, see How to Use an External ID When Granting Access to Your AWS Resources to a Third Party in the IAM User Guide.",
+          "type": "string"
+        },
+        "inlinePolicy": {
+          "description": "An IAM policy as a JSON-encoded string that you want to use as an inline session policy.",
+          "type": "string"
+        },
+        "policyARNs": {
+          "description": "The Amazon Resource Names (ARNs) of the IAM managed policies that you want to use as managed session policies. The policies must exist in the same account as the role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleARN": {
+          "description": "The Amazon Resource Name (ARN) of the role to assume.",
+          "type": "string"
+        },
+        "sessionName": {
+          "description": "An identifier for the assumed role session",
+          "type": "string"
+        },
+        "sourceIdentityRef": {
+          "description": "SourceIdentityRef is a reference to another identity which will be chained to do role assumption. All identity types are accepted.",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "roleARN"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1alpha4.json
@@ -1,0 +1,142 @@
+{
+  "description": "AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API It is used to assume a role using the provided sourceRef.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterRoleIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "durationSeconds": {
+          "description": "The duration, in seconds, of the role session before it is renewed.",
+          "format": "int32",
+          "maximum": 43200,
+          "minimum": 900,
+          "type": "integer"
+        },
+        "externalID": {
+          "description": "A unique identifier that might be required when you assume a role in another account. If the administrator of the account to which the role belongs provided you with an external ID, then provide that value in the ExternalId parameter. This value can be any string, such as a passphrase or account number. A cross-account role is usually set up to trust everyone in an account. Therefore, the administrator of the trusting account might send an external ID to the administrator of the trusted account. That way, only someone with the ID can assume the role, rather than everyone in the account. For more information about the external ID, see How to Use an External ID When Granting Access to Your AWS Resources to a Third Party in the IAM User Guide.",
+          "type": "string"
+        },
+        "inlinePolicy": {
+          "description": "An IAM policy as a JSON-encoded string that you want to use as an inline session policy.",
+          "type": "string"
+        },
+        "policyARNs": {
+          "description": "The Amazon Resource Names (ARNs) of the IAM managed policies that you want to use as managed session policies. The policies must exist in the same account as the role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleARN": {
+          "description": "The Amazon Resource Name (ARN) of the role to assume.",
+          "type": "string"
+        },
+        "sessionName": {
+          "description": "An identifier for the assumed role session",
+          "type": "string"
+        },
+        "sourceIdentityRef": {
+          "description": "SourceIdentityRef is a reference to another identity which will be chained to do role assumption. All identity types are accepted.",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "roleARN"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta1.json
@@ -1,0 +1,143 @@
+{
+  "description": "AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API It is used to assume a role using the provided sourceRef.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterRoleIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "durationSeconds": {
+          "description": "The duration, in seconds, of the role session before it is renewed.",
+          "format": "int32",
+          "maximum": 43200,
+          "minimum": 900,
+          "type": "integer"
+        },
+        "externalID": {
+          "description": "A unique identifier that might be required when you assume a role in another account. If the administrator of the account to which the role belongs provided you with an external ID, then provide that value in the ExternalId parameter. This value can be any string, such as a passphrase or account number. A cross-account role is usually set up to trust everyone in an account. Therefore, the administrator of the trusting account might send an external ID to the administrator of the trusted account. That way, only someone with the ID can assume the role, rather than everyone in the account. For more information about the external ID, see How to Use an External ID When Granting Access to Your AWS Resources to a Third Party in the IAM User Guide.",
+          "type": "string"
+        },
+        "inlinePolicy": {
+          "description": "An IAM policy as a JSON-encoded string that you want to use as an inline session policy.",
+          "type": "string"
+        },
+        "policyARNs": {
+          "description": "The Amazon Resource Names (ARNs) of the IAM managed policies that you want to use as managed session policies. The policies must exist in the same account as the role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleARN": {
+          "description": "The Amazon Resource Name (ARN) of the role to assume.",
+          "type": "string"
+        },
+        "sessionName": {
+          "description": "An identifier for the assumed role session",
+          "type": "string"
+        },
+        "sourceIdentityRef": {
+          "description": "SourceIdentityRef is a reference to another identity which will be chained to do role assumption. All identity types are accepted.",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "roleARN"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta2.json
@@ -1,0 +1,143 @@
+{
+  "description": "AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API It is used to assume a role using the provided sourceRef.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterRoleIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "durationSeconds": {
+          "description": "The duration, in seconds, of the role session before it is renewed.",
+          "format": "int32",
+          "maximum": 43200,
+          "minimum": 900,
+          "type": "integer"
+        },
+        "externalID": {
+          "description": "A unique identifier that might be required when you assume a role in another account. If the administrator of the account to which the role belongs provided you with an external ID, then provide that value in the ExternalId parameter. This value can be any string, such as a passphrase or account number. A cross-account role is usually set up to trust everyone in an account. Therefore, the administrator of the trusting account might send an external ID to the administrator of the trusted account. That way, only someone with the ID can assume the role, rather than everyone in the account. For more information about the external ID, see How to Use an External ID When Granting Access to Your AWS Resources to a Third Party in the IAM User Guide.",
+          "type": "string"
+        },
+        "inlinePolicy": {
+          "description": "An IAM policy as a JSON-encoded string that you want to use as an inline session policy.",
+          "type": "string"
+        },
+        "policyARNs": {
+          "description": "The Amazon Resource Names (ARNs) of the IAM managed policies that you want to use as managed session policies. The policies must exist in the same account as the role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleARN": {
+          "description": "The Amazon Resource Name (ARN) of the role to assume.",
+          "type": "string"
+        },
+        "sessionName": {
+          "description": "An identifier for the assumed role session",
+          "type": "string"
+        },
+        "sourceIdentityRef": {
+          "description": "SourceIdentityRef is a reference to another identity which will be chained to do role assumption. All identity types are accepted.",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "roleARN"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1alpha3.json
@@ -1,0 +1,102 @@
+{
+  "description": "AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API It represents a reference to an AWS access key ID and secret access key, stored in a secret.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterStaticIdentity",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty AllowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "Reference to a secret containing the credentials. The secret should contain the following data keys: AccessKeyID: AKIAIOSFODNN7EXAMPLE SecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY SessionToken: Optional",
+          "properties": {
+            "name": {
+              "description": "Name is unique within a namespace to reference a secret resource.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace defines the space within which the secret name must be unique.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "secretRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1alpha4.json
@@ -1,0 +1,91 @@
+{
+  "description": "AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API It represents a reference to an AWS access key ID and secret access key, stored in a secret.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterStaticIdentity",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "Reference to a secret containing the credentials. The secret should contain the following data keys: AccessKeyID: AKIAIOSFODNN7EXAMPLE SecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY SessionToken: Optional",
+          "type": "string"
+        }
+      },
+      "required": [
+        "secretRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta1.json
@@ -1,0 +1,92 @@
+{
+  "description": "AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API It represents a reference to an AWS access key ID and secret access key, stored in a secret.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterStaticIdentity",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "Reference to a secret containing the credentials. The secret should contain the following data keys: AccessKeyID: AKIAIOSFODNN7EXAMPLE SecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY SessionToken: Optional",
+          "type": "string"
+        }
+      },
+      "required": [
+        "secretRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta2.json
@@ -1,0 +1,92 @@
+{
+  "description": "AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API It represents a reference to an AWS access key ID and secret access key, stored in a secret.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec for this AWSClusterStaticIdentity",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "An nil or empty list indicates that AWSClusters cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "Reference to a secret containing the credentials. The secret should contain the following data keys: AccessKeyID: AKIAIOSFODNN7EXAMPLE SecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY SessionToken: Optional",
+          "type": "string"
+        }
+      },
+      "required": [
+        "secretRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1alpha4.json
@@ -1,0 +1,316 @@
+{
+  "description": "AWSClusterTemplate is the Schema for the awsclustertemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSClusterTemplateSpec defines the desired state of AWSClusterTemplate.",
+      "properties": {
+        "template": {
+          "properties": {
+            "spec": {
+              "description": "AWSClusterSpec defines the desired state of AWSCluster",
+              "properties": {
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+                  "type": "object"
+                },
+                "bastion": {
+                  "description": "Bastion contains options to configure the bastion host.",
+                  "properties": {
+                    "allowedCIDRBlocks": {
+                      "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "ami": {
+                      "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+                      "type": "string"
+                    },
+                    "disableIngressRules": {
+                      "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+                      "type": "boolean"
+                    },
+                    "instanceType": {
+                      "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+                  "properties": {
+                    "host": {
+                      "description": "The hostname on which the API server is serving.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "The port on which the API server is serving.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "host",
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "controlPlaneLoadBalancer": {
+                  "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
+                  "properties": {
+                    "additionalSecurityGroups": {
+                      "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+                      "type": "boolean"
+                    },
+                    "scheme": {
+                      "default": "internet-facing",
+                      "description": "Scheme sets the scheme of the load balancer (defaults to internet-facing)",
+                      "enum": [
+                        "internet-facing",
+                        "Internet-facing",
+                        "internal"
+                      ],
+                      "type": "string"
+                    },
+                    "subnets": {
+                      "description": "Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "identityRef": {
+                  "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+                  "properties": {
+                    "kind": {
+                      "description": "Kind of the identity.",
+                      "enum": [
+                        "AWSClusterControllerIdentity",
+                        "AWSClusterRoleIdentity",
+                        "AWSClusterStaticIdentity"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the identity.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "imageLookupBaseOS": {
+                  "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+                  "type": "string"
+                },
+                "imageLookupFormat": {
+                  "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "type": "string"
+                },
+                "imageLookupOrg": {
+                  "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+                  "type": "string"
+                },
+                "network": {
+                  "description": "NetworkSpec encapsulates all things related to AWS network.",
+                  "properties": {
+                    "cni": {
+                      "description": "CNI configuration",
+                      "properties": {
+                        "cniIngressRules": {
+                          "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                          "items": {
+                            "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                            "properties": {
+                              "description": {
+                                "type": "string"
+                              },
+                              "fromPort": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                                "type": "string"
+                              },
+                              "toPort": {
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "description",
+                              "fromPort",
+                              "protocol",
+                              "toPort"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "securityGroupOverrides": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+                      "type": "object"
+                    },
+                    "subnets": {
+                      "description": "Subnets configuration.",
+                      "items": {
+                        "description": "SubnetSpec configures an AWS Subnet.",
+                        "properties": {
+                          "availabilityZone": {
+                            "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                            "type": "string"
+                          },
+                          "cidrBlock": {
+                            "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID defines a unique identifier to reference this resource.",
+                            "type": "string"
+                          },
+                          "isPublic": {
+                            "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                            "type": "boolean"
+                          },
+                          "natGatewayId": {
+                            "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                            "type": "string"
+                          },
+                          "routeTableId": {
+                            "description": "RouteTableID is the routing table id associated with the subnet.",
+                            "type": "string"
+                          },
+                          "tags": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Tags is a collection of tags describing the resource.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "vpc": {
+                      "description": "VPC configuration.",
+                      "properties": {
+                        "availabilityZoneSelection": {
+                          "default": "Ordered",
+                          "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                          "enum": [
+                            "Ordered",
+                            "Random"
+                          ],
+                          "type": "string"
+                        },
+                        "availabilityZoneUsageLimit": {
+                          "default": 3,
+                          "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "cidrBlock": {
+                          "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                          "type": "string"
+                        },
+                        "internetGatewayId": {
+                          "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                          "type": "string"
+                        },
+                        "tags": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Tags is a collection of tags describing the resource.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "region": {
+                  "description": "The AWS Region the cluster lives in.",
+                  "type": "string"
+                },
+                "sshKeyName": {
+                  "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta1.json
@@ -1,0 +1,403 @@
+{
+  "description": "AWSClusterTemplate is the schema for Amazon EC2 based Kubernetes Cluster Templates.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSClusterTemplateSpec defines the desired state of AWSClusterTemplate.",
+      "properties": {
+        "template": {
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "AWSClusterSpec defines the desired state of an EC2-based Kubernetes cluster.",
+              "properties": {
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+                  "type": "object"
+                },
+                "bastion": {
+                  "description": "Bastion contains options to configure the bastion host.",
+                  "properties": {
+                    "allowedCIDRBlocks": {
+                      "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "ami": {
+                      "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+                      "type": "string"
+                    },
+                    "disableIngressRules": {
+                      "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+                      "type": "boolean"
+                    },
+                    "instanceType": {
+                      "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+                  "properties": {
+                    "host": {
+                      "description": "The hostname on which the API server is serving.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "The port on which the API server is serving.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "host",
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "controlPlaneLoadBalancer": {
+                  "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
+                  "properties": {
+                    "additionalSecurityGroups": {
+                      "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+                      "type": "boolean"
+                    },
+                    "healthCheckProtocol": {
+                      "description": "HealthCheckProtocol sets the protocol type for classic ELB health check target default value is ClassicELBProtocolSSL",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once set, the value cannot be changed.",
+                      "maxLength": 32,
+                      "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
+                      "type": "string"
+                    },
+                    "scheme": {
+                      "default": "internet-facing",
+                      "description": "Scheme sets the scheme of the load balancer (defaults to internet-facing)",
+                      "enum": [
+                        "internet-facing",
+                        "internal"
+                      ],
+                      "type": "string"
+                    },
+                    "subnets": {
+                      "description": "Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "identityRef": {
+                  "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+                  "properties": {
+                    "kind": {
+                      "description": "Kind of the identity.",
+                      "enum": [
+                        "AWSClusterControllerIdentity",
+                        "AWSClusterRoleIdentity",
+                        "AWSClusterStaticIdentity"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the identity.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "imageLookupBaseOS": {
+                  "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+                  "type": "string"
+                },
+                "imageLookupFormat": {
+                  "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "type": "string"
+                },
+                "imageLookupOrg": {
+                  "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+                  "type": "string"
+                },
+                "network": {
+                  "description": "NetworkSpec encapsulates all things related to AWS network.",
+                  "properties": {
+                    "cni": {
+                      "description": "CNI configuration",
+                      "properties": {
+                        "cniIngressRules": {
+                          "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                          "items": {
+                            "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                            "properties": {
+                              "description": {
+                                "type": "string"
+                              },
+                              "fromPort": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                                "type": "string"
+                              },
+                              "toPort": {
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "description",
+                              "fromPort",
+                              "protocol",
+                              "toPort"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "securityGroupOverrides": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+                      "type": "object"
+                    },
+                    "subnets": {
+                      "description": "Subnets configuration.",
+                      "items": {
+                        "description": "SubnetSpec configures an AWS Subnet.",
+                        "properties": {
+                          "availabilityZone": {
+                            "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                            "type": "string"
+                          },
+                          "cidrBlock": {
+                            "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID defines a unique identifier to reference this resource.",
+                            "type": "string"
+                          },
+                          "ipv6CidrBlock": {
+                            "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                            "type": "string"
+                          },
+                          "isIpv6": {
+                            "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                            "type": "boolean"
+                          },
+                          "isPublic": {
+                            "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                            "type": "boolean"
+                          },
+                          "natGatewayId": {
+                            "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                            "type": "string"
+                          },
+                          "routeTableId": {
+                            "description": "RouteTableID is the routing table id associated with the subnet.",
+                            "type": "string"
+                          },
+                          "tags": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Tags is a collection of tags describing the resource.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "vpc": {
+                      "description": "VPC configuration.",
+                      "properties": {
+                        "availabilityZoneSelection": {
+                          "default": "Ordered",
+                          "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                          "enum": [
+                            "Ordered",
+                            "Random"
+                          ],
+                          "type": "string"
+                        },
+                        "availabilityZoneUsageLimit": {
+                          "default": 3,
+                          "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "cidrBlock": {
+                          "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                          "type": "string"
+                        },
+                        "internetGatewayId": {
+                          "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                          "type": "string"
+                        },
+                        "ipv6": {
+                          "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                          "properties": {
+                            "cidrBlock": {
+                              "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                              "type": "string"
+                            },
+                            "egressOnlyInternetGatewayId": {
+                              "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
+                              "type": "string"
+                            },
+                            "poolId": {
+                              "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tags": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Tags is a collection of tags describing the resource.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "region": {
+                  "description": "The AWS Region the cluster lives in.",
+                  "type": "string"
+                },
+                "s3Bucket": {
+                  "description": "S3Bucket contains options to configure a supporting S3 bucket for this cluster - currently used for nodes requiring Ignition (https://coreos.github.io/ignition/) for bootstrapping (requires BootstrapFormatIgnition feature flag to be enabled).",
+                  "properties": {
+                    "controlPlaneIAMInstanceProfile": {
+                      "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed to read control-plane node bootstrap data from S3 Bucket.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name defines name of S3 Bucket to be created.",
+                      "maxLength": 63,
+                      "minLength": 3,
+                      "pattern": "^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
+                      "type": "string"
+                    },
+                    "nodesIAMInstanceProfiles": {
+                      "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read worker nodes bootstrap data from S3 Bucket.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "controlPlaneIAMInstanceProfile",
+                    "name",
+                    "nodesIAMInstanceProfiles"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sshKeyName": {
+                  "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta2.json
@@ -1,0 +1,429 @@
+{
+  "description": "AWSClusterTemplate is the schema for Amazon EC2 based Kubernetes Cluster Templates.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSClusterTemplateSpec defines the desired state of AWSClusterTemplate.",
+      "properties": {
+        "template": {
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "AWSClusterSpec defines the desired state of an EC2-based Kubernetes cluster.",
+              "properties": {
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+                  "type": "object"
+                },
+                "bastion": {
+                  "description": "Bastion contains options to configure the bastion host.",
+                  "properties": {
+                    "allowedCIDRBlocks": {
+                      "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "ami": {
+                      "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+                      "type": "string"
+                    },
+                    "disableIngressRules": {
+                      "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+                      "type": "boolean"
+                    },
+                    "instanceType": {
+                      "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "controlPlaneEndpoint": {
+                  "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+                  "properties": {
+                    "host": {
+                      "description": "The hostname on which the API server is serving.",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "The port on which the API server is serving.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "host",
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "controlPlaneLoadBalancer": {
+                  "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
+                  "properties": {
+                    "additionalSecurityGroups": {
+                      "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+                      "type": "boolean"
+                    },
+                    "disableHostsRewrite": {
+                      "description": "DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts file of each instance. This is by default, false.",
+                      "type": "boolean"
+                    },
+                    "healthCheckProtocol": {
+                      "description": "HealthCheckProtocol sets the protocol type for ELB health check target default value is ELBProtocolSSL",
+                      "type": "string"
+                    },
+                    "loadBalancerType": {
+                      "default": "classic",
+                      "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+                      "enum": [
+                        "classic",
+                        "elb",
+                        "alb",
+                        "nlb"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once set, the value cannot be changed.",
+                      "maxLength": 32,
+                      "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
+                      "type": "string"
+                    },
+                    "preserveClientIP": {
+                      "description": "PreserveClientIP lets the user control if preservation of client ips must be retained or not. If this is enabled 6443 will be opened to 0.0.0.0/0.",
+                      "type": "boolean"
+                    },
+                    "scheme": {
+                      "default": "internet-facing",
+                      "description": "Scheme sets the scheme of the load balancer (defaults to internet-facing)",
+                      "enum": [
+                        "internet-facing",
+                        "internal"
+                      ],
+                      "type": "string"
+                    },
+                    "subnets": {
+                      "description": "Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "identityRef": {
+                  "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+                  "properties": {
+                    "kind": {
+                      "description": "Kind of the identity.",
+                      "enum": [
+                        "AWSClusterControllerIdentity",
+                        "AWSClusterRoleIdentity",
+                        "AWSClusterStaticIdentity"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the identity.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "imageLookupBaseOS": {
+                  "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+                  "type": "string"
+                },
+                "imageLookupFormat": {
+                  "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "type": "string"
+                },
+                "imageLookupOrg": {
+                  "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+                  "type": "string"
+                },
+                "network": {
+                  "description": "NetworkSpec encapsulates all things related to AWS network.",
+                  "properties": {
+                    "cni": {
+                      "description": "CNI configuration",
+                      "properties": {
+                        "cniIngressRules": {
+                          "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                          "items": {
+                            "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
+                            "properties": {
+                              "description": {
+                                "type": "string"
+                              },
+                              "fromPort": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                                "type": "string"
+                              },
+                              "toPort": {
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "description",
+                              "fromPort",
+                              "protocol",
+                              "toPort"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "securityGroupOverrides": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+                      "type": "object"
+                    },
+                    "subnets": {
+                      "description": "Subnets configuration.",
+                      "items": {
+                        "description": "SubnetSpec configures an AWS Subnet.",
+                        "properties": {
+                          "availabilityZone": {
+                            "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region.",
+                            "type": "string"
+                          },
+                          "cidrBlock": {
+                            "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "ID defines a unique identifier to reference this resource.",
+                            "type": "string"
+                          },
+                          "ipv6CidrBlock": {
+                            "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                            "type": "string"
+                          },
+                          "isIpv6": {
+                            "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                            "type": "boolean"
+                          },
+                          "isPublic": {
+                            "description": "IsPublic defines the subnet as a public subnet. A subnet is public when it is associated with a route table that has a route to an internet gateway.",
+                            "type": "boolean"
+                          },
+                          "natGatewayId": {
+                            "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                            "type": "string"
+                          },
+                          "routeTableId": {
+                            "description": "RouteTableID is the routing table id associated with the subnet.",
+                            "type": "string"
+                          },
+                          "tags": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Tags is a collection of tags describing the resource.",
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "id"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "id"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "vpc": {
+                      "description": "VPC configuration.",
+                      "properties": {
+                        "availabilityZoneSelection": {
+                          "default": "Ordered",
+                          "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                          "enum": [
+                            "Ordered",
+                            "Random"
+                          ],
+                          "type": "string"
+                        },
+                        "availabilityZoneUsageLimit": {
+                          "default": 3,
+                          "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "cidrBlock": {
+                          "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
+                          "type": "string"
+                        },
+                        "internetGatewayId": {
+                          "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
+                          "type": "string"
+                        },
+                        "ipv6": {
+                          "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                          "properties": {
+                            "cidrBlock": {
+                              "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                              "type": "string"
+                            },
+                            "egressOnlyInternetGatewayId": {
+                              "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
+                              "type": "string"
+                            },
+                            "poolId": {
+                              "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tags": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Tags is a collection of tags describing the resource.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "region": {
+                  "description": "The AWS Region the cluster lives in.",
+                  "type": "string"
+                },
+                "s3Bucket": {
+                  "description": "S3Bucket contains options to configure a supporting S3 bucket for this cluster - currently used for nodes requiring Ignition (https://coreos.github.io/ignition/) for bootstrapping (requires BootstrapFormatIgnition feature flag to be enabled).",
+                  "properties": {
+                    "controlPlaneIAMInstanceProfile": {
+                      "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed to read control-plane node bootstrap data from S3 Bucket.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name defines name of S3 Bucket to be created.",
+                      "maxLength": 63,
+                      "minLength": 3,
+                      "pattern": "^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
+                      "type": "string"
+                    },
+                    "nodesIAMInstanceProfiles": {
+                      "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read worker nodes bootstrap data from S3 Bucket.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "controlPlaneIAMInstanceProfile",
+                    "name",
+                    "nodesIAMInstanceProfiles"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sshKeyName": {
+                  "description": "SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1alpha3.json
@@ -1,0 +1,139 @@
+{
+  "description": "AWSFargateProfile is the Schema for the awsfargateprofiles API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FargateProfileSpec defines the desired state of FargateProfile",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "profileName": {
+          "description": "ProfileName specifies the profile name.",
+          "type": "string"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role for this fargate pool If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "type": "string"
+        },
+        "selectors": {
+          "description": "Selectors specify fargate pod selectors.",
+          "items": {
+            "description": "FargateSelector specifies a selector for pods that should run on this fargate pool",
+            "properties": {
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Labels specifies which pod labels this selector should match.",
+                "type": "object"
+              },
+              "namespace": {
+                "description": "Namespace specifies which namespace this selector should match.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "subnetIDs": {
+          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "clusterName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FargateProfileStatus defines the observed state of FargateProfile",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the Fargate profile.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the FargateProfile is available.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1alpha4.json
@@ -1,0 +1,139 @@
+{
+  "description": "AWSFargateProfile is the Schema for the awsfargateprofiles API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FargateProfileSpec defines the desired state of FargateProfile",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "profileName": {
+          "description": "ProfileName specifies the profile name.",
+          "type": "string"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role for this fargate pool If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "type": "string"
+        },
+        "selectors": {
+          "description": "Selectors specify fargate pod selectors.",
+          "items": {
+            "description": "FargateSelector specifies a selector for pods that should run on this fargate pool",
+            "properties": {
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Labels specifies which pod labels this selector should match.",
+                "type": "object"
+              },
+              "namespace": {
+                "description": "Namespace specifies which namespace this selector should match.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "subnetIDs": {
+          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "clusterName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FargateProfileStatus defines the observed state of FargateProfile",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the Fargate profile.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the FargateProfile is available.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta1.json
@@ -1,0 +1,140 @@
+{
+  "description": "AWSFargateProfile is the Schema for the awsfargateprofiles API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FargateProfileSpec defines the desired state of FargateProfile.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "profileName": {
+          "description": "ProfileName specifies the profile name.",
+          "type": "string"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role for this fargate pool If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "type": "string"
+        },
+        "selectors": {
+          "description": "Selectors specify fargate pod selectors.",
+          "items": {
+            "description": "FargateSelector specifies a selector for pods that should run on this fargate pool.",
+            "properties": {
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Labels specifies which pod labels this selector should match.",
+                "type": "object"
+              },
+              "namespace": {
+                "description": "Namespace specifies which namespace this selector should match.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "subnetIDs": {
+          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "clusterName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FargateProfileStatus defines the observed state of FargateProfile.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the Fargate profile.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the FargateProfile is available.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta2.json
@@ -1,0 +1,140 @@
+{
+  "description": "AWSFargateProfile is the Schema for the awsfargateprofiles API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FargateProfileSpec defines the desired state of FargateProfile.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "clusterName": {
+          "description": "ClusterName is the name of the Cluster this object belongs to.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "profileName": {
+          "description": "ProfileName specifies the profile name.",
+          "type": "string"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role for this fargate pool If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "type": "string"
+        },
+        "selectors": {
+          "description": "Selectors specify fargate pod selectors.",
+          "items": {
+            "description": "FargateSelector specifies a selector for pods that should run on this fargate pool.",
+            "properties": {
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Labels specifies which pod labels this selector should match.",
+                "type": "object"
+              },
+              "namespace": {
+                "description": "Namespace specifies which namespace this selector should match.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "subnetIDs": {
+          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "clusterName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FargateProfileStatus defines the observed state of FargateProfile.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the Fargate profile.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the FargateProfile is available.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachine_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachine_v1alpha2.json
@@ -1,0 +1,265 @@
+{
+  "description": "AWSMachine is the Schema for the awsmachines API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineSpec defines the desired state of AWSMachine",
+      "properties": {
+        "additionalSecurityGroups": {
+          "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+          "items": {
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+            "properties": {
+              "arn": {
+                "description": "ARN of resource",
+                "type": "string"
+              },
+              "filters": {
+                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "items": {
+                  "description": "Filter is a filter used to identify an AWS resource",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the filter. Filter names are case-sensitive.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "ID of resource",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+          "type": "object"
+        },
+        "ami": {
+          "description": "AMI is the reference to the AMI from which to create the machine instance.",
+          "properties": {
+            "arn": {
+              "description": "ARN of resource",
+              "type": "string"
+            },
+            "filters": {
+              "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+              "items": {
+                "description": "Filter is a filter used to identify an AWS resource",
+                "properties": {
+                  "name": {
+                    "description": "Name of the filter. Filter names are case-sensitive.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name",
+                  "values"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "availabilityZone": {
+          "description": "AvailabilityZone is references the AWS availability zone to use for this instance. If multiple subnets are matched for the availability zone, the first one return is picked.",
+          "type": "string"
+        },
+        "cloudInit": {
+          "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+          "properties": {
+            "enableSecureSecretsManager": {
+              "description": "enableSecureSecretsManager, when set to true will use AWS Secrets Manager to ensure userdata privacy. A cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+              "type": "boolean"
+            },
+            "secretCount": {
+              "description": "SecretCount is the number of secrets used to form the complete secret",
+              "format": "int32",
+              "type": "integer"
+            },
+            "secretPrefix": {
+              "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "iamInstanceProfile": {
+          "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+          "type": "string"
+        },
+        "networkInterfaces": {
+          "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 2,
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "publicIP": {
+          "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+          "type": "boolean"
+        },
+        "rootDeviceSize": {
+          "description": "RootDeviceSize is the size of the root volume in gigabytes(GB).",
+          "format": "int64",
+          "type": "integer"
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the instance.",
+          "type": "string"
+        },
+        "subnet": {
+          "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+          "properties": {
+            "arn": {
+              "description": "ARN of resource",
+              "type": "string"
+            },
+            "filters": {
+              "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+              "items": {
+                "description": "Filter is a filter used to identify an AWS resource",
+                "properties": {
+                  "name": {
+                    "description": "Name of the filter. Filter names are case-sensitive.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name",
+                  "values"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachineStatus defines the observed state of AWSMachine",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the AWS instance associated addresses.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "errorMessage": {
+          "description": "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instanceState": {
+          "description": "InstanceState is the state of the AWS instance for this machine.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachine_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachine_v1alpha3.json
@@ -1,0 +1,426 @@
+{
+  "description": "AWSMachine is the Schema for the awsmachines API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineSpec defines the desired state of AWSMachine",
+      "properties": {
+        "additionalSecurityGroups": {
+          "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+          "items": {
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+            "properties": {
+              "arn": {
+                "description": "ARN of resource",
+                "type": "string"
+              },
+              "filters": {
+                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "items": {
+                  "description": "Filter is a filter used to identify an AWS resource",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the filter. Filter names are case-sensitive.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "ID of resource",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+          "type": "object"
+        },
+        "ami": {
+          "description": "AMI is the reference to the AMI from which to create the machine instance.",
+          "properties": {
+            "arn": {
+              "description": "ARN of resource",
+              "type": "string"
+            },
+            "filters": {
+              "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+              "items": {
+                "description": "Filter is a filter used to identify an AWS resource",
+                "properties": {
+                  "name": {
+                    "description": "Name of the filter. Filter names are case-sensitive.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name",
+                  "values"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudInit": {
+          "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+          "properties": {
+            "insecureSkipSecretsManager": {
+              "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+              "type": "boolean"
+            },
+            "secretCount": {
+              "description": "SecretCount is the number of secrets used to form the complete secret",
+              "format": "int32",
+              "type": "integer"
+            },
+            "secretPrefix": {
+              "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+              "type": "string"
+            },
+            "secureSecretsBackend": {
+              "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+              "enum": [
+                "secrets-manager",
+                "ssm-parameter-store"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomain": {
+          "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. For this infrastructure provider, the ID is equivalent to an AWS Availability Zone. If multiple subnets are matched for the availability zone, the first one returned is picked.",
+          "type": "string"
+        },
+        "iamInstanceProfile": {
+          "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+          "type": "string"
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+          "type": "string"
+        },
+        "instanceID": {
+          "description": "InstanceID is the EC2 instance ID for this machine.",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+          "type": "string"
+        },
+        "networkInterfaces": {
+          "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 2,
+          "type": "array"
+        },
+        "nonRootVolumes": {
+          "description": "Configuration options for the non root storage volumes.",
+          "items": {
+            "description": "Volume encapsulates the configuration options for the storage device",
+            "properties": {
+              "deviceName": {
+                "description": "Device name",
+                "type": "string"
+              },
+              "encrypted": {
+                "description": "Encrypted is whether the volume should be encrypted or not.",
+                "type": "boolean"
+              },
+              "encryptionKey": {
+                "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                "type": "string"
+              },
+              "iops": {
+                "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "size": {
+                "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                "format": "int64",
+                "minimum": 8,
+                "type": "integer"
+              },
+              "type": {
+                "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "publicIP": {
+          "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+          "type": "boolean"
+        },
+        "rootVolume": {
+          "description": "RootVolume encapsulates the configuration options for the root volume",
+          "properties": {
+            "deviceName": {
+              "description": "Device name",
+              "type": "string"
+            },
+            "encrypted": {
+              "description": "Encrypted is whether the volume should be encrypted or not.",
+              "type": "boolean"
+            },
+            "encryptionKey": {
+              "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+              "type": "string"
+            },
+            "iops": {
+              "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "size": {
+              "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+              "format": "int64",
+              "minimum": 8,
+              "type": "integer"
+            },
+            "type": {
+              "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "size"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "spotMarketOptions": {
+          "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
+          "properties": {
+            "maxPrice": {
+              "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        },
+        "subnet": {
+          "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+          "properties": {
+            "arn": {
+              "description": "ARN of resource",
+              "type": "string"
+            },
+            "filters": {
+              "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+              "items": {
+                "description": "Filter is a filter used to identify an AWS resource",
+                "properties": {
+                  "name": {
+                    "description": "Name of the filter. Filter names are case-sensitive.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name",
+                  "values"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tenancy": {
+          "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+          "enum": [
+            "default",
+            "dedicated",
+            "host"
+          ],
+          "type": "string"
+        },
+        "uncompressedUserData": {
+          "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachineStatus defines the observed state of AWSMachine",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the AWS instance associated addresses.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AWSMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instanceState": {
+          "description": "InstanceState is the state of the AWS instance for this machine.",
+          "type": "string"
+        },
+        "interruptible": {
+          "description": "Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS. This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachine_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachine_v1alpha4.json
@@ -1,0 +1,418 @@
+{
+  "description": "AWSMachine is the Schema for the awsmachines API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineSpec defines the desired state of AWSMachine",
+      "properties": {
+        "additionalSecurityGroups": {
+          "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+          "items": {
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+            "properties": {
+              "arn": {
+                "description": "ARN of resource",
+                "type": "string"
+              },
+              "filters": {
+                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "items": {
+                  "description": "Filter is a filter used to identify an AWS resource",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the filter. Filter names are case-sensitive.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "ID of resource",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+          "type": "object"
+        },
+        "ami": {
+          "description": "AMI is the reference to the AMI from which to create the machine instance.",
+          "properties": {
+            "eksLookupType": {
+              "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+              "enum": [
+                "AmazonLinux",
+                "AmazonLinuxGPU"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudInit": {
+          "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+          "properties": {
+            "insecureSkipSecretsManager": {
+              "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+              "type": "boolean"
+            },
+            "secretCount": {
+              "description": "SecretCount is the number of secrets used to form the complete secret",
+              "format": "int32",
+              "type": "integer"
+            },
+            "secretPrefix": {
+              "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+              "type": "string"
+            },
+            "secureSecretsBackend": {
+              "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+              "enum": [
+                "secrets-manager",
+                "ssm-parameter-store"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomain": {
+          "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. For this infrastructure provider, the ID is equivalent to an AWS Availability Zone. If multiple subnets are matched for the availability zone, the first one returned is picked.",
+          "type": "string"
+        },
+        "iamInstanceProfile": {
+          "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+          "type": "string"
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+          "type": "string"
+        },
+        "instanceID": {
+          "description": "InstanceID is the EC2 instance ID for this machine.",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+          "minLength": 2,
+          "type": "string"
+        },
+        "networkInterfaces": {
+          "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 2,
+          "type": "array"
+        },
+        "nonRootVolumes": {
+          "description": "Configuration options for the non root storage volumes.",
+          "items": {
+            "description": "Volume encapsulates the configuration options for the storage device",
+            "properties": {
+              "deviceName": {
+                "description": "Device name",
+                "type": "string"
+              },
+              "encrypted": {
+                "description": "Encrypted is whether the volume should be encrypted or not.",
+                "type": "boolean"
+              },
+              "encryptionKey": {
+                "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                "type": "string"
+              },
+              "iops": {
+                "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "size": {
+                "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                "format": "int64",
+                "minimum": 8,
+                "type": "integer"
+              },
+              "throughput": {
+                "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "type": {
+                "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "publicIP": {
+          "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+          "type": "boolean"
+        },
+        "rootVolume": {
+          "description": "RootVolume encapsulates the configuration options for the root volume",
+          "properties": {
+            "deviceName": {
+              "description": "Device name",
+              "type": "string"
+            },
+            "encrypted": {
+              "description": "Encrypted is whether the volume should be encrypted or not.",
+              "type": "boolean"
+            },
+            "encryptionKey": {
+              "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+              "type": "string"
+            },
+            "iops": {
+              "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "size": {
+              "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+              "format": "int64",
+              "minimum": 8,
+              "type": "integer"
+            },
+            "throughput": {
+              "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": {
+              "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "size"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "spotMarketOptions": {
+          "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
+          "properties": {
+            "maxPrice": {
+              "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        },
+        "subnet": {
+          "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+          "properties": {
+            "arn": {
+              "description": "ARN of resource",
+              "type": "string"
+            },
+            "filters": {
+              "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+              "items": {
+                "description": "Filter is a filter used to identify an AWS resource",
+                "properties": {
+                  "name": {
+                    "description": "Name of the filter. Filter names are case-sensitive.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name",
+                  "values"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tenancy": {
+          "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+          "enum": [
+            "default",
+            "dedicated",
+            "host"
+          ],
+          "type": "string"
+        },
+        "uncompressedUserData": {
+          "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "instanceType"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachineStatus defines the observed state of AWSMachine",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the AWS instance associated addresses.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AWSMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instanceState": {
+          "description": "InstanceState is the state of the AWS instance for this machine.",
+          "type": "string"
+        },
+        "interruptible": {
+          "description": "Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS. This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachine_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachine_v1beta1.json
@@ -1,0 +1,434 @@
+{
+  "description": "AWSMachine is the schema for Amazon EC2 machines.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineSpec defines the desired state of an Amazon EC2 instance.",
+      "properties": {
+        "additionalSecurityGroups": {
+          "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+          "items": {
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+            "properties": {
+              "arn": {
+                "description": "ARN of resource. Deprecated: This field has no function and is going to be removed in the next release.",
+                "type": "string"
+              },
+              "filters": {
+                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "items": {
+                  "description": "Filter is a filter used to identify an AWS resource.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the filter. Filter names are case-sensitive.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "ID of resource",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+          "type": "object"
+        },
+        "ami": {
+          "description": "AMI is the reference to the AMI from which to create the machine instance.",
+          "properties": {
+            "eksLookupType": {
+              "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+              "enum": [
+                "AmazonLinux",
+                "AmazonLinuxGPU"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudInit": {
+          "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+          "properties": {
+            "insecureSkipSecretsManager": {
+              "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+              "type": "boolean"
+            },
+            "secretCount": {
+              "description": "SecretCount is the number of secrets used to form the complete secret",
+              "format": "int32",
+              "type": "integer"
+            },
+            "secretPrefix": {
+              "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+              "type": "string"
+            },
+            "secureSecretsBackend": {
+              "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+              "enum": [
+                "secrets-manager",
+                "ssm-parameter-store"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "failureDomain": {
+          "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. For this infrastructure provider, the ID is equivalent to an AWS Availability Zone. If multiple subnets are matched for the availability zone, the first one returned is picked.",
+          "type": "string"
+        },
+        "iamInstanceProfile": {
+          "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+          "type": "string"
+        },
+        "ignition": {
+          "description": "Ignition defined options related to the bootstrapping systems where Ignition is used.",
+          "properties": {
+            "version": {
+              "default": "2.3",
+              "description": "Version defines which version of Ignition will be used to generate bootstrap data.",
+              "enum": [
+                "2.3"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+          "type": "string"
+        },
+        "instanceID": {
+          "description": "InstanceID is the EC2 instance ID for this machine.",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+          "minLength": 2,
+          "type": "string"
+        },
+        "networkInterfaces": {
+          "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 2,
+          "type": "array"
+        },
+        "nonRootVolumes": {
+          "description": "Configuration options for the non root storage volumes.",
+          "items": {
+            "description": "Volume encapsulates the configuration options for the storage device.",
+            "properties": {
+              "deviceName": {
+                "description": "Device name",
+                "type": "string"
+              },
+              "encrypted": {
+                "description": "Encrypted is whether the volume should be encrypted or not.",
+                "type": "boolean"
+              },
+              "encryptionKey": {
+                "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                "type": "string"
+              },
+              "iops": {
+                "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "size": {
+                "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                "format": "int64",
+                "minimum": 8,
+                "type": "integer"
+              },
+              "throughput": {
+                "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "type": {
+                "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "publicIP": {
+          "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+          "type": "boolean"
+        },
+        "rootVolume": {
+          "description": "RootVolume encapsulates the configuration options for the root volume",
+          "properties": {
+            "deviceName": {
+              "description": "Device name",
+              "type": "string"
+            },
+            "encrypted": {
+              "description": "Encrypted is whether the volume should be encrypted or not.",
+              "type": "boolean"
+            },
+            "encryptionKey": {
+              "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+              "type": "string"
+            },
+            "iops": {
+              "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "size": {
+              "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+              "format": "int64",
+              "minimum": 8,
+              "type": "integer"
+            },
+            "throughput": {
+              "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": {
+              "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "size"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "spotMarketOptions": {
+          "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
+          "properties": {
+            "maxPrice": {
+              "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        },
+        "subnet": {
+          "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+          "properties": {
+            "arn": {
+              "description": "ARN of resource. Deprecated: This field has no function and is going to be removed in the next release.",
+              "type": "string"
+            },
+            "filters": {
+              "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+              "items": {
+                "description": "Filter is a filter used to identify an AWS resource.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the filter. Filter names are case-sensitive.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name",
+                  "values"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tenancy": {
+          "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+          "enum": [
+            "default",
+            "dedicated",
+            "host"
+          ],
+          "type": "string"
+        },
+        "uncompressedUserData": {
+          "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "instanceType"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachineStatus defines the observed state of AWSMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the AWS instance associated addresses.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AWSMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instanceState": {
+          "description": "InstanceState is the state of the AWS instance for this machine.",
+          "type": "string"
+        },
+        "interruptible": {
+          "description": "Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS. This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachine_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachine_v1beta2.json
@@ -1,0 +1,464 @@
+{
+  "description": "AWSMachine is the schema for Amazon EC2 machines.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineSpec defines the desired state of an Amazon EC2 instance.",
+      "properties": {
+        "additionalSecurityGroups": {
+          "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+          "items": {
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+            "properties": {
+              "filters": {
+                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "items": {
+                  "description": "Filter is a filter used to identify an AWS resource.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the filter. Filter names are case-sensitive.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "ID of resource",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+          "type": "object"
+        },
+        "ami": {
+          "description": "AMI is the reference to the AMI from which to create the machine instance.",
+          "properties": {
+            "eksLookupType": {
+              "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+              "enum": [
+                "AmazonLinux",
+                "AmazonLinuxGPU"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudInit": {
+          "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+          "properties": {
+            "insecureSkipSecretsManager": {
+              "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+              "type": "boolean"
+            },
+            "secretCount": {
+              "description": "SecretCount is the number of secrets used to form the complete secret",
+              "format": "int32",
+              "type": "integer"
+            },
+            "secretPrefix": {
+              "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+              "type": "string"
+            },
+            "secureSecretsBackend": {
+              "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+              "enum": [
+                "secrets-manager",
+                "ssm-parameter-store"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "iamInstanceProfile": {
+          "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+          "type": "string"
+        },
+        "ignition": {
+          "description": "Ignition defined options related to the bootstrapping systems where Ignition is used.",
+          "properties": {
+            "version": {
+              "default": "2.3",
+              "description": "Version defines which version of Ignition will be used to generate bootstrap data.",
+              "enum": [
+                "2.3"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseOS": {
+          "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOrg": {
+          "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+          "type": "string"
+        },
+        "instanceID": {
+          "description": "InstanceID is the EC2 instance ID for this machine.",
+          "type": "string"
+        },
+        "instanceMetadataOptions": {
+          "description": "InstanceMetadataOptions is the metadata options for the EC2 instance.",
+          "properties": {
+            "httpEndpoint": {
+              "default": "enabled",
+              "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+              "enum": [
+                "enabled",
+                "disabled"
+              ],
+              "type": "string"
+            },
+            "httpPutResponseHopLimit": {
+              "default": 1,
+              "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+              "format": "int64",
+              "maximum": 64,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "httpTokens": {
+              "default": "required",
+              "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+              "enum": [
+                "optional",
+                "required"
+              ],
+              "type": "string"
+            },
+            "instanceMetadataTags": {
+              "default": "disabled",
+              "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+              "enum": [
+                "enabled",
+                "disabled"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "instanceType": {
+          "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+          "minLength": 2,
+          "type": "string"
+        },
+        "networkInterfaces": {
+          "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 2,
+          "type": "array"
+        },
+        "nonRootVolumes": {
+          "description": "Configuration options for the non root storage volumes.",
+          "items": {
+            "description": "Volume encapsulates the configuration options for the storage device.",
+            "properties": {
+              "deviceName": {
+                "description": "Device name",
+                "type": "string"
+              },
+              "encrypted": {
+                "description": "Encrypted is whether the volume should be encrypted or not.",
+                "type": "boolean"
+              },
+              "encryptionKey": {
+                "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                "type": "string"
+              },
+              "iops": {
+                "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "size": {
+                "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                "format": "int64",
+                "minimum": 8,
+                "type": "integer"
+              },
+              "throughput": {
+                "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "type": {
+                "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "publicIP": {
+          "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+          "type": "boolean"
+        },
+        "rootVolume": {
+          "description": "RootVolume encapsulates the configuration options for the root volume",
+          "properties": {
+            "deviceName": {
+              "description": "Device name",
+              "type": "string"
+            },
+            "encrypted": {
+              "description": "Encrypted is whether the volume should be encrypted or not.",
+              "type": "boolean"
+            },
+            "encryptionKey": {
+              "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+              "type": "string"
+            },
+            "iops": {
+              "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "size": {
+              "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+              "format": "int64",
+              "minimum": 8,
+              "type": "integer"
+            },
+            "throughput": {
+              "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": {
+              "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "size"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "spotMarketOptions": {
+          "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
+          "properties": {
+            "maxPrice": {
+              "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshKeyName": {
+          "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+          "type": "string"
+        },
+        "subnet": {
+          "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+          "properties": {
+            "filters": {
+              "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+              "items": {
+                "description": "Filter is a filter used to identify an AWS resource.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the filter. Filter names are case-sensitive.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name",
+                  "values"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "id": {
+              "description": "ID of resource",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tenancy": {
+          "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+          "enum": [
+            "default",
+            "dedicated",
+            "host"
+          ],
+          "type": "string"
+        },
+        "uncompressedUserData": {
+          "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "instanceType"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachineStatus defines the observed state of AWSMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the AWS instance associated addresses.",
+          "items": {
+            "description": "MachineAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The machine address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AWSMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instanceState": {
+          "description": "InstanceState is the state of the AWS instance for this machine.",
+          "type": "string"
+        },
+        "interruptible": {
+          "description": "Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS. This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachinepool_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinepool_v1alpha3.json
@@ -1,0 +1,453 @@
+{
+  "description": "AWSMachinePool is the Schema for the awsmachinepools API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachinePoolSpec defines the desired state of AWSMachinePool",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider.",
+          "type": "object"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones is an array of availability zones instances can run in",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "awsLaunchTemplate": {
+          "description": "AWSLaunchTemplate specifies the launch template and version to use when an instance is launched.",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "items": {
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+                "properties": {
+                  "arn": {
+                    "description": "ARN of resource",
+                    "type": "string"
+                  },
+                  "filters": {
+                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "items": {
+                      "description": "Filter is a filter used to identify an AWS resource",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the filter. Filter names are case-sensitive.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "values"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI is the reference to the AMI from which to create the machine instance.",
+              "properties": {
+                "arn": {
+                  "description": "ARN of resource",
+                  "type": "string"
+                },
+                "filters": {
+                  "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                  "items": {
+                    "description": "Filter is a filter used to identify an AWS resource",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the filter. Filter names are case-sensitive.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "values"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "id": {
+                  "description": "ID of resource",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "iamInstanceProfile": {
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "type": "string"
+            },
+            "imageLookupBaseOS": {
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "type": "string"
+            },
+            "imageLookupFormat": {
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "type": "string"
+            },
+            "imageLookupOrg": {
+              "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+              "type": "string"
+            },
+            "instanceType": {
+              "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the launch template.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "RootVolume encapsulates the configuration options for the root volume",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "type": "string"
+            },
+            "versionNumber": {
+              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "capacityRebalance": {
+          "description": "Enable or disable the capacity rebalance autoscaling group feature",
+          "type": "boolean"
+        },
+        "defaultCoolDown": {
+          "description": "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. If no value is supplied by user a default value of 300 seconds is set",
+          "type": "string"
+        },
+        "maxSize": {
+          "default": 1,
+          "description": "MaxSize defines the maximum size of the group.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "minSize": {
+          "default": 1,
+          "description": "MinSize defines the minimum size of the group.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "mixedInstancesPolicy": {
+          "description": "MixedInstancesPolicy describes how multiple instance types will be used by the ASG.",
+          "properties": {
+            "instancesDistribution": {
+              "description": "InstancesDistribution to configure distribution of On-Demand Instances and Spot Instances.",
+              "properties": {
+                "onDemandAllocationStrategy": {
+                  "default": "prioritized",
+                  "description": "OnDemandAllocationStrategy indicates how to allocate instance types to fulfill On-Demand capacity.",
+                  "enum": [
+                    "prioritized"
+                  ],
+                  "type": "string"
+                },
+                "onDemandBaseCapacity": {
+                  "default": 0,
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "onDemandPercentageAboveBaseCapacity": {
+                  "default": 100,
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "spotAllocationStrategy": {
+                  "default": "lowest-price",
+                  "description": "SpotAllocationStrategy indicates how to allocate instances across Spot Instance pools.",
+                  "enum": [
+                    "lowest-price",
+                    "capacity-optimized"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "overrides": {
+              "items": {
+                "description": "Overrides are used to override the instance type specified by the launch template with multiple instance types that can be used to launch On-Demand Instances and Spot Instances.",
+                "properties": {
+                  "instanceType": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "instanceType"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "description": "ProviderID is the ARN of the associated ASG",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "refreshPreferences": {
+          "description": "RefreshPreferences describes set of preferences associated with the instance refresh request.",
+          "properties": {
+            "instanceWarmup": {
+              "description": "The number of seconds until a newly launched instance is configured and ready to use. During this time, the next replacement will not be initiated. The default is to use the value for the health check grace period defined for the group.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "minHealthyPercentage": {
+              "description": "The amount of capacity as a percentage in ASG that must remain healthy during an instance refresh. The default is 90.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "strategy": {
+              "description": "The strategy to use for the instance refresh. The only valid value is Rolling. A rolling update is an update that is applied to all instances in an Auto Scaling group until all instances have been updated.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subnets": {
+          "description": "Subnets is an array of subnet configurations",
+          "items": {
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+            "properties": {
+              "arn": {
+                "description": "ARN of resource",
+                "type": "string"
+              },
+              "filters": {
+                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "items": {
+                  "description": "Filter is a filter used to identify an AWS resource",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the filter. Filter names are case-sensitive.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "ID of resource",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "awsLaunchTemplate",
+        "maxSize",
+        "minSize"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachinePoolStatus defines the observed state of AWSMachinePool",
+      "properties": {
+        "asgStatus": {
+          "description": "ASGStatus is a status string returned by the autoscaling API",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AWSMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "AWSMachinePoolInstanceStatus defines the status of the AWSMachinePoolInstance.",
+            "properties": {
+              "instanceID": {
+                "description": "InstanceID is the identification of the Machine Instance within ASG",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "launchTemplateID": {
+          "description": "The ID of the launch template",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachinepool_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinepool_v1alpha4.json
@@ -1,0 +1,436 @@
+{
+  "description": "AWSMachinePool is the Schema for the awsmachinepools API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachinePoolSpec defines the desired state of AWSMachinePool",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider.",
+          "type": "object"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones is an array of availability zones instances can run in",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "awsLaunchTemplate": {
+          "description": "AWSLaunchTemplate specifies the launch template and version to use when an instance is launched.",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "items": {
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+                "properties": {
+                  "arn": {
+                    "description": "ARN of resource",
+                    "type": "string"
+                  },
+                  "filters": {
+                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "items": {
+                      "description": "Filter is a filter used to identify an AWS resource",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the filter. Filter names are case-sensitive.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "values"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI is the reference to the AMI from which to create the machine instance.",
+              "properties": {
+                "eksLookupType": {
+                  "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+                  "enum": [
+                    "AmazonLinux",
+                    "AmazonLinuxGPU"
+                  ],
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID of resource",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "iamInstanceProfile": {
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "type": "string"
+            },
+            "imageLookupBaseOS": {
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "type": "string"
+            },
+            "imageLookupFormat": {
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "type": "string"
+            },
+            "imageLookupOrg": {
+              "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+              "type": "string"
+            },
+            "instanceType": {
+              "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the launch template.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "RootVolume encapsulates the configuration options for the root volume",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "type": "string"
+            },
+            "versionNumber": {
+              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "capacityRebalance": {
+          "description": "Enable or disable the capacity rebalance autoscaling group feature",
+          "type": "boolean"
+        },
+        "defaultCoolDown": {
+          "description": "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. If no value is supplied by user a default value of 300 seconds is set",
+          "type": "string"
+        },
+        "maxSize": {
+          "default": 1,
+          "description": "MaxSize defines the maximum size of the group.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "minSize": {
+          "default": 1,
+          "description": "MinSize defines the minimum size of the group.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "mixedInstancesPolicy": {
+          "description": "MixedInstancesPolicy describes how multiple instance types will be used by the ASG.",
+          "properties": {
+            "instancesDistribution": {
+              "description": "InstancesDistribution to configure distribution of On-Demand Instances and Spot Instances.",
+              "properties": {
+                "onDemandAllocationStrategy": {
+                  "default": "prioritized",
+                  "description": "OnDemandAllocationStrategy indicates how to allocate instance types to fulfill On-Demand capacity.",
+                  "enum": [
+                    "prioritized"
+                  ],
+                  "type": "string"
+                },
+                "onDemandBaseCapacity": {
+                  "default": 0,
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "onDemandPercentageAboveBaseCapacity": {
+                  "default": 100,
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "spotAllocationStrategy": {
+                  "default": "lowest-price",
+                  "description": "SpotAllocationStrategy indicates how to allocate instances across Spot Instance pools.",
+                  "enum": [
+                    "lowest-price",
+                    "capacity-optimized"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "overrides": {
+              "items": {
+                "description": "Overrides are used to override the instance type specified by the launch template with multiple instance types that can be used to launch On-Demand Instances and Spot Instances.",
+                "properties": {
+                  "instanceType": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "instanceType"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "description": "ProviderID is the ARN of the associated ASG",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "refreshPreferences": {
+          "description": "RefreshPreferences describes set of preferences associated with the instance refresh request.",
+          "properties": {
+            "instanceWarmup": {
+              "description": "The number of seconds until a newly launched instance is configured and ready to use. During this time, the next replacement will not be initiated. The default is to use the value for the health check grace period defined for the group.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "minHealthyPercentage": {
+              "description": "The amount of capacity as a percentage in ASG that must remain healthy during an instance refresh. The default is 90.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "strategy": {
+              "description": "The strategy to use for the instance refresh. The only valid value is Rolling. A rolling update is an update that is applied to all instances in an Auto Scaling group until all instances have been updated.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subnets": {
+          "description": "Subnets is an array of subnet configurations",
+          "items": {
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+            "properties": {
+              "arn": {
+                "description": "ARN of resource",
+                "type": "string"
+              },
+              "filters": {
+                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "items": {
+                  "description": "Filter is a filter used to identify an AWS resource",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the filter. Filter names are case-sensitive.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "ID of resource",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "awsLaunchTemplate",
+        "maxSize",
+        "minSize"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachinePoolStatus defines the observed state of AWSMachinePool",
+      "properties": {
+        "asgStatus": {
+          "description": "ASGStatus is a status string returned by the autoscaling API",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AWSMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "AWSMachinePoolInstanceStatus defines the status of the AWSMachinePoolInstance.",
+            "properties": {
+              "instanceID": {
+                "description": "InstanceID is the identification of the Machine Instance within ASG",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "launchTemplateID": {
+          "description": "The ID of the launch template",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta1.json
@@ -1,0 +1,444 @@
+{
+  "description": "AWSMachinePool is the Schema for the awsmachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachinePoolSpec defines the desired state of AWSMachinePool.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider.",
+          "type": "object"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones is an array of availability zones instances can run in",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "awsLaunchTemplate": {
+          "description": "AWSLaunchTemplate specifies the launch template and version to use when an instance is launched.",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "items": {
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                "properties": {
+                  "filters": {
+                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "items": {
+                      "description": "Filter is a filter used to identify an AWS resource.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the filter. Filter names are case-sensitive.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "values"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI is the reference to the AMI from which to create the machine instance.",
+              "properties": {
+                "eksLookupType": {
+                  "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+                  "enum": [
+                    "AmazonLinux",
+                    "AmazonLinuxGPU"
+                  ],
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID of resource",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "iamInstanceProfile": {
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "type": "string"
+            },
+            "imageLookupBaseOS": {
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "type": "string"
+            },
+            "imageLookupFormat": {
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "type": "string"
+            },
+            "imageLookupOrg": {
+              "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+              "type": "string"
+            },
+            "instanceType": {
+              "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the launch template.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "RootVolume encapsulates the configuration options for the root volume",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions are options for configuring AWSMachinePool instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "type": "string"
+            },
+            "versionNumber": {
+              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "capacityRebalance": {
+          "description": "Enable or disable the capacity rebalance autoscaling group feature",
+          "type": "boolean"
+        },
+        "defaultCoolDown": {
+          "description": "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. If no value is supplied by user a default value of 300 seconds is set",
+          "type": "string"
+        },
+        "maxSize": {
+          "default": 1,
+          "description": "MaxSize defines the maximum size of the group.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "minSize": {
+          "default": 1,
+          "description": "MinSize defines the minimum size of the group.",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "mixedInstancesPolicy": {
+          "description": "MixedInstancesPolicy describes how multiple instance types will be used by the ASG.",
+          "properties": {
+            "instancesDistribution": {
+              "description": "InstancesDistribution to configure distribution of On-Demand Instances and Spot Instances.",
+              "properties": {
+                "onDemandAllocationStrategy": {
+                  "default": "prioritized",
+                  "description": "OnDemandAllocationStrategy indicates how to allocate instance types to fulfill On-Demand capacity.",
+                  "enum": [
+                    "prioritized"
+                  ],
+                  "type": "string"
+                },
+                "onDemandBaseCapacity": {
+                  "default": 0,
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "onDemandPercentageAboveBaseCapacity": {
+                  "default": 100,
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "spotAllocationStrategy": {
+                  "default": "lowest-price",
+                  "description": "SpotAllocationStrategy indicates how to allocate instances across Spot Instance pools.",
+                  "enum": [
+                    "lowest-price",
+                    "capacity-optimized"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "overrides": {
+              "items": {
+                "description": "Overrides are used to override the instance type specified by the launch template with multiple instance types that can be used to launch On-Demand Instances and Spot Instances.",
+                "properties": {
+                  "instanceType": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "instanceType"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "description": "ProviderID is the ARN of the associated ASG",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "refreshPreferences": {
+          "description": "RefreshPreferences describes set of preferences associated with the instance refresh request.",
+          "properties": {
+            "instanceWarmup": {
+              "description": "The number of seconds until a newly launched instance is configured and ready to use. During this time, the next replacement will not be initiated. The default is to use the value for the health check grace period defined for the group.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "minHealthyPercentage": {
+              "description": "The amount of capacity as a percentage in ASG that must remain healthy during an instance refresh. The default is 90.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "strategy": {
+              "description": "The strategy to use for the instance refresh. The only valid value is Rolling. A rolling update is an update that is applied to all instances in an Auto Scaling group until all instances have been updated.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subnets": {
+          "description": "Subnets is an array of subnet configurations",
+          "items": {
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+            "properties": {
+              "filters": {
+                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "items": {
+                  "description": "Filter is a filter used to identify an AWS resource.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the filter. Filter names are case-sensitive.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "ID of resource",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "awsLaunchTemplate",
+        "maxSize",
+        "minSize"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachinePoolStatus defines the observed state of AWSMachinePool.",
+      "properties": {
+        "asgStatus": {
+          "description": "ASGStatus is a status string returned by the autoscaling API.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AWSMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "AWSMachinePoolInstanceStatus defines the status of the AWSMachinePoolInstance.",
+            "properties": {
+              "instanceID": {
+                "description": "InstanceID is the identification of the Machine Instance within ASG",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "launchTemplateID": {
+          "description": "The ID of the launch template",
+          "type": "string"
+        },
+        "launchTemplateVersion": {
+          "description": "The version of the launch template",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta2.json
@@ -1,0 +1,492 @@
+{
+  "description": "AWSMachinePool is the Schema for the awsmachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachinePoolSpec defines the desired state of AWSMachinePool.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider.",
+          "type": "object"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones is an array of availability zones instances can run in",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "awsLaunchTemplate": {
+          "description": "AWSLaunchTemplate specifies the launch template and version to use when an instance is launched.",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "items": {
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                "properties": {
+                  "filters": {
+                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "items": {
+                      "description": "Filter is a filter used to identify an AWS resource.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the filter. Filter names are case-sensitive.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "values"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI is the reference to the AMI from which to create the machine instance.",
+              "properties": {
+                "eksLookupType": {
+                  "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+                  "enum": [
+                    "AmazonLinux",
+                    "AmazonLinuxGPU"
+                  ],
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID of resource",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "iamInstanceProfile": {
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "type": "string"
+            },
+            "imageLookupBaseOS": {
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "type": "string"
+            },
+            "imageLookupFormat": {
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "type": "string"
+            },
+            "imageLookupOrg": {
+              "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+              "type": "string"
+            },
+            "instanceType": {
+              "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the launch template.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "RootVolume encapsulates the configuration options for the root volume",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions are options for configuring AWSMachinePool instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "type": "string"
+            },
+            "versionNumber": {
+              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "capacityRebalance": {
+          "description": "Enable or disable the capacity rebalance autoscaling group feature",
+          "type": "boolean"
+        },
+        "defaultCoolDown": {
+          "description": "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. If no value is supplied by user a default value of 300 seconds is set",
+          "type": "string"
+        },
+        "maxSize": {
+          "default": 1,
+          "description": "MaxSize defines the maximum size of the group.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "minSize": {
+          "default": 1,
+          "description": "MinSize defines the minimum size of the group.",
+          "format": "int32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "mixedInstancesPolicy": {
+          "description": "MixedInstancesPolicy describes how multiple instance types will be used by the ASG.",
+          "properties": {
+            "instancesDistribution": {
+              "description": "InstancesDistribution to configure distribution of On-Demand Instances and Spot Instances.",
+              "properties": {
+                "onDemandAllocationStrategy": {
+                  "default": "prioritized",
+                  "description": "OnDemandAllocationStrategy indicates how to allocate instance types to fulfill On-Demand capacity.",
+                  "enum": [
+                    "prioritized"
+                  ],
+                  "type": "string"
+                },
+                "onDemandBaseCapacity": {
+                  "default": 0,
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "onDemandPercentageAboveBaseCapacity": {
+                  "default": 100,
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "spotAllocationStrategy": {
+                  "default": "lowest-price",
+                  "description": "SpotAllocationStrategy indicates how to allocate instances across Spot Instance pools.",
+                  "enum": [
+                    "lowest-price",
+                    "capacity-optimized"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "overrides": {
+              "items": {
+                "description": "Overrides are used to override the instance type specified by the launch template with multiple instance types that can be used to launch On-Demand Instances and Spot Instances.",
+                "properties": {
+                  "instanceType": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "instanceType"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "description": "ProviderID is the ARN of the associated ASG",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "refreshPreferences": {
+          "description": "RefreshPreferences describes set of preferences associated with the instance refresh request.",
+          "properties": {
+            "disable": {
+              "description": "Disable, if true, disables instance refresh from triggering when new launch templates are detected. This is useful in scenarios where ASG nodes are externally managed.",
+              "type": "boolean"
+            },
+            "instanceWarmup": {
+              "description": "The number of seconds until a newly launched instance is configured and ready to use. During this time, the next replacement will not be initiated. The default is to use the value for the health check grace period defined for the group.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "minHealthyPercentage": {
+              "description": "The amount of capacity as a percentage in ASG that must remain healthy during an instance refresh. The default is 90.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "strategy": {
+              "description": "The strategy to use for the instance refresh. The only valid value is Rolling. A rolling update is an update that is applied to all instances in an Auto Scaling group until all instances have been updated.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subnets": {
+          "description": "Subnets is an array of subnet configurations",
+          "items": {
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+            "properties": {
+              "filters": {
+                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "items": {
+                  "description": "Filter is a filter used to identify an AWS resource.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the filter. Filter names are case-sensitive.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "ID of resource",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "suspendProcesses": {
+          "description": "SuspendProcesses defines a list of processes to suspend for the given ASG. This is constantly reconciled. If a process is removed from this list it will automatically be resumed.",
+          "properties": {
+            "all": {
+              "type": "boolean"
+            },
+            "processes": {
+              "description": "Processes defines the processes which can be enabled or disabled individually.",
+              "properties": {
+                "addToLoadBalancer": {
+                  "type": "boolean"
+                },
+                "alarmNotification": {
+                  "type": "boolean"
+                },
+                "azRebalance": {
+                  "type": "boolean"
+                },
+                "healthCheck": {
+                  "type": "boolean"
+                },
+                "instanceRefresh": {
+                  "type": "boolean"
+                },
+                "launch": {
+                  "type": "boolean"
+                },
+                "replaceUnhealthy": {
+                  "type": "boolean"
+                },
+                "scheduledActions": {
+                  "type": "boolean"
+                },
+                "terminate": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "awsLaunchTemplate",
+        "maxSize",
+        "minSize"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachinePoolStatus defines the observed state of AWSMachinePool.",
+      "properties": {
+        "asgStatus": {
+          "description": "ASGStatus is a status string returned by the autoscaling API.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AWSMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instances": {
+          "description": "Instances contains the status for each instance in the pool",
+          "items": {
+            "description": "AWSMachinePoolInstanceStatus defines the status of the AWSMachinePoolInstance.",
+            "properties": {
+              "instanceID": {
+                "description": "InstanceID is the identification of the Machine Instance within ASG",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the Machine Instance",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "launchTemplateID": {
+          "description": "The ID of the launch template",
+          "type": "string"
+        },
+        "launchTemplateVersion": {
+          "description": "The version of the launch template",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1alpha2.json
@@ -1,0 +1,239 @@
+{
+  "description": "AWSMachineTemplate is the Schema for the awsmachinetemplates API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate",
+      "properties": {
+        "template": {
+          "description": "AWSMachineTemplateResource describes the data needed to create am AWSMachine from a template",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "additionalSecurityGroups": {
+                  "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+                  "items": {
+                    "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+                    "properties": {
+                      "arn": {
+                        "description": "ARN of resource",
+                        "type": "string"
+                      },
+                      "filters": {
+                        "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                        "items": {
+                          "description": "Filter is a filter used to identify an AWS resource",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the filter. Filter names are case-sensitive.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "values"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "id": {
+                        "description": "ID of resource",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+                  "type": "object"
+                },
+                "ami": {
+                  "description": "AMI is the reference to the AMI from which to create the machine instance.",
+                  "properties": {
+                    "arn": {
+                      "description": "ARN of resource",
+                      "type": "string"
+                    },
+                    "filters": {
+                      "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                      "items": {
+                        "description": "Filter is a filter used to identify an AWS resource",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the filter. Filter names are case-sensitive.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZone": {
+                  "description": "AvailabilityZone is references the AWS availability zone to use for this instance. If multiple subnets are matched for the availability zone, the first one return is picked.",
+                  "type": "string"
+                },
+                "cloudInit": {
+                  "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+                  "properties": {
+                    "enableSecureSecretsManager": {
+                      "description": "enableSecureSecretsManager, when set to true will use AWS Secrets Manager to ensure userdata privacy. A cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+                      "type": "boolean"
+                    },
+                    "secretCount": {
+                      "description": "SecretCount is the number of secrets used to form the complete secret",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "secretPrefix": {
+                      "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "iamInstanceProfile": {
+                  "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+                  "type": "string"
+                },
+                "imageLookupOrg": {
+                  "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+                  "type": "string"
+                },
+                "instanceType": {
+                  "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+                  "type": "string"
+                },
+                "networkInterfaces": {
+                  "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 2,
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "publicIP": {
+                  "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+                  "type": "boolean"
+                },
+                "rootDeviceSize": {
+                  "description": "RootDeviceSize is the size of the root volume in gigabytes(GB).",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "sshKeyName": {
+                  "description": "SSHKeyName is the name of the ssh key to attach to the instance.",
+                  "type": "string"
+                },
+                "subnet": {
+                  "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+                  "properties": {
+                    "arn": {
+                      "description": "ARN of resource",
+                      "type": "string"
+                    },
+                    "filters": {
+                      "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                      "items": {
+                        "description": "Filter is a filter used to identify an AWS resource",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the filter. Filter names are case-sensitive.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1alpha3.json
@@ -1,0 +1,356 @@
+{
+  "description": "AWSMachineTemplate is the Schema for the awsmachinetemplates API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate",
+      "properties": {
+        "template": {
+          "description": "AWSMachineTemplateResource describes the data needed to create am AWSMachine from a template",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "additionalSecurityGroups": {
+                  "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+                  "items": {
+                    "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+                    "properties": {
+                      "arn": {
+                        "description": "ARN of resource",
+                        "type": "string"
+                      },
+                      "filters": {
+                        "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                        "items": {
+                          "description": "Filter is a filter used to identify an AWS resource",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the filter. Filter names are case-sensitive.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "values"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "id": {
+                        "description": "ID of resource",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+                  "type": "object"
+                },
+                "ami": {
+                  "description": "AMI is the reference to the AMI from which to create the machine instance.",
+                  "properties": {
+                    "arn": {
+                      "description": "ARN of resource",
+                      "type": "string"
+                    },
+                    "filters": {
+                      "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                      "items": {
+                        "description": "Filter is a filter used to identify an AWS resource",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the filter. Filter names are case-sensitive.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "cloudInit": {
+                  "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+                  "properties": {
+                    "insecureSkipSecretsManager": {
+                      "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+                      "type": "boolean"
+                    },
+                    "secretCount": {
+                      "description": "SecretCount is the number of secrets used to form the complete secret",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "secretPrefix": {
+                      "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+                      "type": "string"
+                    },
+                    "secureSecretsBackend": {
+                      "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+                      "enum": [
+                        "secrets-manager",
+                        "ssm-parameter-store"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. For this infrastructure provider, the ID is equivalent to an AWS Availability Zone. If multiple subnets are matched for the availability zone, the first one returned is picked.",
+                  "type": "string"
+                },
+                "iamInstanceProfile": {
+                  "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+                  "type": "string"
+                },
+                "imageLookupBaseOS": {
+                  "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+                  "type": "string"
+                },
+                "imageLookupFormat": {
+                  "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "type": "string"
+                },
+                "imageLookupOrg": {
+                  "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+                  "type": "string"
+                },
+                "instanceID": {
+                  "description": "InstanceID is the EC2 instance ID for this machine.",
+                  "type": "string"
+                },
+                "instanceType": {
+                  "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+                  "type": "string"
+                },
+                "networkInterfaces": {
+                  "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 2,
+                  "type": "array"
+                },
+                "nonRootVolumes": {
+                  "description": "Configuration options for the non root storage volumes.",
+                  "items": {
+                    "description": "Volume encapsulates the configuration options for the storage device",
+                    "properties": {
+                      "deviceName": {
+                        "description": "Device name",
+                        "type": "string"
+                      },
+                      "encrypted": {
+                        "description": "Encrypted is whether the volume should be encrypted or not.",
+                        "type": "boolean"
+                      },
+                      "encryptionKey": {
+                        "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                        "type": "string"
+                      },
+                      "iops": {
+                        "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "size": {
+                        "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                        "format": "int64",
+                        "minimum": 8,
+                        "type": "integer"
+                      },
+                      "type": {
+                        "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "size"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "publicIP": {
+                  "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+                  "type": "boolean"
+                },
+                "rootVolume": {
+                  "description": "RootVolume encapsulates the configuration options for the root volume",
+                  "properties": {
+                    "deviceName": {
+                      "description": "Device name",
+                      "type": "string"
+                    },
+                    "encrypted": {
+                      "description": "Encrypted is whether the volume should be encrypted or not.",
+                      "type": "boolean"
+                    },
+                    "encryptionKey": {
+                      "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                      "type": "string"
+                    },
+                    "iops": {
+                      "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "size": {
+                      "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                      "format": "int64",
+                      "minimum": 8,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "size"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spotMarketOptions": {
+                  "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
+                  "properties": {
+                    "maxPrice": {
+                      "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sshKeyName": {
+                  "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+                  "type": "string"
+                },
+                "subnet": {
+                  "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+                  "properties": {
+                    "arn": {
+                      "description": "ARN of resource",
+                      "type": "string"
+                    },
+                    "filters": {
+                      "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                      "items": {
+                        "description": "Filter is a filter used to identify an AWS resource",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the filter. Filter names are case-sensitive.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tenancy": {
+                  "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+                  "enum": [
+                    "default",
+                    "dedicated",
+                    "host"
+                  ],
+                  "type": "string"
+                },
+                "uncompressedUserData": {
+                  "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1alpha4.json
@@ -1,0 +1,348 @@
+{
+  "description": "AWSMachineTemplate is the Schema for the awsmachinetemplates API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate",
+      "properties": {
+        "template": {
+          "description": "AWSMachineTemplateResource describes the data needed to create am AWSMachine from a template",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "additionalSecurityGroups": {
+                  "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+                  "items": {
+                    "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+                    "properties": {
+                      "arn": {
+                        "description": "ARN of resource",
+                        "type": "string"
+                      },
+                      "filters": {
+                        "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                        "items": {
+                          "description": "Filter is a filter used to identify an AWS resource",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the filter. Filter names are case-sensitive.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "values"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "id": {
+                        "description": "ID of resource",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+                  "type": "object"
+                },
+                "ami": {
+                  "description": "AMI is the reference to the AMI from which to create the machine instance.",
+                  "properties": {
+                    "eksLookupType": {
+                      "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+                      "enum": [
+                        "AmazonLinux",
+                        "AmazonLinuxGPU"
+                      ],
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "cloudInit": {
+                  "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+                  "properties": {
+                    "insecureSkipSecretsManager": {
+                      "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+                      "type": "boolean"
+                    },
+                    "secretCount": {
+                      "description": "SecretCount is the number of secrets used to form the complete secret",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "secretPrefix": {
+                      "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+                      "type": "string"
+                    },
+                    "secureSecretsBackend": {
+                      "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+                      "enum": [
+                        "secrets-manager",
+                        "ssm-parameter-store"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. For this infrastructure provider, the ID is equivalent to an AWS Availability Zone. If multiple subnets are matched for the availability zone, the first one returned is picked.",
+                  "type": "string"
+                },
+                "iamInstanceProfile": {
+                  "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+                  "type": "string"
+                },
+                "imageLookupBaseOS": {
+                  "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+                  "type": "string"
+                },
+                "imageLookupFormat": {
+                  "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "type": "string"
+                },
+                "imageLookupOrg": {
+                  "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+                  "type": "string"
+                },
+                "instanceID": {
+                  "description": "InstanceID is the EC2 instance ID for this machine.",
+                  "type": "string"
+                },
+                "instanceType": {
+                  "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "networkInterfaces": {
+                  "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 2,
+                  "type": "array"
+                },
+                "nonRootVolumes": {
+                  "description": "Configuration options for the non root storage volumes.",
+                  "items": {
+                    "description": "Volume encapsulates the configuration options for the storage device",
+                    "properties": {
+                      "deviceName": {
+                        "description": "Device name",
+                        "type": "string"
+                      },
+                      "encrypted": {
+                        "description": "Encrypted is whether the volume should be encrypted or not.",
+                        "type": "boolean"
+                      },
+                      "encryptionKey": {
+                        "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                        "type": "string"
+                      },
+                      "iops": {
+                        "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "size": {
+                        "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                        "format": "int64",
+                        "minimum": 8,
+                        "type": "integer"
+                      },
+                      "throughput": {
+                        "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "type": {
+                        "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "size"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "publicIP": {
+                  "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+                  "type": "boolean"
+                },
+                "rootVolume": {
+                  "description": "RootVolume encapsulates the configuration options for the root volume",
+                  "properties": {
+                    "deviceName": {
+                      "description": "Device name",
+                      "type": "string"
+                    },
+                    "encrypted": {
+                      "description": "Encrypted is whether the volume should be encrypted or not.",
+                      "type": "boolean"
+                    },
+                    "encryptionKey": {
+                      "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                      "type": "string"
+                    },
+                    "iops": {
+                      "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "size": {
+                      "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                      "format": "int64",
+                      "minimum": 8,
+                      "type": "integer"
+                    },
+                    "throughput": {
+                      "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "type": {
+                      "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "size"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spotMarketOptions": {
+                  "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
+                  "properties": {
+                    "maxPrice": {
+                      "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sshKeyName": {
+                  "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+                  "type": "string"
+                },
+                "subnet": {
+                  "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+                  "properties": {
+                    "arn": {
+                      "description": "ARN of resource",
+                      "type": "string"
+                    },
+                    "filters": {
+                      "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                      "items": {
+                        "description": "Filter is a filter used to identify an AWS resource",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the filter. Filter names are case-sensitive.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tenancy": {
+                  "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+                  "enum": [
+                    "default",
+                    "dedicated",
+                    "host"
+                  ],
+                  "type": "string"
+                },
+                "uncompressedUserData": {
+                  "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "instanceType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta1.json
@@ -1,0 +1,407 @@
+{
+  "description": "AWSMachineTemplate is the schema for the Amazon EC2 Machine Templates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "AWSMachineTemplateResource describes the data needed to create am AWSMachine from a template.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "additionalSecurityGroups": {
+                  "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+                  "items": {
+                    "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                    "properties": {
+                      "arn": {
+                        "description": "ARN of resource. Deprecated: This field has no function and is going to be removed in the next release.",
+                        "type": "string"
+                      },
+                      "filters": {
+                        "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                        "items": {
+                          "description": "Filter is a filter used to identify an AWS resource.",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the filter. Filter names are case-sensitive.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "values"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "id": {
+                        "description": "ID of resource",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+                  "type": "object"
+                },
+                "ami": {
+                  "description": "AMI is the reference to the AMI from which to create the machine instance.",
+                  "properties": {
+                    "eksLookupType": {
+                      "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+                      "enum": [
+                        "AmazonLinux",
+                        "AmazonLinuxGPU"
+                      ],
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "cloudInit": {
+                  "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+                  "properties": {
+                    "insecureSkipSecretsManager": {
+                      "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+                      "type": "boolean"
+                    },
+                    "secretCount": {
+                      "description": "SecretCount is the number of secrets used to form the complete secret",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "secretPrefix": {
+                      "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+                      "type": "string"
+                    },
+                    "secureSecretsBackend": {
+                      "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+                      "enum": [
+                        "secrets-manager",
+                        "ssm-parameter-store"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. For this infrastructure provider, the ID is equivalent to an AWS Availability Zone. If multiple subnets are matched for the availability zone, the first one returned is picked.",
+                  "type": "string"
+                },
+                "iamInstanceProfile": {
+                  "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+                  "type": "string"
+                },
+                "ignition": {
+                  "description": "Ignition defined options related to the bootstrapping systems where Ignition is used.",
+                  "properties": {
+                    "version": {
+                      "default": "2.3",
+                      "description": "Version defines which version of Ignition will be used to generate bootstrap data.",
+                      "enum": [
+                        "2.3"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "imageLookupBaseOS": {
+                  "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+                  "type": "string"
+                },
+                "imageLookupFormat": {
+                  "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "type": "string"
+                },
+                "imageLookupOrg": {
+                  "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+                  "type": "string"
+                },
+                "instanceID": {
+                  "description": "InstanceID is the EC2 instance ID for this machine.",
+                  "type": "string"
+                },
+                "instanceType": {
+                  "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "networkInterfaces": {
+                  "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 2,
+                  "type": "array"
+                },
+                "nonRootVolumes": {
+                  "description": "Configuration options for the non root storage volumes.",
+                  "items": {
+                    "description": "Volume encapsulates the configuration options for the storage device.",
+                    "properties": {
+                      "deviceName": {
+                        "description": "Device name",
+                        "type": "string"
+                      },
+                      "encrypted": {
+                        "description": "Encrypted is whether the volume should be encrypted or not.",
+                        "type": "boolean"
+                      },
+                      "encryptionKey": {
+                        "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                        "type": "string"
+                      },
+                      "iops": {
+                        "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "size": {
+                        "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                        "format": "int64",
+                        "minimum": 8,
+                        "type": "integer"
+                      },
+                      "throughput": {
+                        "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "type": {
+                        "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "size"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "publicIP": {
+                  "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+                  "type": "boolean"
+                },
+                "rootVolume": {
+                  "description": "RootVolume encapsulates the configuration options for the root volume",
+                  "properties": {
+                    "deviceName": {
+                      "description": "Device name",
+                      "type": "string"
+                    },
+                    "encrypted": {
+                      "description": "Encrypted is whether the volume should be encrypted or not.",
+                      "type": "boolean"
+                    },
+                    "encryptionKey": {
+                      "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                      "type": "string"
+                    },
+                    "iops": {
+                      "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "size": {
+                      "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                      "format": "int64",
+                      "minimum": 8,
+                      "type": "integer"
+                    },
+                    "throughput": {
+                      "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "type": {
+                      "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "size"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spotMarketOptions": {
+                  "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
+                  "properties": {
+                    "maxPrice": {
+                      "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sshKeyName": {
+                  "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+                  "type": "string"
+                },
+                "subnet": {
+                  "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+                  "properties": {
+                    "arn": {
+                      "description": "ARN of resource. Deprecated: This field has no function and is going to be removed in the next release.",
+                      "type": "string"
+                    },
+                    "filters": {
+                      "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                      "items": {
+                        "description": "Filter is a filter used to identify an AWS resource.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the filter. Filter names are case-sensitive.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tenancy": {
+                  "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+                  "enum": [
+                    "default",
+                    "dedicated",
+                    "host"
+                  ],
+                  "type": "string"
+                },
+                "uncompressedUserData": {
+                  "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "instanceType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachineTemplateStatus defines a status for an AWSMachineTemplate.",
+      "properties": {
+        "capacity": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+            "x-kubernetes-int-or-string": true
+          },
+          "description": "Capacity defines the resource capacity for this machine. This value is used for autoscaling from zero operations as defined in: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta2.json
@@ -1,0 +1,437 @@
+{
+  "description": "AWSMachineTemplate is the schema for the Amazon EC2 Machine Templates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "AWSMachineTemplateResource describes the data needed to create am AWSMachine from a template.",
+          "properties": {
+            "metadata": {
+              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "additionalSecurityGroups": {
+                  "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+                  "items": {
+                    "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                    "properties": {
+                      "filters": {
+                        "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                        "items": {
+                          "description": "Filter is a filter used to identify an AWS resource.",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the filter. Filter names are case-sensitive.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "values"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "id": {
+                        "description": "ID of resource",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+                  "type": "object"
+                },
+                "ami": {
+                  "description": "AMI is the reference to the AMI from which to create the machine instance.",
+                  "properties": {
+                    "eksLookupType": {
+                      "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+                      "enum": [
+                        "AmazonLinux",
+                        "AmazonLinuxGPU"
+                      ],
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "cloudInit": {
+                  "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+                  "properties": {
+                    "insecureSkipSecretsManager": {
+                      "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+                      "type": "boolean"
+                    },
+                    "secretCount": {
+                      "description": "SecretCount is the number of secrets used to form the complete secret",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "secretPrefix": {
+                      "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+                      "type": "string"
+                    },
+                    "secureSecretsBackend": {
+                      "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+                      "enum": [
+                        "secrets-manager",
+                        "ssm-parameter-store"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "iamInstanceProfile": {
+                  "description": "IAMInstanceProfile is a name of an IAM instance profile to assign to the instance",
+                  "type": "string"
+                },
+                "ignition": {
+                  "description": "Ignition defined options related to the bootstrapping systems where Ignition is used.",
+                  "properties": {
+                    "version": {
+                      "default": "2.3",
+                      "description": "Version defines which version of Ignition will be used to generate bootstrap data.",
+                      "enum": [
+                        "2.3"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "imageLookupBaseOS": {
+                  "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+                  "type": "string"
+                },
+                "imageLookupFormat": {
+                  "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "type": "string"
+                },
+                "imageLookupOrg": {
+                  "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+                  "type": "string"
+                },
+                "instanceID": {
+                  "description": "InstanceID is the EC2 instance ID for this machine.",
+                  "type": "string"
+                },
+                "instanceMetadataOptions": {
+                  "description": "InstanceMetadataOptions is the metadata options for the EC2 instance.",
+                  "properties": {
+                    "httpEndpoint": {
+                      "default": "enabled",
+                      "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+                      "enum": [
+                        "enabled",
+                        "disabled"
+                      ],
+                      "type": "string"
+                    },
+                    "httpPutResponseHopLimit": {
+                      "default": 1,
+                      "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+                      "format": "int64",
+                      "maximum": 64,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "httpTokens": {
+                      "default": "required",
+                      "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+                      "enum": [
+                        "optional",
+                        "required"
+                      ],
+                      "type": "string"
+                    },
+                    "instanceMetadataTags": {
+                      "default": "disabled",
+                      "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+                      "enum": [
+                        "enabled",
+                        "disabled"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "instanceType": {
+                  "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+                  "minLength": 2,
+                  "type": "string"
+                },
+                "networkInterfaces": {
+                  "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 2,
+                  "type": "array"
+                },
+                "nonRootVolumes": {
+                  "description": "Configuration options for the non root storage volumes.",
+                  "items": {
+                    "description": "Volume encapsulates the configuration options for the storage device.",
+                    "properties": {
+                      "deviceName": {
+                        "description": "Device name",
+                        "type": "string"
+                      },
+                      "encrypted": {
+                        "description": "Encrypted is whether the volume should be encrypted or not.",
+                        "type": "boolean"
+                      },
+                      "encryptionKey": {
+                        "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                        "type": "string"
+                      },
+                      "iops": {
+                        "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "size": {
+                        "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                        "format": "int64",
+                        "minimum": 8,
+                        "type": "integer"
+                      },
+                      "throughput": {
+                        "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "type": {
+                        "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "size"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "publicIP": {
+                  "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+                  "type": "boolean"
+                },
+                "rootVolume": {
+                  "description": "RootVolume encapsulates the configuration options for the root volume",
+                  "properties": {
+                    "deviceName": {
+                      "description": "Device name",
+                      "type": "string"
+                    },
+                    "encrypted": {
+                      "description": "Encrypted is whether the volume should be encrypted or not.",
+                      "type": "boolean"
+                    },
+                    "encryptionKey": {
+                      "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                      "type": "string"
+                    },
+                    "iops": {
+                      "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "size": {
+                      "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                      "format": "int64",
+                      "minimum": 8,
+                      "type": "integer"
+                    },
+                    "throughput": {
+                      "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "type": {
+                      "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "size"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spotMarketOptions": {
+                  "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
+                  "properties": {
+                    "maxPrice": {
+                      "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sshKeyName": {
+                  "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+                  "type": "string"
+                },
+                "subnet": {
+                  "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+                  "properties": {
+                    "filters": {
+                      "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                      "items": {
+                        "description": "Filter is a filter used to identify an AWS resource.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the filter. Filter names are case-sensitive.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "ID of resource",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tenancy": {
+                  "description": "Tenancy indicates if instance should run on shared or single-tenant hardware.",
+                  "enum": [
+                    "default",
+                    "dedicated",
+                    "host"
+                  ],
+                  "type": "string"
+                },
+                "uncompressedUserData": {
+                  "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "instanceType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSMachineTemplateStatus defines a status for an AWSMachineTemplate.",
+      "properties": {
+        "capacity": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+            "x-kubernetes-int-or-string": true
+          },
+          "description": "Capacity defines the resource capacity for this machine. This value is used for autoscaling from zero operations as defined in: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmanagedcluster_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awsmanagedcluster_v1alpha3.json
@@ -1,0 +1,77 @@
+{
+  "description": "AWSManagedCluster is the Schema for the awsmanagedclusters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedClusterSpec defines the desired state of AWSManagedCluster",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedClusterStatus defines the observed state of AWSManagedCluster",
+      "properties": {
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains specifies a list fo available availability zones that can be used",
+          "type": "object"
+        },
+        "ready": {
+          "description": "Ready is when the AWSManagedControlPlane has a API server URL.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmanagedcluster_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmanagedcluster_v1beta2.json
@@ -1,0 +1,77 @@
+{
+  "description": "AWSManagedCluster is the Schema for the awsmanagedclusters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedClusterSpec defines the desired state of AWSManagedCluster",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedClusterStatus defines the observed state of AWSManagedCluster",
+      "properties": {
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains specifies a list fo available availability zones that can be used",
+          "type": "object"
+        },
+        "ready": {
+          "description": "Ready is when the AWSManagedControlPlane has a API server URL.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1alpha3.json
@@ -1,0 +1,196 @@
+{
+  "description": "AWSManagedMachinePool is the Schema for the awsmanagedmachinepools API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedMachinePoolSpec defines the desired state of AWSManagedMachinePool",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "amiType": {
+          "default": "AL2_x86_64",
+          "description": "AMIType defines the AMI type",
+          "enum": [
+            "AL2_x86_64",
+            "AL2_x86_64_GPU",
+            "AL2_ARM_64"
+          ],
+          "type": "string"
+        },
+        "amiVersion": {
+          "description": "AMIVersion defines the desired AMI release version. If no version number is supplied then the latest version for the Kubernetes version will be used",
+          "minLength": 2,
+          "type": "string"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones is an array of availability zones instances can run in",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "diskSize": {
+          "description": "DiskSize specifies the root disk size",
+          "format": "int32",
+          "type": "integer"
+        },
+        "eksNodegroupName": {
+          "description": "EKSNodegroupName specifies the name of the nodegroup in AWS corresponding to this MachinePool. If you don't specify a name then a default name will be created based on the namespace and name of the managed machine pool.",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "InstanceType specifies the AWS instance type",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels specifies labels for the Kubernetes node objects",
+          "type": "object"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the provider IDs of instances in the autoscaling group corresponding to the nodegroup represented by this machine pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "remoteAccess": {
+          "description": "RemoteAccess specifies how machines can be accessed remotely",
+          "properties": {
+            "public": {
+              "description": "Public specifies whether to open port 22 to the public internet",
+              "type": "boolean"
+            },
+            "sourceSecurityGroups": {
+              "description": "SourceSecurityGroups specifies which security groups are allowed access",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName specifies which EC2 SSH key can be used to access machines. If left empty, the key from the control plane is used.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role for the node group. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "type": "string"
+        },
+        "scaling": {
+          "description": "Scaling specifies scaling for the ASG behind this pool",
+          "properties": {
+            "maxSize": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "minSize": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subnetIDs": {
+          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedMachinePoolStatus defines the observed state of AWSManagedMachinePool",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the managed machine pool",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the AWSManagedMachinePool nodegroup has joined the cluster",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1alpha4.json
@@ -1,0 +1,238 @@
+{
+  "description": "AWSManagedMachinePool is the Schema for the awsmanagedmachinepools API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedMachinePoolSpec defines the desired state of AWSManagedMachinePool",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "amiType": {
+          "default": "AL2_x86_64",
+          "description": "AMIType defines the AMI type",
+          "enum": [
+            "AL2_x86_64",
+            "AL2_x86_64_GPU",
+            "AL2_ARM_64"
+          ],
+          "type": "string"
+        },
+        "amiVersion": {
+          "description": "AMIVersion defines the desired AMI release version. If no version number is supplied then the latest version for the Kubernetes version will be used",
+          "minLength": 2,
+          "type": "string"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones is an array of availability zones instances can run in",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "capacityType": {
+          "default": "onDemand",
+          "description": "CapacityType specifies the capacity type for the ASG behind this pool",
+          "enum": [
+            "onDemand",
+            "spot"
+          ],
+          "type": "string"
+        },
+        "diskSize": {
+          "description": "DiskSize specifies the root disk size",
+          "format": "int32",
+          "type": "integer"
+        },
+        "eksNodegroupName": {
+          "description": "EKSNodegroupName specifies the name of the nodegroup in AWS corresponding to this MachinePool. If you don't specify a name then a default name will be created based on the namespace and name of the managed machine pool.",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "InstanceType specifies the AWS instance type",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels specifies labels for the Kubernetes node objects",
+          "type": "object"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the provider IDs of instances in the autoscaling group corresponding to the nodegroup represented by this machine pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "remoteAccess": {
+          "description": "RemoteAccess specifies how machines can be accessed remotely",
+          "properties": {
+            "public": {
+              "description": "Public specifies whether to open port 22 to the public internet",
+              "type": "boolean"
+            },
+            "sourceSecurityGroups": {
+              "description": "SourceSecurityGroups specifies which security groups are allowed access",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName specifies which EC2 SSH key can be used to access machines. If left empty, the key from the control plane is used.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role for the node group. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "type": "string"
+        },
+        "scaling": {
+          "description": "Scaling specifies scaling for the ASG behind this pool",
+          "properties": {
+            "maxSize": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "minSize": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subnetIDs": {
+          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "taints": {
+          "description": "Taints specifies the taints to apply to the nodes of the machine pool",
+          "items": {
+            "description": "Taint defines the specs for a Kubernetes taint.",
+            "properties": {
+              "effect": {
+                "description": "Effect specifies the effect for the taint",
+                "enum": [
+                  "no-schedule",
+                  "no-execute",
+                  "prefer-no-schedule"
+                ],
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the key of the taint",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value is the value of the taint",
+                "type": "string"
+              }
+            },
+            "required": [
+              "effect",
+              "key",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedMachinePoolStatus defines the observed state of AWSManagedMachinePool",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the managed machine pool",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the AWSManagedMachinePool nodegroup has joined the cluster",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta1.json
@@ -1,0 +1,427 @@
+{
+  "description": "AWSManagedMachinePool is the Schema for the awsmanagedmachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedMachinePoolSpec defines the desired state of AWSManagedMachinePool.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "amiType": {
+          "default": "AL2_x86_64",
+          "description": "AMIType defines the AMI type",
+          "enum": [
+            "AL2_x86_64",
+            "AL2_x86_64_GPU",
+            "AL2_ARM_64",
+            "CUSTOM"
+          ],
+          "type": "string"
+        },
+        "amiVersion": {
+          "description": "AMIVersion defines the desired AMI release version. If no version number is supplied then the latest version for the Kubernetes version will be used",
+          "minLength": 2,
+          "type": "string"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones is an array of availability zones instances can run in",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "awsLaunchTemplate": {
+          "description": "AWSLaunchTemplate specifies the launch template to use to create the managed node group. If AWSLaunchTemplate is specified, certain node group configuraions outside of launch template are prohibited (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "items": {
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                "properties": {
+                  "filters": {
+                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "items": {
+                      "description": "Filter is a filter used to identify an AWS resource.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the filter. Filter names are case-sensitive.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "values"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI is the reference to the AMI from which to create the machine instance.",
+              "properties": {
+                "eksLookupType": {
+                  "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+                  "enum": [
+                    "AmazonLinux",
+                    "AmazonLinuxGPU"
+                  ],
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID of resource",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "iamInstanceProfile": {
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "type": "string"
+            },
+            "imageLookupBaseOS": {
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "type": "string"
+            },
+            "imageLookupFormat": {
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "type": "string"
+            },
+            "imageLookupOrg": {
+              "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+              "type": "string"
+            },
+            "instanceType": {
+              "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the launch template.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "RootVolume encapsulates the configuration options for the root volume",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions are options for configuring AWSMachinePool instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "type": "string"
+            },
+            "versionNumber": {
+              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "capacityType": {
+          "default": "onDemand",
+          "description": "CapacityType specifies the capacity type for the ASG behind this pool",
+          "enum": [
+            "onDemand",
+            "spot"
+          ],
+          "type": "string"
+        },
+        "diskSize": {
+          "description": "DiskSize specifies the root disk size",
+          "format": "int32",
+          "type": "integer"
+        },
+        "eksNodegroupName": {
+          "description": "EKSNodegroupName specifies the name of the nodegroup in AWS corresponding to this MachinePool. If you don't specify a name then a default name will be created based on the namespace and name of the managed machine pool.",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "InstanceType specifies the AWS instance type",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels specifies labels for the Kubernetes node objects",
+          "type": "object"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the provider IDs of instances in the autoscaling group corresponding to the nodegroup represented by this machine pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "remoteAccess": {
+          "description": "RemoteAccess specifies how machines can be accessed remotely",
+          "properties": {
+            "public": {
+              "description": "Public specifies whether to open port 22 to the public internet",
+              "type": "boolean"
+            },
+            "sourceSecurityGroups": {
+              "description": "SourceSecurityGroups specifies which security groups are allowed access",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName specifies which EC2 SSH key can be used to access machines. If left empty, the key from the control plane is used.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "roleAdditionalPolicies": {
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to the node group role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role for the node group. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "type": "string"
+        },
+        "scaling": {
+          "description": "Scaling specifies scaling for the ASG behind this pool",
+          "properties": {
+            "maxSize": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "minSize": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subnetIDs": {
+          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "taints": {
+          "description": "Taints specifies the taints to apply to the nodes of the machine pool",
+          "items": {
+            "description": "Taint defines the specs for a Kubernetes taint.",
+            "properties": {
+              "effect": {
+                "description": "Effect specifies the effect for the taint",
+                "enum": [
+                  "no-schedule",
+                  "no-execute",
+                  "prefer-no-schedule"
+                ],
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the key of the taint",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value is the value of the taint",
+                "type": "string"
+              }
+            },
+            "required": [
+              "effect",
+              "key",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "updateConfig": {
+          "description": "UpdateConfig holds the optional config to control the behaviour of the update to the nodegroup.",
+          "properties": {
+            "maxUnavailable": {
+              "description": "MaxUnavailable is the maximum number of nodes unavailable at once during a version update. Nodes will be updated in parallel. The maximum number is 100.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "maxUnavailablePrecentage": {
+              "description": "MaxUnavailablePercentage is the maximum percentage of nodes unavailable during a version update. This percentage of nodes will be updated in parallel, up to 100 nodes at once.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedMachinePoolStatus defines the observed state of AWSManagedMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the managed machine pool",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "launchTemplateID": {
+          "description": "The ID of the launch template",
+          "type": "string"
+        },
+        "launchTemplateVersion": {
+          "description": "The version of the launch template",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the AWSManagedMachinePool nodegroup has joined the cluster",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta2.json
@@ -1,0 +1,427 @@
+{
+  "description": "AWSManagedMachinePool is the Schema for the awsmanagedmachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AWSManagedMachinePoolSpec defines the desired state of AWSManagedMachinePool.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "amiType": {
+          "default": "AL2_x86_64",
+          "description": "AMIType defines the AMI type",
+          "enum": [
+            "AL2_x86_64",
+            "AL2_x86_64_GPU",
+            "AL2_ARM_64",
+            "CUSTOM"
+          ],
+          "type": "string"
+        },
+        "amiVersion": {
+          "description": "AMIVersion defines the desired AMI release version. If no version number is supplied then the latest version for the Kubernetes version will be used",
+          "minLength": 2,
+          "type": "string"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones is an array of availability zones instances can run in",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "awsLaunchTemplate": {
+          "description": "AWSLaunchTemplate specifies the launch template to use to create the managed node group. If AWSLaunchTemplate is specified, certain node group configuraions outside of launch template are prohibited (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).",
+          "properties": {
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "items": {
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                "properties": {
+                  "filters": {
+                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "items": {
+                      "description": "Filter is a filter used to identify an AWS resource.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the filter. Filter names are case-sensitive.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "values"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "ami": {
+              "description": "AMI is the reference to the AMI from which to create the machine instance.",
+              "properties": {
+                "eksLookupType": {
+                  "description": "EKSOptimizedLookupType If specified, will look up an EKS Optimized image in SSM Parameter store",
+                  "enum": [
+                    "AmazonLinux",
+                    "AmazonLinuxGPU"
+                  ],
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID of resource",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "iamInstanceProfile": {
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "type": "string"
+            },
+            "imageLookupBaseOS": {
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "type": "string"
+            },
+            "imageLookupFormat": {
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "type": "string"
+            },
+            "imageLookupOrg": {
+              "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
+              "type": "string"
+            },
+            "instanceType": {
+              "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the launch template.",
+              "type": "string"
+            },
+            "rootVolume": {
+              "description": "RootVolume encapsulates the configuration options for the root volume",
+              "properties": {
+                "deviceName": {
+                  "description": "Device name",
+                  "type": "string"
+                },
+                "encrypted": {
+                  "description": "Encrypted is whether the volume should be encrypted or not.",
+                  "type": "boolean"
+                },
+                "encryptionKey": {
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "type": "string"
+                },
+                "iops": {
+                  "description": "IOPS is the number of IOPS requested for the disk. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "size": {
+                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "format": "int64",
+                  "minimum": 8,
+                  "type": "integer"
+                },
+                "throughput": {
+                  "description": "Throughput to provision in MiB/s supported for the volume type. Not applicable to all types.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "type": {
+                  "description": "Type is the type of the volume (e.g. gp2, io1, etc...).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "size"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spotMarketOptions": {
+              "description": "SpotMarketOptions are options for configuring AWSMachinePool instances to be run using AWS Spot instances.",
+              "properties": {
+                "maxPrice": {
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "type": "string"
+            },
+            "versionNumber": {
+              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "capacityType": {
+          "default": "onDemand",
+          "description": "CapacityType specifies the capacity type for the ASG behind this pool",
+          "enum": [
+            "onDemand",
+            "spot"
+          ],
+          "type": "string"
+        },
+        "diskSize": {
+          "description": "DiskSize specifies the root disk size",
+          "format": "int32",
+          "type": "integer"
+        },
+        "eksNodegroupName": {
+          "description": "EKSNodegroupName specifies the name of the nodegroup in AWS corresponding to this MachinePool. If you don't specify a name then a default name will be created based on the namespace and name of the managed machine pool.",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "InstanceType specifies the AWS instance type",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels specifies labels for the Kubernetes node objects",
+          "type": "object"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the provider IDs of instances in the autoscaling group corresponding to the nodegroup represented by this machine pool",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "remoteAccess": {
+          "description": "RemoteAccess specifies how machines can be accessed remotely",
+          "properties": {
+            "public": {
+              "description": "Public specifies whether to open port 22 to the public internet",
+              "type": "boolean"
+            },
+            "sourceSecurityGroups": {
+              "description": "SourceSecurityGroups specifies which security groups are allowed access",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "sshKeyName": {
+              "description": "SSHKeyName specifies which EC2 SSH key can be used to access machines. If left empty, the key from the control plane is used.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "roleAdditionalPolicies": {
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to the node group role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleName": {
+          "description": "RoleName specifies the name of IAM role for the node group. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "type": "string"
+        },
+        "scaling": {
+          "description": "Scaling specifies scaling for the ASG behind this pool",
+          "properties": {
+            "maxSize": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "minSize": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subnetIDs": {
+          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "taints": {
+          "description": "Taints specifies the taints to apply to the nodes of the machine pool",
+          "items": {
+            "description": "Taint defines the specs for a Kubernetes taint.",
+            "properties": {
+              "effect": {
+                "description": "Effect specifies the effect for the taint",
+                "enum": [
+                  "no-schedule",
+                  "no-execute",
+                  "prefer-no-schedule"
+                ],
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the key of the taint",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value is the value of the taint",
+                "type": "string"
+              }
+            },
+            "required": [
+              "effect",
+              "key",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "updateConfig": {
+          "description": "UpdateConfig holds the optional config to control the behaviour of the update to the nodegroup.",
+          "properties": {
+            "maxUnavailable": {
+              "description": "MaxUnavailable is the maximum number of nodes unavailable at once during a version update. Nodes will be updated in parallel. The maximum number is 100.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "maxUnavailablePercentage": {
+              "description": "MaxUnavailablePercentage is the maximum percentage of nodes unavailable during a version update. This percentage of nodes will be updated in parallel, up to 100 nodes at once.",
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AWSManagedMachinePoolStatus defines the observed state of AWSManagedMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the managed machine pool",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "launchTemplateID": {
+          "description": "The ID of the launch template",
+          "type": "string"
+        },
+        "launchTemplateVersion": {
+          "description": "The version of the launch template",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the AWSManagedMachinePool nodegroup has joined the cluster",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds schemas for all CRs currently defined by the [Cluster API Provider AWS](https://github.com/kubernetes-sigs/cluster-api-provider-aws).

CRD sources:

```
# current/main

$ kustomize build github.com/kubernetes-sigs/cluster-api-provider-aws/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to awsclustercontrolleridentity_v1beta1.json
JSON schema written to awsclustercontrolleridentity_v1beta2.json
JSON schema written to awsmanagedcontrolplane_v1beta1.json
JSON schema written to awsmanagedcontrolplane_v1beta2.json
JSON schema written to awsmanagedmachinepool_v1beta1.json
JSON schema written to awsmanagedmachinepool_v1beta2.json
JSON schema written to eksconfig_v1beta1.json
JSON schema written to eksconfig_v1beta2.json
JSON schema written to eksconfigtemplate_v1beta1.json
JSON schema written to eksconfigtemplate_v1beta2.json
JSON schema written to awsclusterroleidentity_v1beta1.json
JSON schema written to awsclusterroleidentity_v1beta2.json
JSON schema written to awscluster_v1beta1.json
JSON schema written to awscluster_v1beta2.json
JSON schema written to awsclusterstaticidentity_v1beta1.json
JSON schema written to awsclusterstaticidentity_v1beta2.json
JSON schema written to awsclustertemplate_v1beta1.json
JSON schema written to awsclustertemplate_v1beta2.json
JSON schema written to awsfargateprofile_v1beta1.json
JSON schema written to awsfargateprofile_v1beta2.json
JSON schema written to awsmachinepool_v1beta1.json
JSON schema written to awsmachinepool_v1beta2.json
JSON schema written to awsmachine_v1beta1.json
JSON schema written to awsmachine_v1beta2.json
JSON schema written to awsmachinetemplate_v1beta1.json
JSON schema written to awsmachinetemplate_v1beta2.json
JSON schema written to awsmanagedcluster_v1beta2.json

# v1alpha3 (deprecated) + v1alpha4 (deprecated)

$ kustomize build 'github.com/kubernetes-sigs/cluster-api-provider-aws/config/crd?ref=v1.5.2' | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to awsclustercontrolleridentity_v1alpha3.json
JSON schema written to awsclustercontrolleridentity_v1alpha4.json
JSON schema written to awsclustercontrolleridentity_v1beta1.json   # skipped
JSON schema written to awsmanagedmachinepool_v1alpha3.json
JSON schema written to awsmanagedmachinepool_v1alpha4.json
JSON schema written to awsmanagedmachinepool_v1beta1.json          # skipped
JSON schema written to eksconfig_v1alpha3.json
JSON schema written to eksconfig_v1alpha4.json
JSON schema written to eksconfig_v1beta1.json                      # skipped
JSON schema written to eksconfigtemplate_v1alpha3.json
JSON schema written to eksconfigtemplate_v1alpha4.json
JSON schema written to eksconfigtemplate_v1beta1.json              # skipped
JSON schema written to awsclusterroleidentity_v1alpha3.json
JSON schema written to awsclusterroleidentity_v1alpha4.json
JSON schema written to awsclusterroleidentity_v1beta1.json         # skipped
JSON schema written to awscluster_v1alpha3.json
JSON schema written to awscluster_v1alpha4.json
JSON schema written to awscluster_v1beta1.json                     # skipped
JSON schema written to awsclusterstaticidentity_v1alpha3.json
JSON schema written to awsclusterstaticidentity_v1alpha4.json
JSON schema written to awsclusterstaticidentity_v1beta1.json       # skipped
JSON schema written to awsclustertemplate_v1alpha4.json
JSON schema written to awsclustertemplate_v1beta1.json             # skipped
JSON schema written to awsfargateprofile_v1alpha3.json
JSON schema written to awsfargateprofile_v1alpha4.json
JSON schema written to awsfargateprofile_v1beta1.json              # skipped
JSON schema written to awsmachinepool_v1alpha3.json
JSON schema written to awsmachinepool_v1alpha4.json
JSON schema written to awsmachinepool_v1beta1.json                 # skipped
JSON schema written to awsmachine_v1alpha3.json
JSON schema written to awsmachine_v1alpha4.json
JSON schema written to awsmachine_v1beta1.json                     # skipped
JSON schema written to awsmachinetemplate_v1alpha3.json
JSON schema written to awsmachinetemplate_v1alpha4.json
JSON schema written to awsmachinetemplate_v1beta1.json             # skipped
JSON schema written to awsmanagedcontrolplane_v1alpha3.json
JSON schema written to awsmanagedcontrolplane_v1alpha4.json
JSON schema written to awsmanagedcontrolplane_v1beta1.json         # skipped

# v1alpha3 (deprecated)

$ kustomize build 'github.com/kubernetes-sigs/cluster-api-provider-aws/config/crd?ref=v0.7.3' | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to awsclustercontrolleridentity_v1alpha3.json
JSON schema written to awsclustercontrolleridentity_v1alpha4.json  # skipped
JSON schema written to awsmanagedmachinepool_v1alpha3.json
JSON schema written to awsmanagedmachinepool_v1alpha4.json         # skipped
JSON schema written to eksconfig_v1alpha3.json
JSON schema written to eksconfig_v1alpha4.json                     # skipped
JSON schema written to eksconfigtemplate_v1alpha3.json
JSON schema written to eksconfigtemplate_v1alpha4.json             # skipped
JSON schema written to awsclusterroleidentity_v1alpha3.json
JSON schema written to awsclusterroleidentity_v1alpha4.json        # skipped
JSON schema written to awscluster_v1alpha3.json
JSON schema written to awscluster_v1alpha4.json                    # skipped
JSON schema written to awsclusterstaticidentity_v1alpha3.json
JSON schema written to awsclusterstaticidentity_v1alpha4.json      # skipped
JSON schema written to awsclustertemplate_v1alpha4.json            # skipped
JSON schema written to awsfargateprofile_v1alpha3.json
JSON schema written to awsfargateprofile_v1alpha4.json             # skipped
JSON schema written to awsmachinepool_v1alpha3.json
JSON schema written to awsmachinepool_v1alpha4.json                # skipped
JSON schema written to awsmachine_v1alpha3.json
JSON schema written to awsmachine_v1alpha4.json                    # skipped
JSON schema written to awsmachinetemplate_v1alpha3.json
JSON schema written to awsmachinetemplate_v1alpha4.json            # skipped
JSON schema written to awsmanagedcontrolplane_v1alpha3.json
JSON schema written to awsmanagedcontrolplane_v1alpha4.json        # skipped

# v1alpha2 (deprecated)

$ kustomize build 'github.com/kubernetes-sigs/cluster-api-provider-aws/config/crd?ref=v0.6.9' | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to awsclustercontrolleridentity_v1alpha3.json  # skipped
JSON schema written to awsclusterroleidentity_v1alpha3.json        # skipped
JSON schema written to awscluster_v1alpha2.json
JSON schema written to awscluster_v1alpha3.json                    # skipped
JSON schema written to awsclusterstaticidentity_v1alpha3.json      # skipped
JSON schema written to awsfargateprofile_v1alpha3.json             # skipped
JSON schema written to awsmachinepool_v1alpha3.json                # skipped
JSON schema written to awsmachine_v1alpha2.json
JSON schema written to awsmachine_v1alpha3.json                    # skipped
JSON schema written to awsmachinetemplate_v1alpha2.json
JSON schema written to awsmachinetemplate_v1alpha3.json            # skipped
JSON schema written to awsmanagedcluster_v1alpha3.json
JSON schema written to awsmanagedmachinepool_v1alpha3.json         # skipped

# v1alpha1 (deprecated)

$ kustomize build 'github.com/kubernetes-sigs/cluster-api-provider-aws/config/crds?ref=v0.3.9' | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to awsclusterproviderspec_v1alpha1.json
JSON schema written to awsclusterproviderstatus_v1alpha1.json
JSON schema written to awsmachineproviderspec_v1alpha1.json
JSON schema written to awsmachineproviderstatus_v1alpha1.json

```