### PR TITLE
Add Cluster API Provider Azure schemas

### DIFF
--- a/azureprovider.k8s.io/azureclusterproviderspec_v1alpha1.json
+++ b/azureprovider.k8s.io/azureclusterproviderspec_v1alpha1.json
@@ -1,0 +1,555 @@
+{
+  "properties": {
+    "adminKubeconfig": {
+      "description": "AdminKubeconfig generated using the certificates part of the spec do not move to status, since it uses on disk ca certs, which causes issues during regeneration",
+      "type": "string"
+    },
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "caKeyPair": {
+      "description": "CAKeyPair is the key pair for CA certs.",
+      "properties": {
+        "cert": {
+          "description": "base64 encoded cert and key",
+          "format": "byte",
+          "type": "string"
+        },
+        "key": {
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cert",
+        "key"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "clusterConfiguration": {
+      "description": "ClusterConfiguration holds the cluster-wide information used during a kubeadm init call.",
+      "properties": {
+        "apiServer": {
+          "description": "APIServer contains extra settings for the API server control plane component",
+          "properties": {
+            "certSANs": {
+              "description": "CertSANs sets extra Subject Alternative Names for the API Server signing cert.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "extraArgs": {
+              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+              "type": "object"
+            },
+            "extraVolumes": {
+              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+              "items": {
+                "properties": {
+                  "hostPath": {
+                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the volume inside the pod template.",
+                    "type": "string"
+                  },
+                  "pathType": {
+                    "description": "PathType is the type of the HostPath.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "ReadOnly controls write access to the volume",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "hostPath",
+                  "mountPath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "timeoutForControlPlane": {
+              "description": "TimeoutForControlPlane controls the timeout that we use for API server to appear",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "type": "string"
+        },
+        "certificatesDir": {
+          "description": "CertificatesDir specifies where to store or look for all required certificates.",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "The cluster name",
+          "type": "string"
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane.",
+          "type": "string"
+        },
+        "controllerManager": {
+          "description": "ControllerManager contains extra settings for the controller manager control plane component",
+          "properties": {
+            "extraArgs": {
+              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+              "type": "object"
+            },
+            "extraVolumes": {
+              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+              "items": {
+                "properties": {
+                  "hostPath": {
+                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the volume inside the pod template.",
+                    "type": "string"
+                  },
+                  "pathType": {
+                    "description": "PathType is the type of the HostPath.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "ReadOnly controls write access to the volume",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "hostPath",
+                  "mountPath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dns": {
+          "description": "DNS defines the options for the DNS add-on installed in the cluster.",
+          "properties": {
+            "imageRepository": {
+              "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+              "type": "string"
+            },
+            "imageTag": {
+              "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type defines the DNS add-on to be used",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "etcd": {
+          "description": "Etcd holds configuration for etcd.",
+          "properties": {
+            "external": {
+              "description": "External describes how to connect to an external etcd cluster Local and External are mutually exclusive",
+              "properties": {
+                "caFile": {
+                  "description": "CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.",
+                  "type": "string"
+                },
+                "certFile": {
+                  "description": "CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.",
+                  "type": "string"
+                },
+                "endpoints": {
+                  "description": "Endpoints of etcd members. Required for ExternalEtcd.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "keyFile": {
+                  "description": "KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "endpoints",
+                "caFile",
+                "certFile",
+                "keyFile"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "local": {
+              "description": "Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive",
+              "properties": {
+                "dataDir": {
+                  "description": "DataDir is the directory etcd will place its data. Defaults to \"/var/lib/etcd\".",
+                  "type": "string"
+                },
+                "extraArgs": {
+                  "description": "ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.",
+                  "type": "object"
+                },
+                "imageRepository": {
+                  "description": "ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.",
+                  "type": "string"
+                },
+                "imageTag": {
+                  "description": "ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.",
+                  "type": "string"
+                },
+                "peerCertSANs": {
+                  "description": "PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "serverCertSANs": {
+                  "description": "ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "dataDir"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "featureGates": {
+          "description": "FeatureGates enabled by the user.",
+          "type": "object"
+        },
+        "imageRepository": {
+          "description": "ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/kubernetes-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "kubernetesVersion": {
+          "description": "KubernetesVersion is the target version of the control plane.",
+          "type": "string"
+        },
+        "networking": {
+          "description": "Networking holds configuration for the networking topology of the cluster.",
+          "properties": {
+            "dnsDomain": {
+              "description": "DNSDomain is the dns domain used by k8s services. Defaults to \"cluster.local\".",
+              "type": "string"
+            },
+            "podSubnet": {
+              "description": "PodSubnet is the subnet used by pods.",
+              "type": "string"
+            },
+            "serviceSubnet": {
+              "description": "ServiceSubnet is the subnet used by k8s services. Defaults to \"10.96.0.0/12\".",
+              "type": "string"
+            }
+          },
+          "required": [
+            "serviceSubnet",
+            "podSubnet",
+            "dnsDomain"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "scheduler": {
+          "description": "Scheduler contains extra settings for the scheduler control plane component",
+          "properties": {
+            "extraArgs": {
+              "description": "ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.",
+              "type": "object"
+            },
+            "extraVolumes": {
+              "description": "ExtraVolumes is an extra set of host volumes, mounted to the control plane component.",
+              "items": {
+                "properties": {
+                  "hostPath": {
+                    "description": "HostPath is the path in the host that will be mounted inside the pod.",
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "description": "MountPath is the path inside the pod where hostPath will be mounted.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the volume inside the pod template.",
+                    "type": "string"
+                  },
+                  "pathType": {
+                    "description": "PathType is the type of the HostPath.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "ReadOnly controls write access to the volume",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "hostPath",
+                  "mountPath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "useHyperKubeImage": {
+          "description": "UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "etcd",
+        "networking",
+        "kubernetesVersion",
+        "controlPlaneEndpoint",
+        "dns",
+        "certificatesDir",
+        "imageRepository"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "discoveryHashes": {
+      "description": "DiscoveryHashes generated using the certificates part of the spec, used by master and nodes bootstrapping this never changes until ca is rotated do not move to status, since it uses on disk ca certs, which causes issues during regeneration",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "etcdCAKeyPair": {
+      "description": "EtcdCAKeyPair is the key pair for etcd.",
+      "properties": {
+        "cert": {
+          "description": "base64 encoded cert and key",
+          "format": "byte",
+          "type": "string"
+        },
+        "key": {
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cert",
+        "key"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "frontProxyCAKeyPair": {
+      "description": "FrontProxyCAKeyPair is the key pair for the front proxy.",
+      "properties": {
+        "cert": {
+          "description": "base64 encoded cert and key",
+          "format": "byte",
+          "type": "string"
+        },
+        "key": {
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cert",
+        "key"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "location": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "networkSpec": {
+      "description": "NetworkSpec encapsulates all things related to Azure network.",
+      "properties": {
+        "subnets": {
+          "description": "Subnets configuration.",
+          "items": {
+            "properties": {
+              "cidrBlock": {
+                "description": "CidrBlock is the CIDR block to be used when the provider creates a managed Vnet.",
+                "type": "string"
+              },
+              "id": {
+                "description": "ID defines a unique identifier to reference this resource.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name defines a name for the subnet resource.",
+                "type": "string"
+              },
+              "securityGroup": {
+                "description": "SecurityGroup defines the NSG (network security group) that should be attached to this subnet.",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "items": {
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "destination": {
+                          "description": "Destination - The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                          "type": "string"
+                        },
+                        "destinationPorts": {
+                          "description": "DestinationPorts - The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "description": "Source - The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                          "type": "string"
+                        },
+                        "sourcePorts": {
+                          "description": "SourcePorts - The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "protocol"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "ingressRule"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "vnetId": {
+                "description": "VnetID defines the ID of the virtual network this subnet should be built in.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "vnetId",
+              "securityGroup"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "vnet": {
+          "description": "Vnet configuration.",
+          "properties": {
+            "cidrBlock": {
+              "description": "CidrBlock is the CIDR block to be used when the provider creates a managed virtual network.",
+              "type": "string"
+            },
+            "id": {
+              "description": "ID is the identifier of the virtual network this provider should use to create resources.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name defines a name for the virtual network resource.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "resourceGroup": {
+      "type": "string"
+    },
+    "saKeyPair": {
+      "description": "SAKeyPair is the service account key pair.",
+      "properties": {
+        "cert": {
+          "description": "base64 encoded cert and key",
+          "format": "byte",
+          "type": "string"
+        },
+        "key": {
+          "format": "byte",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cert",
+        "key"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "resourceGroup",
+    "location"
+  ]
+}

--- a/azureprovider.k8s.io/azureclusterproviderstatus_v1alpha1.json
+++ b/azureprovider.k8s.io/azureclusterproviderstatus_v1alpha1.json
@@ -1,0 +1,156 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "bastion": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "identity": {
+          "type": "string"
+        },
+        "image": {
+          "description": "Storage profile",
+          "properties": {
+            "offer": {
+              "type": "string"
+            },
+            "publisher": {
+              "type": "string"
+            },
+            "sku": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "publisher",
+            "offer",
+            "sku",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "name": {
+          "type": "string"
+        },
+        "osDisk": {
+          "properties": {
+            "diskSizeGB": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "managedDisk": {
+              "properties": {
+                "storageAccountType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "storageAccountType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "osType": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "osType",
+            "managedDisk",
+            "diskSizeGB"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "startupScript": {
+          "type": "string"
+        },
+        "vmSize": {
+          "description": "Hardware profile",
+          "type": "string"
+        },
+        "vmState": {
+          "description": "State - The provisioning state, which only appears in the response.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "network": {
+      "properties": {
+        "apiServerIp": {
+          "description": "APIServerIP is the Kubernetes API server public IP address.",
+          "properties": {
+            "dnsName": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ipAddress": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "apiServerLb": {
+          "description": "APIServerLB is the Kubernetes API server load balancer.",
+          "properties": {
+            "backendPool": {
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "frontendIpConfig": {
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "sku": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "securityGroups": {
+          "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+}

--- a/azureprovider.k8s.io/azuremachineproviderspec_v1alpha1.json
+++ b/azureprovider.k8s.io/azuremachineproviderspec_v1alpha1.json
@@ -1,0 +1,85 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "image": {
+      "properties": {
+        "offer": {
+          "type": "string"
+        },
+        "publisher": {
+          "type": "string"
+        },
+        "sku": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "publisher",
+        "offer",
+        "sku",
+        "version"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "location": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "osDisk": {
+      "properties": {
+        "diskSizeGB": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "managedDisk": {
+          "properties": {
+            "storageAccountType": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "storageAccountType"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "osType": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "osType",
+        "managedDisk",
+        "diskSizeGB"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "sshPublicKey": {
+      "type": "string"
+    },
+    "vmSize": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "location",
+    "vmSize",
+    "image",
+    "osDisk",
+    "sshPublicKey"
+  ]
+}

--- a/azureprovider.k8s.io/azuremachineproviderstatus_v1alpha1.json
+++ b/azureprovider.k8s.io/azuremachineproviderstatus_v1alpha1.json
@@ -1,0 +1,67 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+    },
+    "conditions": {
+      "description": "Conditions is a set of conditions associated with the Machine to indicate errors or other status.",
+      "items": {
+        "properties": {
+          "lastProbeTime": {
+            "description": "LastProbeTime is the last time we probed the condition.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastTransitionTime": {
+            "description": "LastTransitionTime is the last time the condition transitioned from one status to another.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "message": {
+            "description": "Message is a human-readable message indicating details about last transition.",
+            "type": "string"
+          },
+          "reason": {
+            "description": "Reason is a unique, one-word, CamelCase reason for the condition's last transition.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status is the status of the condition.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Type is the type of the condition.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "status",
+          "lastProbeTime",
+          "lastTransitionTime",
+          "reason",
+          "message"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "type": "array"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "vmId": {
+      "description": "VMID is the ID of the virtual machine created in Azure.",
+      "type": "string"
+    },
+    "vmState": {
+      "description": "VMState is the provisioning state of the Azure virtual machine.",
+      "type": "string"
+    }
+  }
+}

--- a/infrastructure.cluster.x-k8s.io/azurecluster_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/azurecluster_v1alpha2.json
@@ -1,0 +1,459 @@
+{
+  "description": "AzureCluster is the Schema for the azureclusters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureClusterSpec defines the desired state of AzureCluster",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "location": {
+          "type": "string"
+        },
+        "networkSpec": {
+          "description": "NetworkSpec encapsulates all things related to Azure network.",
+          "properties": {
+            "subnets": {
+              "description": "Subnets is the configuration for the control-plane subnet and the node subnet.",
+              "items": {
+                "description": "SubnetSpec configures an Azure subnet.",
+                "properties": {
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed Vnet.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "internalLBIPAddress": {
+                    "description": "InternalLBIPAddress is the IP address that will be used as the internal LB private IP. For the control plane subnet only.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name defines a name for the subnet resource.",
+                    "type": "string"
+                  },
+                  "role": {
+                    "description": "Role defines the subnet role (eg. Node, ControlPlane)",
+                    "type": "string"
+                  },
+                  "securityGroup": {
+                    "description": "SecurityGroup defines the NSG (network security group) that should be attached to this subnet.",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "ingressRule": {
+                        "description": "IngressRules is a slice of Azure ingress rules for security groups.",
+                        "items": {
+                          "description": "IngressRule defines an Azure ingress rule for security groups.",
+                          "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "destination": {
+                              "description": "Destination - The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                              "type": "string"
+                            },
+                            "destinationPorts": {
+                              "description": "DestinationPorts - The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                              "type": "string"
+                            },
+                            "source": {
+                              "description": "Source - The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                              "type": "string"
+                            },
+                            "sourcePorts": {
+                              "description": "SourcePorts - The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "description",
+                            "protocol"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Tags defines a map of tags.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vnet": {
+              "description": "Vnet is the configuration for the Azure virtual network.",
+              "properties": {
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed virtual network.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "ID is the identifier of the virtual network this provider should use to create resources.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name defines a name for the virtual network resource.",
+                  "type": "string"
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup is the name of the resource group of the existing virtual network or the resource group where a managed virtual network should be created.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resourceGroup": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "location",
+        "resourceGroup"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureClusterStatus defines the observed state of AzureCluster",
+      "properties": {
+        "apiEndpoints": {
+          "description": "APIEndpoints represents the endpoints to communicate with the control plane.",
+          "items": {
+            "description": "APIEndpoint represents a reachable Kubernetes API endpoint.",
+            "properties": {
+              "host": {
+                "description": "The hostname on which the API server is serving.",
+                "type": "string"
+              },
+              "port": {
+                "description": "The port on which the API server is serving.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "host",
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bastion": {
+          "description": "VM describes an Azure virtual machine.",
+          "properties": {
+            "addresses": {
+              "description": "Addresses contains the Azure instance associated addresses.",
+              "items": {
+                "description": "NodeAddress contains information for the node's address.",
+                "properties": {
+                  "address": {
+                    "description": "The node address.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "address",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "availabilityZone": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "identity": {
+              "description": "VMIdentity defines the identity of the virtual machine, if configured.",
+              "type": "string"
+            },
+            "image": {
+              "description": "Storage profile",
+              "properties": {
+                "gallery": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "offer": {
+                  "type": "string"
+                },
+                "publisher": {
+                  "type": "string"
+                },
+                "resourceGroup": {
+                  "type": "string"
+                },
+                "sku": {
+                  "type": "string"
+                },
+                "subscriptionID": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "name": {
+              "type": "string"
+            },
+            "osDisk": {
+              "properties": {
+                "diskSizeGB": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "managedDisk": {
+                  "properties": {
+                    "storageAccountType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "storageAccountType"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "osType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "diskSizeGB",
+                "managedDisk",
+                "osType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startupScript": {
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Tags defines a map of tags.",
+              "type": "object"
+            },
+            "vmSize": {
+              "description": "Hardware profile",
+              "type": "string"
+            },
+            "vmState": {
+              "description": "State - The provisioning state, which only appears in the response.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "network": {
+          "description": "Network encapsulates Azure networking resources.",
+          "properties": {
+            "apiServerIp": {
+              "description": "APIServerIP is the Kubernetes API server public IP address.",
+              "properties": {
+                "dnsName": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "ipAddress": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "apiServerLb": {
+              "description": "APIServerLB is the Kubernetes API server load balancer.",
+              "properties": {
+                "backendPool": {
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "frontendIpConfig": {
+                  "type": "object"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "LoadBalancerSKU enumerates the values for load balancer sku name.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags defines a map of tags.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityGroups": {
+              "additionalProperties": {
+                "description": "SecurityGroup defines an Azure security group.",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "ingressRule": {
+                    "description": "IngressRules is a slice of Azure ingress rules for security groups.",
+                    "items": {
+                      "description": "IngressRule defines an Azure ingress rule for security groups.",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "destination": {
+                          "description": "Destination - The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                          "type": "string"
+                        },
+                        "destinationPorts": {
+                          "description": "DestinationPorts - The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "type": "string"
+                        },
+                        "source": {
+                          "description": "Source - The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                          "type": "string"
+                        },
+                        "sourcePorts": {
+                          "description": "SourcePorts - The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "protocol"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Tags defines a map of tags.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "description": "SecurityGroups is a map from the role/kind of the security group to its unique name, if any.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azurecluster_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/azurecluster_v1alpha3.json
@@ -1,0 +1,397 @@
+{
+  "description": "AzureCluster is the Schema for the azureclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureClusterSpec defines the desired state of AzureCluster.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a AzureIdentity to be used when reconciling this cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "location": {
+          "type": "string"
+        },
+        "networkSpec": {
+          "description": "NetworkSpec encapsulates all things related to Azure network.",
+          "properties": {
+            "apiServerLB": {
+              "description": "APIServerLB is the configuration for the control-plane load balancer.",
+              "properties": {
+                "frontendIPs": {
+                  "items": {
+                    "description": "FrontendIP defines a load balancer frontend IP configuration.",
+                    "properties": {
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "privateIP": {
+                        "type": "string"
+                      },
+                      "publicIP": {
+                        "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                        "properties": {
+                          "dnsName": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU defines an Azure load balancer SKU.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "LBType defines an Azure load balancer Type.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "subnets": {
+              "description": "Subnets is the configuration for the control-plane subnet and the node subnet.",
+              "items": {
+                "description": "SubnetSpec configures an Azure subnet.",
+                "properties": {
+                  "cidrBlock": {
+                    "description": "CidrBlock is the CIDR block to be used when the provider creates a managed Vnet. Deprecated: Use CIDRBlocks instead",
+                    "type": "string"
+                  },
+                  "cidrBlocks": {
+                    "description": "CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "internalLBIPAddress": {
+                    "description": "InternalLBIPAddress is the IP address that will be used as the internal LB private IP. For the control plane subnet only. Deprecated: Use LoadBalancer private IP instead",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name defines a name for the subnet resource.",
+                    "type": "string"
+                  },
+                  "role": {
+                    "description": "Role defines the subnet role (eg. Node, ControlPlane)",
+                    "type": "string"
+                  },
+                  "routeTable": {
+                    "description": "RouteTable defines the route table that should be attached to this subnet.",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "securityGroup": {
+                    "description": "SecurityGroup defines the NSG (network security group) that should be attached to this subnet.",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "ingressRule": {
+                        "description": "IngressRules is a slice of Azure ingress rules for security groups.",
+                        "items": {
+                          "description": "IngressRule defines an Azure ingress rule for security groups.",
+                          "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "destination": {
+                              "description": "Destination - The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                              "type": "string"
+                            },
+                            "destinationPorts": {
+                              "description": "DestinationPorts - The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "priority": {
+                              "description": "Priority - A number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "protocol": {
+                              "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                              "type": "string"
+                            },
+                            "source": {
+                              "description": "Source - The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                              "type": "string"
+                            },
+                            "sourcePorts": {
+                              "description": "SourcePorts - The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "description",
+                            "name",
+                            "protocol"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Tags defines a map of tags.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vnet": {
+              "description": "Vnet is the configuration for the Azure virtual network.",
+              "properties": {
+                "cidrBlock": {
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed virtual network. Deprecated: Use CIDRBlocks instead",
+                  "type": "string"
+                },
+                "cidrBlocks": {
+                  "description": "CIDRBlocks defines the virtual network's address space, specified as one or more address prefixes in CIDR notation.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "id": {
+                  "description": "ID is the identifier of the virtual network this provider should use to create resources.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name defines a name for the virtual network resource.",
+                  "type": "string"
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup is the name of the resource group of the existing virtual network or the resource group where a managed virtual network should be created.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resourceGroup": {
+          "type": "string"
+        },
+        "subscriptionID": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureClusterStatus defines the observed state of AzureCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains specifies the list of unique failure domains for the location/region of the cluster. A FailureDomain maps to Availability Zone with an Azure Region (if the region support them). An Availability Zone is a separate data center within a region and they can be used to ensure the cluster is more resilient to failure. See: https://learn.microsoft.com/azure/reliability/availability-zones-overview This list will be used by Cluster API to try and spread the machines across the failure domains.",
+          "type": "object"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azurecluster_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/azurecluster_v1alpha4.json
@@ -1,0 +1,925 @@
+{
+  "description": "AzureCluster is the Schema for the azureclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureClusterSpec defines the desired state of AzureCluster.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "azureEnvironment": {
+          "description": "AzureEnvironment is the name of the AzureCloud to be used. The default value that would be used by most users is \"AzurePublicCloud\", other values are: - ChinaCloud: \"AzureChinaCloud\" - GermanCloud: \"AzureGermanCloud\" - PublicCloud: \"AzurePublicCloud\" - USGovernmentCloud: \"AzureUSGovernmentCloud\"",
+          "type": "string"
+        },
+        "bastionSpec": {
+          "description": "BastionSpec encapsulates all things related to the Bastions in the cluster.",
+          "properties": {
+            "azureBastion": {
+              "description": "AzureBastion specifies how the Azure Bastion cloud component should be configured.",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "publicIP": {
+                  "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                  "properties": {
+                    "dnsName": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "subnet": {
+                  "description": "SubnetSpec configures an Azure subnet.",
+                  "properties": {
+                    "cidrBlocks": {
+                      "description": "CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "ID defines a unique identifier to reference this resource.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name defines a name for the subnet resource.",
+                      "type": "string"
+                    },
+                    "natGateway": {
+                      "description": "NatGateway associated with this subnet.",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "ip": {
+                          "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                          "properties": {
+                            "dnsName": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "role": {
+                      "description": "Role defines the subnet role (eg. Node, ControlPlane)",
+                      "type": "string"
+                    },
+                    "routeTable": {
+                      "description": "RouteTable defines the route table that should be attached to this subnet.",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "securityGroup": {
+                      "description": "SecurityGroup defines the NSG (network security group) that should be attached to this subnet.",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "securityRules": {
+                          "description": "SecurityRules is a slice of Azure security rules for security groups.",
+                          "items": {
+                            "description": "SecurityRule defines an Azure security rule for security groups.",
+                            "properties": {
+                              "description": {
+                                "description": "A description for this rule. Restricted to 140 chars.",
+                                "type": "string"
+                              },
+                              "destination": {
+                                "description": "Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                                "type": "string"
+                              },
+                              "destinationPorts": {
+                                "description": "DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                                "type": "string"
+                              },
+                              "direction": {
+                                "description": "Direction indicates whether the rule applies to inbound, or outbound traffic. \"Inbound\" or \"Outbound\".",
+                                "enum": [
+                                  "Inbound",
+                                  "Outbound"
+                                ],
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is a unique name within the network security group.",
+                                "type": "string"
+                              },
+                              "priority": {
+                                "description": "Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "description": "Protocol specifies the protocol type. \"Tcp\", \"Udp\", \"Icmp\", or \"*\".",
+                                "enum": [
+                                  "Tcp",
+                                  "Udp",
+                                  "Icmp",
+                                  "*"
+                                ],
+                                "type": "string"
+                              },
+                              "source": {
+                                "description": "Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                                "type": "string"
+                              },
+                              "sourcePorts": {
+                                "description": "SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "description",
+                              "direction",
+                              "name",
+                              "protocol"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "tags": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Tags defines a map of tags.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudProviderConfigOverrides": {
+          "description": "CloudProviderConfigOverrides is an optional set of configuration values that can be overridden in azure cloud provider config. This is only a subset of options that are available in azure cloud provider config. Some values for the cloud provider config are inferred from other parts of cluster api provider azure spec, and may not be available for overrides. See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs Note: All cloud provider config values can be customized by creating the secret beforehand. CloudProviderConfigOverrides is only used when the secret is managed by the Azure Provider.",
+          "properties": {
+            "backOffs": {
+              "description": "BackOffConfig indicates the back-off config options.",
+              "properties": {
+                "cloudProviderBackoff": {
+                  "type": "boolean"
+                },
+                "cloudProviderBackoffDuration": {
+                  "type": "integer"
+                },
+                "cloudProviderBackoffExponent": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "cloudProviderBackoffJitter": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "cloudProviderBackoffRetries": {
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rateLimits": {
+              "items": {
+                "description": "RateLimitSpec represents the rate limit configuration for a particular kind of resource. Eg. loadBalancerRateLimit is used to configure rate limits for load balancers. This eventually gets converted to CloudProviderRateLimitConfig that cloud-provider-azure expects. See: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/d585c2031925b39c925624302f22f8856e29e352/pkg/provider/azure_ratelimit.go#L25 We cannot use CloudProviderRateLimitConfig directly because floating point values are not supported in controller-tools. See: https://github.com/kubernetes-sigs/controller-tools/issues/245",
+                "properties": {
+                  "config": {
+                    "description": "RateLimitConfig indicates the rate limit config options.",
+                    "properties": {
+                      "cloudProviderRateLimit": {
+                        "type": "boolean"
+                      },
+                      "cloudProviderRateLimitBucket": {
+                        "type": "integer"
+                      },
+                      "cloudProviderRateLimitBucketWrite": {
+                        "type": "integer"
+                      },
+                      "cloudProviderRateLimitQPS": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "cloudProviderRateLimitQPSWrite": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Name is the name of the rate limit spec.",
+                    "enum": [
+                      "defaultRateLimit",
+                      "routeRateLimit",
+                      "subnetsRateLimit",
+                      "interfaceRateLimit",
+                      "routeTableRateLimit",
+                      "loadBalancerRateLimit",
+                      "publicIPAddressRateLimit",
+                      "securityGroupRateLimit",
+                      "virtualMachineRateLimit",
+                      "storageAccountRateLimit",
+                      "diskRateLimit",
+                      "snapshotRateLimit",
+                      "virtualMachineScaleSetRateLimit",
+                      "virtualMachineSizesRateLimit",
+                      "availabilitySetRateLimit"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to an AzureIdentity to be used when reconciling this cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "location": {
+          "type": "string"
+        },
+        "networkSpec": {
+          "description": "NetworkSpec encapsulates all things related to Azure network.",
+          "properties": {
+            "apiServerLB": {
+              "description": "APIServerLB is the configuration for the control-plane load balancer.",
+              "properties": {
+                "frontendIPs": {
+                  "items": {
+                    "description": "FrontendIP defines a load balancer frontend IP configuration.",
+                    "properties": {
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "privateIP": {
+                        "type": "string"
+                      },
+                      "publicIP": {
+                        "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                        "properties": {
+                          "dnsName": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "frontendIPsCount": {
+                  "description": "FrontendIPsCount specifies the number of frontend IP addresses for the load balancer.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "idleTimeoutInMinutes": {
+                  "description": "IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU defines an Azure load balancer SKU.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "LBType defines an Azure load balancer Type.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "controlPlaneOutboundLB": {
+              "description": "ControlPlaneOutboundLB is the configuration for the control-plane outbound load balancer. This is different from APIServerLB, and is used only in private clusters (optionally) for enabling outbound traffic.",
+              "properties": {
+                "frontendIPs": {
+                  "items": {
+                    "description": "FrontendIP defines a load balancer frontend IP configuration.",
+                    "properties": {
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "privateIP": {
+                        "type": "string"
+                      },
+                      "publicIP": {
+                        "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                        "properties": {
+                          "dnsName": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "frontendIPsCount": {
+                  "description": "FrontendIPsCount specifies the number of frontend IP addresses for the load balancer.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "idleTimeoutInMinutes": {
+                  "description": "IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU defines an Azure load balancer SKU.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "LBType defines an Azure load balancer Type.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeOutboundLB": {
+              "description": "NodeOutboundLB is the configuration for the node outbound load balancer.",
+              "properties": {
+                "frontendIPs": {
+                  "items": {
+                    "description": "FrontendIP defines a load balancer frontend IP configuration.",
+                    "properties": {
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "privateIP": {
+                        "type": "string"
+                      },
+                      "publicIP": {
+                        "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                        "properties": {
+                          "dnsName": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "frontendIPsCount": {
+                  "description": "FrontendIPsCount specifies the number of frontend IP addresses for the load balancer.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "idleTimeoutInMinutes": {
+                  "description": "IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU defines an Azure load balancer SKU.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "LBType defines an Azure load balancer Type.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "privateDNSZoneName": {
+              "description": "PrivateDNSZoneName defines the zone name for the Azure Private DNS.",
+              "type": "string"
+            },
+            "subnets": {
+              "description": "Subnets is the configuration for the control-plane subnet and the node subnet.",
+              "items": {
+                "description": "SubnetSpec configures an Azure subnet.",
+                "properties": {
+                  "cidrBlocks": {
+                    "description": "CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "ID defines a unique identifier to reference this resource.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name defines a name for the subnet resource.",
+                    "type": "string"
+                  },
+                  "natGateway": {
+                    "description": "NatGateway associated with this subnet.",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "ip": {
+                        "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                        "properties": {
+                          "dnsName": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "role": {
+                    "description": "Role defines the subnet role (eg. Node, ControlPlane)",
+                    "type": "string"
+                  },
+                  "routeTable": {
+                    "description": "RouteTable defines the route table that should be attached to this subnet.",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "securityGroup": {
+                    "description": "SecurityGroup defines the NSG (network security group) that should be attached to this subnet.",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "securityRules": {
+                        "description": "SecurityRules is a slice of Azure security rules for security groups.",
+                        "items": {
+                          "description": "SecurityRule defines an Azure security rule for security groups.",
+                          "properties": {
+                            "description": {
+                              "description": "A description for this rule. Restricted to 140 chars.",
+                              "type": "string"
+                            },
+                            "destination": {
+                              "description": "Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                              "type": "string"
+                            },
+                            "destinationPorts": {
+                              "description": "DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                              "type": "string"
+                            },
+                            "direction": {
+                              "description": "Direction indicates whether the rule applies to inbound, or outbound traffic. \"Inbound\" or \"Outbound\".",
+                              "enum": [
+                                "Inbound",
+                                "Outbound"
+                              ],
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is a unique name within the network security group.",
+                              "type": "string"
+                            },
+                            "priority": {
+                              "description": "Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "protocol": {
+                              "description": "Protocol specifies the protocol type. \"Tcp\", \"Udp\", \"Icmp\", or \"*\".",
+                              "enum": [
+                                "Tcp",
+                                "Udp",
+                                "Icmp",
+                                "*"
+                              ],
+                              "type": "string"
+                            },
+                            "source": {
+                              "description": "Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                              "type": "string"
+                            },
+                            "sourcePorts": {
+                              "description": "SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "description",
+                            "direction",
+                            "name",
+                            "protocol"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "tags": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Tags defines a map of tags.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vnet": {
+              "description": "Vnet is the configuration for the Azure virtual network.",
+              "properties": {
+                "cidrBlocks": {
+                  "description": "CIDRBlocks defines the virtual network's address space, specified as one or more address prefixes in CIDR notation.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "id": {
+                  "description": "ID is the identifier of the virtual network this provider should use to create resources.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name defines a name for the virtual network resource.",
+                  "type": "string"
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup is the name of the resource group of the existing virtual network or the resource group where a managed virtual network should be created.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resourceGroup": {
+          "type": "string"
+        },
+        "subscriptionID": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureClusterStatus defines the observed state of AzureCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains specifies the list of unique failure domains for the location/region of the cluster. A FailureDomain maps to Availability Zone with an Azure Region (if the region support them). An Availability Zone is a separate data center within a region and they can be used to ensure the cluster is more resilient to failure. See: https://learn.microsoft.com/azure/reliability/availability-zones-overview This list will be used by Cluster API to try and spread the machines across the failure domains.",
+          "type": "object"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azurecluster_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azurecluster_v1beta1.json
@@ -1,0 +1,1418 @@
+{
+  "description": "AzureCluster is the Schema for the azureclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureClusterSpec defines the desired state of AzureCluster.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "azureEnvironment": {
+          "description": "AzureEnvironment is the name of the AzureCloud to be used. The default value that would be used by most users is \"AzurePublicCloud\", other values are: - ChinaCloud: \"AzureChinaCloud\" - GermanCloud: \"AzureGermanCloud\" - PublicCloud: \"AzurePublicCloud\" - USGovernmentCloud: \"AzureUSGovernmentCloud\"",
+          "type": "string"
+        },
+        "bastionSpec": {
+          "description": "BastionSpec encapsulates all things related to the Bastions in the cluster.",
+          "properties": {
+            "azureBastion": {
+              "description": "AzureBastion specifies how the Azure Bastion cloud component should be configured.",
+              "properties": {
+                "enableTunneling": {
+                  "default": false,
+                  "description": "EnableTunneling enables the native client support feature for the Azure Bastion Host. Defaults to false.",
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "publicIP": {
+                  "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                  "properties": {
+                    "dnsName": {
+                      "type": "string"
+                    },
+                    "ipTags": {
+                      "items": {
+                        "description": "IPTag contains the IpTag associated with the object.",
+                        "properties": {
+                          "tag": {
+                            "description": "Tag specifies the value of the IP tag associated with the public IP. Example: SQL.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type specifies the IP tag type. Example: FirstPartyUsage.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "tag",
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sku": {
+                  "default": "Basic",
+                  "description": "BastionHostSkuName configures the tier of the Azure Bastion Host. Can be either Basic or Standard. Defaults to Basic.",
+                  "enum": [
+                    "Basic",
+                    "Standard"
+                  ],
+                  "type": "string"
+                },
+                "subnet": {
+                  "description": "SubnetSpec configures an Azure subnet.",
+                  "properties": {
+                    "cidrBlocks": {
+                      "description": "CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "ID is the Azure resource ID of the subnet. READ-ONLY",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name defines a name for the subnet resource.",
+                      "type": "string"
+                    },
+                    "natGateway": {
+                      "description": "NatGateway associated with this subnet.",
+                      "properties": {
+                        "id": {
+                          "description": "ID is the Azure resource ID of the NAT gateway. READ-ONLY",
+                          "type": "string"
+                        },
+                        "ip": {
+                          "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                          "properties": {
+                            "dnsName": {
+                              "type": "string"
+                            },
+                            "ipTags": {
+                              "items": {
+                                "description": "IPTag contains the IpTag associated with the object.",
+                                "properties": {
+                                  "tag": {
+                                    "description": "Tag specifies the value of the IP tag associated with the public IP. Example: SQL.",
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "description": "Type specifies the IP tag type. Example: FirstPartyUsage.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "tag",
+                                  "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "privateEndpoints": {
+                      "description": "PrivateEndpoints defines a list of private endpoints that should be attached to this subnet.",
+                      "items": {
+                        "description": "PrivateEndpointSpec configures an Azure Private Endpoint.",
+                        "properties": {
+                          "applicationSecurityGroups": {
+                            "description": "ApplicationSecurityGroups specifies the Application security group in which the private endpoint IP configuration is included.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "customNetworkInterfaceName": {
+                            "description": "CustomNetworkInterfaceName specifies the network interface name associated with the private endpoint.",
+                            "type": "string"
+                          },
+                          "location": {
+                            "description": "Location specifies the region to create the private endpoint.",
+                            "type": "string"
+                          },
+                          "manualApproval": {
+                            "description": "ManualApproval specifies if the connection approval needs to be done manually or not. Set it true when the network admin does not have access to approve connections to the remote resource. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "description": "Name specifies the name of the private endpoint.",
+                            "type": "string"
+                          },
+                          "privateIPAddresses": {
+                            "description": "PrivateIPAddresses specifies the IP addresses for the network interface associated with the private endpoint. They have to be part of the subnet where the private endpoint is linked.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "privateLinkServiceConnections": {
+                            "description": "PrivateLinkServiceConnections specifies Private Link Service Connections of the private endpoint.",
+                            "items": {
+                              "description": "PrivateLinkServiceConnection defines the specification for a private link service connection associated with a private endpoint.",
+                              "properties": {
+                                "groupIDs": {
+                                  "description": "GroupIDs specifies the ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name specifies the name of the private link service.",
+                                  "type": "string"
+                                },
+                                "privateLinkServiceID": {
+                                  "description": "PrivateLinkServiceID specifies the resource ID of the private link service.",
+                                  "type": "string"
+                                },
+                                "requestMessage": {
+                                  "description": "RequestMessage specifies a message passed to the owner of the remote resource with the private endpoint connection request.",
+                                  "maxLength": 140,
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "role": {
+                      "description": "Role defines the subnet role (eg. Node, ControlPlane)",
+                      "enum": [
+                        "node",
+                        "control-plane",
+                        "bastion"
+                      ],
+                      "type": "string"
+                    },
+                    "routeTable": {
+                      "description": "RouteTable defines the route table that should be attached to this subnet.",
+                      "properties": {
+                        "id": {
+                          "description": "ID is the Azure resource ID of the route table. READ-ONLY",
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "securityGroup": {
+                      "description": "SecurityGroup defines the NSG (network security group) that should be attached to this subnet.",
+                      "properties": {
+                        "id": {
+                          "description": "ID is the Azure resource ID of the security group. READ-ONLY",
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "securityRules": {
+                          "description": "SecurityRules is a slice of Azure security rules for security groups.",
+                          "items": {
+                            "description": "SecurityRule defines an Azure security rule for security groups.",
+                            "properties": {
+                              "description": {
+                                "description": "A description for this rule. Restricted to 140 chars.",
+                                "type": "string"
+                              },
+                              "destination": {
+                                "description": "Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                                "type": "string"
+                              },
+                              "destinationPorts": {
+                                "description": "DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                                "type": "string"
+                              },
+                              "direction": {
+                                "description": "Direction indicates whether the rule applies to inbound, or outbound traffic. \"Inbound\" or \"Outbound\".",
+                                "enum": [
+                                  "Inbound",
+                                  "Outbound"
+                                ],
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is a unique name within the network security group.",
+                                "type": "string"
+                              },
+                              "priority": {
+                                "description": "Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "description": "Protocol specifies the protocol type. \"Tcp\", \"Udp\", \"Icmp\", or \"*\".",
+                                "enum": [
+                                  "Tcp",
+                                  "Udp",
+                                  "Icmp",
+                                  "*"
+                                ],
+                                "type": "string"
+                              },
+                              "source": {
+                                "description": "Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                                "type": "string"
+                              },
+                              "sourcePorts": {
+                                "description": "SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "description",
+                              "direction",
+                              "name",
+                              "protocol"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "tags": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Tags defines a map of tags.",
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "serviceEndpoints": {
+                      "description": "ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.",
+                      "items": {
+                        "description": "ServiceEndpointSpec configures an Azure Service Endpoint.",
+                        "properties": {
+                          "locations": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "locations",
+                          "service"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "service"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "role"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudProviderConfigOverrides": {
+          "description": "CloudProviderConfigOverrides is an optional set of configuration values that can be overridden in azure cloud provider config. This is only a subset of options that are available in azure cloud provider config. Some values for the cloud provider config are inferred from other parts of cluster api provider azure spec, and may not be available for overrides. See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs Note: All cloud provider config values can be customized by creating the secret beforehand. CloudProviderConfigOverrides is only used when the secret is managed by the Azure Provider.",
+          "properties": {
+            "backOffs": {
+              "description": "BackOffConfig indicates the back-off config options.",
+              "properties": {
+                "cloudProviderBackoff": {
+                  "type": "boolean"
+                },
+                "cloudProviderBackoffDuration": {
+                  "type": "integer"
+                },
+                "cloudProviderBackoffExponent": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "cloudProviderBackoffJitter": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "cloudProviderBackoffRetries": {
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rateLimits": {
+              "items": {
+                "description": "RateLimitSpec represents the rate limit configuration for a particular kind of resource. Eg. loadBalancerRateLimit is used to configure rate limits for load balancers. This eventually gets converted to CloudProviderRateLimitConfig that cloud-provider-azure expects. See: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/d585c2031925b39c925624302f22f8856e29e352/pkg/provider/azure_ratelimit.go#L25 We cannot use CloudProviderRateLimitConfig directly because floating point values are not supported in controller-tools. See: https://github.com/kubernetes-sigs/controller-tools/issues/245",
+                "properties": {
+                  "config": {
+                    "description": "RateLimitConfig indicates the rate limit config options.",
+                    "properties": {
+                      "cloudProviderRateLimit": {
+                        "type": "boolean"
+                      },
+                      "cloudProviderRateLimitBucket": {
+                        "type": "integer"
+                      },
+                      "cloudProviderRateLimitBucketWrite": {
+                        "type": "integer"
+                      },
+                      "cloudProviderRateLimitQPS": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "cloudProviderRateLimitQPSWrite": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Name is the name of the rate limit spec.",
+                    "enum": [
+                      "defaultRateLimit",
+                      "routeRateLimit",
+                      "subnetsRateLimit",
+                      "interfaceRateLimit",
+                      "routeTableRateLimit",
+                      "loadBalancerRateLimit",
+                      "publicIPAddressRateLimit",
+                      "securityGroupRateLimit",
+                      "virtualMachineRateLimit",
+                      "storageAccountRateLimit",
+                      "diskRateLimit",
+                      "snapshotRateLimit",
+                      "virtualMachineScaleSetRateLimit",
+                      "virtualMachineSizesRateLimit",
+                      "availabilitySetRateLimit"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane. It is not recommended to set this when creating an AzureCluster as CAPZ will set this for you. However, if it is set, CAPZ will not change it.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "extendedLocation": {
+          "description": "ExtendedLocation is an optional set of ExtendedLocation properties for clusters on Azure public MEC.",
+          "properties": {
+            "name": {
+              "description": "Name defines the name for the extended location.",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type defines the type for the extended location.",
+              "enum": [
+                "EdgeZone"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to an AzureIdentity to be used when reconciling this cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "location": {
+          "type": "string"
+        },
+        "networkSpec": {
+          "description": "NetworkSpec encapsulates all things related to Azure network.",
+          "properties": {
+            "apiServerLB": {
+              "description": "APIServerLB is the configuration for the control-plane load balancer.",
+              "properties": {
+                "backendPool": {
+                  "description": "BackendPool describes the backend pool of the load balancer.",
+                  "properties": {
+                    "name": {
+                      "description": "Name specifies the name of backend pool for the load balancer. If not specified, the default name will be set, depending on the load balancer role.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "frontendIPs": {
+                  "items": {
+                    "description": "FrontendIP defines a load balancer frontend IP configuration.",
+                    "properties": {
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "privateIP": {
+                        "type": "string"
+                      },
+                      "publicIP": {
+                        "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                        "properties": {
+                          "dnsName": {
+                            "type": "string"
+                          },
+                          "ipTags": {
+                            "items": {
+                              "description": "IPTag contains the IpTag associated with the object.",
+                              "properties": {
+                                "tag": {
+                                  "description": "Tag specifies the value of the IP tag associated with the public IP. Example: SQL.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "Type specifies the IP tag type. Example: FirstPartyUsage.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "tag",
+                                "type"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "frontendIPsCount": {
+                  "description": "FrontendIPsCount specifies the number of frontend IP addresses for the load balancer.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "id": {
+                  "description": "ID is the Azure resource ID of the load balancer. READ-ONLY",
+                  "type": "string"
+                },
+                "idleTimeoutInMinutes": {
+                  "description": "IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU defines an Azure load balancer SKU.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "LBType defines an Azure load balancer Type.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "controlPlaneOutboundLB": {
+              "description": "ControlPlaneOutboundLB is the configuration for the control-plane outbound load balancer. This is different from APIServerLB, and is used only in private clusters (optionally) for enabling outbound traffic.",
+              "properties": {
+                "backendPool": {
+                  "description": "BackendPool describes the backend pool of the load balancer.",
+                  "properties": {
+                    "name": {
+                      "description": "Name specifies the name of backend pool for the load balancer. If not specified, the default name will be set, depending on the load balancer role.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "frontendIPs": {
+                  "items": {
+                    "description": "FrontendIP defines a load balancer frontend IP configuration.",
+                    "properties": {
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "privateIP": {
+                        "type": "string"
+                      },
+                      "publicIP": {
+                        "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                        "properties": {
+                          "dnsName": {
+                            "type": "string"
+                          },
+                          "ipTags": {
+                            "items": {
+                              "description": "IPTag contains the IpTag associated with the object.",
+                              "properties": {
+                                "tag": {
+                                  "description": "Tag specifies the value of the IP tag associated with the public IP. Example: SQL.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "Type specifies the IP tag type. Example: FirstPartyUsage.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "tag",
+                                "type"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "frontendIPsCount": {
+                  "description": "FrontendIPsCount specifies the number of frontend IP addresses for the load balancer.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "id": {
+                  "description": "ID is the Azure resource ID of the load balancer. READ-ONLY",
+                  "type": "string"
+                },
+                "idleTimeoutInMinutes": {
+                  "description": "IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU defines an Azure load balancer SKU.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "LBType defines an Azure load balancer Type.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeOutboundLB": {
+              "description": "NodeOutboundLB is the configuration for the node outbound load balancer.",
+              "properties": {
+                "backendPool": {
+                  "description": "BackendPool describes the backend pool of the load balancer.",
+                  "properties": {
+                    "name": {
+                      "description": "Name specifies the name of backend pool for the load balancer. If not specified, the default name will be set, depending on the load balancer role.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "frontendIPs": {
+                  "items": {
+                    "description": "FrontendIP defines a load balancer frontend IP configuration.",
+                    "properties": {
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "privateIP": {
+                        "type": "string"
+                      },
+                      "publicIP": {
+                        "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                        "properties": {
+                          "dnsName": {
+                            "type": "string"
+                          },
+                          "ipTags": {
+                            "items": {
+                              "description": "IPTag contains the IpTag associated with the object.",
+                              "properties": {
+                                "tag": {
+                                  "description": "Tag specifies the value of the IP tag associated with the public IP. Example: SQL.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "Type specifies the IP tag type. Example: FirstPartyUsage.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "tag",
+                                "type"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "frontendIPsCount": {
+                  "description": "FrontendIPsCount specifies the number of frontend IP addresses for the load balancer.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "id": {
+                  "description": "ID is the Azure resource ID of the load balancer. READ-ONLY",
+                  "type": "string"
+                },
+                "idleTimeoutInMinutes": {
+                  "description": "IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU defines an Azure load balancer SKU.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "LBType defines an Azure load balancer Type.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "privateDNSZoneName": {
+              "description": "PrivateDNSZoneName defines the zone name for the Azure Private DNS.",
+              "type": "string"
+            },
+            "subnets": {
+              "description": "Subnets is the configuration for the control-plane subnet and the node subnet.",
+              "items": {
+                "description": "SubnetSpec configures an Azure subnet.",
+                "properties": {
+                  "cidrBlocks": {
+                    "description": "CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "ID is the Azure resource ID of the subnet. READ-ONLY",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name defines a name for the subnet resource.",
+                    "type": "string"
+                  },
+                  "natGateway": {
+                    "description": "NatGateway associated with this subnet.",
+                    "properties": {
+                      "id": {
+                        "description": "ID is the Azure resource ID of the NAT gateway. READ-ONLY",
+                        "type": "string"
+                      },
+                      "ip": {
+                        "description": "PublicIPSpec defines the inputs to create an Azure public IP address.",
+                        "properties": {
+                          "dnsName": {
+                            "type": "string"
+                          },
+                          "ipTags": {
+                            "items": {
+                              "description": "IPTag contains the IpTag associated with the object.",
+                              "properties": {
+                                "tag": {
+                                  "description": "Tag specifies the value of the IP tag associated with the public IP. Example: SQL.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "Type specifies the IP tag type. Example: FirstPartyUsage.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "tag",
+                                "type"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "privateEndpoints": {
+                    "description": "PrivateEndpoints defines a list of private endpoints that should be attached to this subnet.",
+                    "items": {
+                      "description": "PrivateEndpointSpec configures an Azure Private Endpoint.",
+                      "properties": {
+                        "applicationSecurityGroups": {
+                          "description": "ApplicationSecurityGroups specifies the Application security group in which the private endpoint IP configuration is included.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "customNetworkInterfaceName": {
+                          "description": "CustomNetworkInterfaceName specifies the network interface name associated with the private endpoint.",
+                          "type": "string"
+                        },
+                        "location": {
+                          "description": "Location specifies the region to create the private endpoint.",
+                          "type": "string"
+                        },
+                        "manualApproval": {
+                          "description": "ManualApproval specifies if the connection approval needs to be done manually or not. Set it true when the network admin does not have access to approve connections to the remote resource. Defaults to false.",
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "description": "Name specifies the name of the private endpoint.",
+                          "type": "string"
+                        },
+                        "privateIPAddresses": {
+                          "description": "PrivateIPAddresses specifies the IP addresses for the network interface associated with the private endpoint. They have to be part of the subnet where the private endpoint is linked.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "privateLinkServiceConnections": {
+                          "description": "PrivateLinkServiceConnections specifies Private Link Service Connections of the private endpoint.",
+                          "items": {
+                            "description": "PrivateLinkServiceConnection defines the specification for a private link service connection associated with a private endpoint.",
+                            "properties": {
+                              "groupIDs": {
+                                "description": "GroupIDs specifies the ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "description": "Name specifies the name of the private link service.",
+                                "type": "string"
+                              },
+                              "privateLinkServiceID": {
+                                "description": "PrivateLinkServiceID specifies the resource ID of the private link service.",
+                                "type": "string"
+                              },
+                              "requestMessage": {
+                                "description": "RequestMessage specifies a message passed to the owner of the remote resource with the private endpoint connection request.",
+                                "maxLength": 140,
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "role": {
+                    "description": "Role defines the subnet role (eg. Node, ControlPlane)",
+                    "enum": [
+                      "node",
+                      "control-plane",
+                      "bastion"
+                    ],
+                    "type": "string"
+                  },
+                  "routeTable": {
+                    "description": "RouteTable defines the route table that should be attached to this subnet.",
+                    "properties": {
+                      "id": {
+                        "description": "ID is the Azure resource ID of the route table. READ-ONLY",
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "securityGroup": {
+                    "description": "SecurityGroup defines the NSG (network security group) that should be attached to this subnet.",
+                    "properties": {
+                      "id": {
+                        "description": "ID is the Azure resource ID of the security group. READ-ONLY",
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "securityRules": {
+                        "description": "SecurityRules is a slice of Azure security rules for security groups.",
+                        "items": {
+                          "description": "SecurityRule defines an Azure security rule for security groups.",
+                          "properties": {
+                            "description": {
+                              "description": "A description for this rule. Restricted to 140 chars.",
+                              "type": "string"
+                            },
+                            "destination": {
+                              "description": "Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                              "type": "string"
+                            },
+                            "destinationPorts": {
+                              "description": "DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                              "type": "string"
+                            },
+                            "direction": {
+                              "description": "Direction indicates whether the rule applies to inbound, or outbound traffic. \"Inbound\" or \"Outbound\".",
+                              "enum": [
+                                "Inbound",
+                                "Outbound"
+                              ],
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is a unique name within the network security group.",
+                              "type": "string"
+                            },
+                            "priority": {
+                              "description": "Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "protocol": {
+                              "description": "Protocol specifies the protocol type. \"Tcp\", \"Udp\", \"Icmp\", or \"*\".",
+                              "enum": [
+                                "Tcp",
+                                "Udp",
+                                "Icmp",
+                                "*"
+                              ],
+                              "type": "string"
+                            },
+                            "source": {
+                              "description": "Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                              "type": "string"
+                            },
+                            "sourcePorts": {
+                              "description": "SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "description",
+                            "direction",
+                            "name",
+                            "protocol"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "tags": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Tags defines a map of tags.",
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "serviceEndpoints": {
+                    "description": "ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.",
+                    "items": {
+                      "description": "ServiceEndpointSpec configures an Azure Service Endpoint.",
+                      "properties": {
+                        "locations": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "locations",
+                        "service"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "service"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  }
+                },
+                "required": [
+                  "name",
+                  "role"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "vnet": {
+              "description": "Vnet is the configuration for the Azure virtual network.",
+              "properties": {
+                "cidrBlocks": {
+                  "description": "CIDRBlocks defines the virtual network's address space, specified as one or more address prefixes in CIDR notation.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "id": {
+                  "description": "ID is the Azure resource ID of the virtual network. READ-ONLY",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name defines a name for the virtual network resource.",
+                  "type": "string"
+                },
+                "peerings": {
+                  "description": "Peerings defines a list of peerings of the newly created virtual network with existing virtual networks.",
+                  "items": {
+                    "description": "VnetPeeringSpec specifies an existing remote virtual network to peer with the AzureCluster's virtual network.",
+                    "properties": {
+                      "remoteVnetName": {
+                        "description": "RemoteVnetName defines name of the remote virtual network.",
+                        "type": "string"
+                      },
+                      "resourceGroup": {
+                        "description": "ResourceGroup is the resource group name of the remote virtual network.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "remoteVnetName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup is the name of the resource group of the existing virtual network or the resource group where a managed virtual network should be created.",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a collection of tags describing the resource.",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resourceGroup": {
+          "type": "string"
+        },
+        "subscriptionID": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureClusterStatus defines the observed state of AzureCluster.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureCluster.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "ControlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains specifies the list of unique failure domains for the location/region of the cluster. A FailureDomain maps to Availability Zone with an Azure Region (if the region support them). An Availability Zone is a separate data center within a region and they can be used to ensure the cluster is more resilient to failure. See: https://learn.microsoft.com/azure/reliability/availability-zones-overview This list will be used by Cluster API to try and spread the machines across the failure domains.",
+          "type": "object"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "data",
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azureclusteridentity_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/azureclusteridentity_v1alpha3.json
@@ -1,0 +1,119 @@
+{
+  "description": "AzureClusterIdentity is the Schema for the azureclustersidentities API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is an array of namespaces that AzureClusters can use this Identity from. \n An empty list (default) indicates that AzureClusters can use this Identity from any namespace. This field is intentionally not a pointer because the nil behavior (no namespaces) is undesirable here.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "clientID": {
+          "description": "Both User Assigned MSI and SP can use this field.",
+          "type": "string"
+        },
+        "clientSecret": {
+          "description": "ClientSecret is a secret reference which should contain either a Service Principal password or certificate secret.",
+          "properties": {
+            "name": {
+              "description": "name is unique within a namespace to reference a secret resource.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace defines the space within which the secret name must be unique.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "resourceID": {
+          "description": "User assigned MSI resource id.",
+          "type": "string"
+        },
+        "tenantID": {
+          "description": "Service principal primary tenant id.",
+          "type": "string"
+        },
+        "type": {
+          "description": "UserAssignedMSI or Service Principal",
+          "enum": [
+            "ServicePrincipal",
+            "UserAssignedMSI"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "clientID",
+        "tenantID",
+        "type"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureClusterIdentity.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azureclusteridentity_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/azureclusteridentity_v1alpha4.json
@@ -1,0 +1,173 @@
+{
+  "description": "AzureClusterIdentity is the Schema for the azureclustersidentities API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify the namespaces the clusters are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AzureClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "A nil or empty list indicates that AzureCluster cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "Selector is a selector of namespaces that AzureCluster can use this Identity from. This is a standard Kubernetes LabelSelector, a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. \n A nil or empty selector indicates that AzureCluster cannot use this AzureClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "clientID": {
+          "description": "Both User Assigned MSI and SP can use this field.",
+          "type": "string"
+        },
+        "clientSecret": {
+          "description": "ClientSecret is a secret reference which should contain either a Service Principal password or certificate secret.",
+          "properties": {
+            "name": {
+              "description": "name is unique within a namespace to reference a secret resource.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace defines the space within which the secret name must be unique.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "resourceID": {
+          "description": "User assigned MSI resource id.",
+          "type": "string"
+        },
+        "tenantID": {
+          "description": "Service principal primary tenant id.",
+          "type": "string"
+        },
+        "type": {
+          "description": "UserAssignedMSI or Service Principal",
+          "enum": [
+            "ServicePrincipal",
+            "UserAssignedMSI"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "clientID",
+        "tenantID",
+        "type"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureClusterIdentity.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azureclusteridentity_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azureclusteridentity_v1beta1.json
@@ -1,0 +1,176 @@
+{
+  "description": "AzureClusterIdentity is the Schema for the azureclustersidentities API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces is used to identify the namespaces the clusters are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AzureClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "nullable": true,
+          "properties": {
+            "list": {
+              "description": "A nil or empty list indicates that AzureCluster cannot use the identity from any namespace.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "selector": {
+              "description": "Selector is a selector of namespaces that AzureCluster can use this Identity from. This is a standard Kubernetes LabelSelector, a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. \n A nil or empty selector indicates that AzureCluster cannot use this AzureClusterIdentity from any namespace.",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "clientID": {
+          "description": "ClientID is the service principal client ID. Both User Assigned MSI and SP can use this field.",
+          "type": "string"
+        },
+        "clientSecret": {
+          "description": "ClientSecret is a secret reference which should contain either a Service Principal password or certificate secret.",
+          "properties": {
+            "name": {
+              "description": "name is unique within a namespace to reference a secret resource.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace defines the space within which the secret name must be unique.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "resourceID": {
+          "description": "ResourceID is the Azure resource ID for the User Assigned MSI resource. Only applicable when type is UserAssignedMSI.",
+          "type": "string"
+        },
+        "tenantID": {
+          "description": "TenantID is the service principal primary tenant id.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is the type of Azure Identity used. ServicePrincipal, ServicePrincipalCertificate, UserAssignedMSI or ManualServicePrincipal.",
+          "enum": [
+            "ServicePrincipal",
+            "UserAssignedMSI",
+            "ManualServicePrincipal",
+            "ServicePrincipalCertificate"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "clientID",
+        "tenantID",
+        "type"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureClusterIdentity.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azureclustertemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azureclustertemplate_v1beta1.json
@@ -1,0 +1,845 @@
+{
+  "description": "AzureClusterTemplate is the Schema for the azureclustertemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureClusterTemplateSpec defines the desired state of AzureClusterTemplate.",
+      "properties": {
+        "template": {
+          "description": "AzureClusterTemplateResource describes the data needed to create an AzureCluster from a template.",
+          "properties": {
+            "spec": {
+              "description": "AzureClusterTemplateResourceSpec specifies an Azure cluster template resource.",
+              "properties": {
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.",
+                  "type": "object"
+                },
+                "azureEnvironment": {
+                  "description": "AzureEnvironment is the name of the AzureCloud to be used. The default value that would be used by most users is \"AzurePublicCloud\", other values are: - ChinaCloud: \"AzureChinaCloud\" - GermanCloud: \"AzureGermanCloud\" - PublicCloud: \"AzurePublicCloud\" - USGovernmentCloud: \"AzureUSGovernmentCloud\"",
+                  "type": "string"
+                },
+                "bastionSpec": {
+                  "description": "BastionSpec encapsulates all things related to the Bastions in the cluster.",
+                  "properties": {
+                    "azureBastion": {
+                      "description": "AzureBastionTemplateSpec specifies a template for an Azure Bastion host.",
+                      "properties": {
+                        "subnet": {
+                          "description": "SubnetTemplateSpec specifies a template for a subnet.",
+                          "properties": {
+                            "cidrBlocks": {
+                              "description": "CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name defines a name for the subnet resource.",
+                              "type": "string"
+                            },
+                            "natGateway": {
+                              "description": "NatGateway associated with this subnet.",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "privateEndpoints": {
+                              "description": "PrivateEndpoints defines a list of private endpoints that should be attached to this subnet.",
+                              "items": {
+                                "description": "PrivateEndpointSpec configures an Azure Private Endpoint.",
+                                "properties": {
+                                  "applicationSecurityGroups": {
+                                    "description": "ApplicationSecurityGroups specifies the Application security group in which the private endpoint IP configuration is included.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "customNetworkInterfaceName": {
+                                    "description": "CustomNetworkInterfaceName specifies the network interface name associated with the private endpoint.",
+                                    "type": "string"
+                                  },
+                                  "location": {
+                                    "description": "Location specifies the region to create the private endpoint.",
+                                    "type": "string"
+                                  },
+                                  "manualApproval": {
+                                    "description": "ManualApproval specifies if the connection approval needs to be done manually or not. Set it true when the network admin does not have access to approve connections to the remote resource. Defaults to false.",
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "description": "Name specifies the name of the private endpoint.",
+                                    "type": "string"
+                                  },
+                                  "privateIPAddresses": {
+                                    "description": "PrivateIPAddresses specifies the IP addresses for the network interface associated with the private endpoint. They have to be part of the subnet where the private endpoint is linked.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "privateLinkServiceConnections": {
+                                    "description": "PrivateLinkServiceConnections specifies Private Link Service Connections of the private endpoint.",
+                                    "items": {
+                                      "description": "PrivateLinkServiceConnection defines the specification for a private link service connection associated with a private endpoint.",
+                                      "properties": {
+                                        "groupIDs": {
+                                          "description": "GroupIDs specifies the ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "description": "Name specifies the name of the private link service.",
+                                          "type": "string"
+                                        },
+                                        "privateLinkServiceID": {
+                                          "description": "PrivateLinkServiceID specifies the resource ID of the private link service.",
+                                          "type": "string"
+                                        },
+                                        "requestMessage": {
+                                          "description": "RequestMessage specifies a message passed to the owner of the remote resource with the private endpoint connection request.",
+                                          "maxLength": 140,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "role": {
+                              "description": "Role defines the subnet role (eg. Node, ControlPlane)",
+                              "enum": [
+                                "node",
+                                "control-plane",
+                                "bastion"
+                              ],
+                              "type": "string"
+                            },
+                            "securityGroup": {
+                              "description": "SecurityGroup defines the NSG (network security group) that should be attached to this subnet.",
+                              "properties": {
+                                "securityRules": {
+                                  "description": "SecurityRules is a slice of Azure security rules for security groups.",
+                                  "items": {
+                                    "description": "SecurityRule defines an Azure security rule for security groups.",
+                                    "properties": {
+                                      "description": {
+                                        "description": "A description for this rule. Restricted to 140 chars.",
+                                        "type": "string"
+                                      },
+                                      "destination": {
+                                        "description": "Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                                        "type": "string"
+                                      },
+                                      "destinationPorts": {
+                                        "description": "DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                                        "type": "string"
+                                      },
+                                      "direction": {
+                                        "description": "Direction indicates whether the rule applies to inbound, or outbound traffic. \"Inbound\" or \"Outbound\".",
+                                        "enum": [
+                                          "Inbound",
+                                          "Outbound"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is a unique name within the network security group.",
+                                        "type": "string"
+                                      },
+                                      "priority": {
+                                        "description": "Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "protocol": {
+                                        "description": "Protocol specifies the protocol type. \"Tcp\", \"Udp\", \"Icmp\", or \"*\".",
+                                        "enum": [
+                                          "Tcp",
+                                          "Udp",
+                                          "Icmp",
+                                          "*"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "source": {
+                                        "description": "Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                                        "type": "string"
+                                      },
+                                      "sourcePorts": {
+                                        "description": "SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "description",
+                                      "direction",
+                                      "name",
+                                      "protocol"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-map-keys": [
+                                    "name"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
+                                },
+                                "tags": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Tags defines a map of tags.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceEndpoints": {
+                              "description": "ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.",
+                              "items": {
+                                "description": "ServiceEndpointSpec configures an Azure Service Endpoint.",
+                                "properties": {
+                                  "locations": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "locations",
+                                  "service"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "service"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "role"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "cloudProviderConfigOverrides": {
+                  "description": "CloudProviderConfigOverrides is an optional set of configuration values that can be overridden in azure cloud provider config. This is only a subset of options that are available in azure cloud provider config. Some values for the cloud provider config are inferred from other parts of cluster api provider azure spec, and may not be available for overrides. See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs Note: All cloud provider config values can be customized by creating the secret beforehand. CloudProviderConfigOverrides is only used when the secret is managed by the Azure Provider.",
+                  "properties": {
+                    "backOffs": {
+                      "description": "BackOffConfig indicates the back-off config options.",
+                      "properties": {
+                        "cloudProviderBackoff": {
+                          "type": "boolean"
+                        },
+                        "cloudProviderBackoffDuration": {
+                          "type": "integer"
+                        },
+                        "cloudProviderBackoffExponent": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "cloudProviderBackoffJitter": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "cloudProviderBackoffRetries": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "rateLimits": {
+                      "items": {
+                        "description": "RateLimitSpec represents the rate limit configuration for a particular kind of resource. Eg. loadBalancerRateLimit is used to configure rate limits for load balancers. This eventually gets converted to CloudProviderRateLimitConfig that cloud-provider-azure expects. See: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/d585c2031925b39c925624302f22f8856e29e352/pkg/provider/azure_ratelimit.go#L25 We cannot use CloudProviderRateLimitConfig directly because floating point values are not supported in controller-tools. See: https://github.com/kubernetes-sigs/controller-tools/issues/245",
+                        "properties": {
+                          "config": {
+                            "description": "RateLimitConfig indicates the rate limit config options.",
+                            "properties": {
+                              "cloudProviderRateLimit": {
+                                "type": "boolean"
+                              },
+                              "cloudProviderRateLimitBucket": {
+                                "type": "integer"
+                              },
+                              "cloudProviderRateLimitBucketWrite": {
+                                "type": "integer"
+                              },
+                              "cloudProviderRateLimitQPS": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "cloudProviderRateLimitQPSWrite": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "description": "Name is the name of the rate limit spec.",
+                            "enum": [
+                              "defaultRateLimit",
+                              "routeRateLimit",
+                              "subnetsRateLimit",
+                              "interfaceRateLimit",
+                              "routeTableRateLimit",
+                              "loadBalancerRateLimit",
+                              "publicIPAddressRateLimit",
+                              "securityGroupRateLimit",
+                              "virtualMachineRateLimit",
+                              "storageAccountRateLimit",
+                              "diskRateLimit",
+                              "snapshotRateLimit",
+                              "virtualMachineScaleSetRateLimit",
+                              "virtualMachineSizesRateLimit",
+                              "availabilitySetRateLimit"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "extendedLocation": {
+                  "description": "ExtendedLocation is an optional set of ExtendedLocation properties for clusters on Azure public MEC.",
+                  "properties": {
+                    "name": {
+                      "description": "Name defines the name for the extended location.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type defines the type for the extended location.",
+                      "enum": [
+                        "EdgeZone"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "identityRef": {
+                  "description": "IdentityRef is a reference to an AzureIdentity to be used when reconciling this cluster",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "location": {
+                  "type": "string"
+                },
+                "networkSpec": {
+                  "description": "NetworkSpec encapsulates all things related to Azure network.",
+                  "properties": {
+                    "apiServerLB": {
+                      "description": "APIServerLB is the configuration for the control-plane load balancer.",
+                      "properties": {
+                        "idleTimeoutInMinutes": {
+                          "description": "IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "sku": {
+                          "description": "SKU defines an Azure load balancer SKU.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "LBType defines an Azure load balancer Type.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "controlPlaneOutboundLB": {
+                      "description": "ControlPlaneOutboundLB is the configuration for the control-plane outbound load balancer. This is different from APIServerLB, and is used only in private clusters (optionally) for enabling outbound traffic.",
+                      "properties": {
+                        "idleTimeoutInMinutes": {
+                          "description": "IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "sku": {
+                          "description": "SKU defines an Azure load balancer SKU.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "LBType defines an Azure load balancer Type.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodeOutboundLB": {
+                      "description": "NodeOutboundLB is the configuration for the node outbound load balancer.",
+                      "properties": {
+                        "idleTimeoutInMinutes": {
+                          "description": "IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "sku": {
+                          "description": "SKU defines an Azure load balancer SKU.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "LBType defines an Azure load balancer Type.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "privateDNSZoneName": {
+                      "description": "PrivateDNSZoneName defines the zone name for the Azure Private DNS.",
+                      "type": "string"
+                    },
+                    "subnets": {
+                      "description": "Subnets is the configuration for the control-plane subnet and the node subnet.",
+                      "items": {
+                        "description": "SubnetTemplateSpec specifies a template for a subnet.",
+                        "properties": {
+                          "cidrBlocks": {
+                            "description": "CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name defines a name for the subnet resource.",
+                            "type": "string"
+                          },
+                          "natGateway": {
+                            "description": "NatGateway associated with this subnet.",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privateEndpoints": {
+                            "description": "PrivateEndpoints defines a list of private endpoints that should be attached to this subnet.",
+                            "items": {
+                              "description": "PrivateEndpointSpec configures an Azure Private Endpoint.",
+                              "properties": {
+                                "applicationSecurityGroups": {
+                                  "description": "ApplicationSecurityGroups specifies the Application security group in which the private endpoint IP configuration is included.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "customNetworkInterfaceName": {
+                                  "description": "CustomNetworkInterfaceName specifies the network interface name associated with the private endpoint.",
+                                  "type": "string"
+                                },
+                                "location": {
+                                  "description": "Location specifies the region to create the private endpoint.",
+                                  "type": "string"
+                                },
+                                "manualApproval": {
+                                  "description": "ManualApproval specifies if the connection approval needs to be done manually or not. Set it true when the network admin does not have access to approve connections to the remote resource. Defaults to false.",
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "description": "Name specifies the name of the private endpoint.",
+                                  "type": "string"
+                                },
+                                "privateIPAddresses": {
+                                  "description": "PrivateIPAddresses specifies the IP addresses for the network interface associated with the private endpoint. They have to be part of the subnet where the private endpoint is linked.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "privateLinkServiceConnections": {
+                                  "description": "PrivateLinkServiceConnections specifies Private Link Service Connections of the private endpoint.",
+                                  "items": {
+                                    "description": "PrivateLinkServiceConnection defines the specification for a private link service connection associated with a private endpoint.",
+                                    "properties": {
+                                      "groupIDs": {
+                                        "description": "GroupIDs specifies the ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "description": "Name specifies the name of the private link service.",
+                                        "type": "string"
+                                      },
+                                      "privateLinkServiceID": {
+                                        "description": "PrivateLinkServiceID specifies the resource ID of the private link service.",
+                                        "type": "string"
+                                      },
+                                      "requestMessage": {
+                                        "description": "RequestMessage specifies a message passed to the owner of the remote resource with the private endpoint connection request.",
+                                        "maxLength": 140,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "role": {
+                            "description": "Role defines the subnet role (eg. Node, ControlPlane)",
+                            "enum": [
+                              "node",
+                              "control-plane",
+                              "bastion"
+                            ],
+                            "type": "string"
+                          },
+                          "securityGroup": {
+                            "description": "SecurityGroup defines the NSG (network security group) that should be attached to this subnet.",
+                            "properties": {
+                              "securityRules": {
+                                "description": "SecurityRules is a slice of Azure security rules for security groups.",
+                                "items": {
+                                  "description": "SecurityRule defines an Azure security rule for security groups.",
+                                  "properties": {
+                                    "description": {
+                                      "description": "A description for this rule. Restricted to 140 chars.",
+                                      "type": "string"
+                                    },
+                                    "destination": {
+                                      "description": "Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.",
+                                      "type": "string"
+                                    },
+                                    "destinationPorts": {
+                                      "description": "DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                                      "type": "string"
+                                    },
+                                    "direction": {
+                                      "description": "Direction indicates whether the rule applies to inbound, or outbound traffic. \"Inbound\" or \"Outbound\".",
+                                      "enum": [
+                                        "Inbound",
+                                        "Outbound"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name is a unique name within the network security group.",
+                                      "type": "string"
+                                    },
+                                    "priority": {
+                                      "description": "Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.",
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "protocol": {
+                                      "description": "Protocol specifies the protocol type. \"Tcp\", \"Udp\", \"Icmp\", or \"*\".",
+                                      "enum": [
+                                        "Tcp",
+                                        "Udp",
+                                        "Icmp",
+                                        "*"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "description": "Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.",
+                                      "type": "string"
+                                    },
+                                    "sourcePorts": {
+                                      "description": "SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "description",
+                                    "direction",
+                                    "name",
+                                    "protocol"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "tags": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "Tags defines a map of tags.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceEndpoints": {
+                            "description": "ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.",
+                            "items": {
+                              "description": "ServiceEndpointSpec configures an Azure Service Endpoint.",
+                              "properties": {
+                                "locations": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "service": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "locations",
+                                "service"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "service"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "role"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "vnet": {
+                      "description": "Vnet is the configuration for the Azure virtual network.",
+                      "properties": {
+                        "cidrBlocks": {
+                          "description": "CIDRBlocks defines the virtual network's address space, specified as one or more address prefixes in CIDR notation.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "peerings": {
+                          "description": "Peerings defines a list of peerings of the newly created virtual network with existing virtual networks.",
+                          "items": {
+                            "description": "VnetPeeringClassSpec specifies a virtual network peering class.",
+                            "properties": {
+                              "remoteVnetName": {
+                                "description": "RemoteVnetName defines name of the remote virtual network.",
+                                "type": "string"
+                              },
+                              "resourceGroup": {
+                                "description": "ResourceGroup is the resource group name of the remote virtual network.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "remoteVnetName"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "tags": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Tags is a collection of tags describing the resource.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "subscriptionID": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "location"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachine_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachine_v1alpha2.json
@@ -1,0 +1,176 @@
+{
+  "description": "AzureMachine is the Schema for the azuremachines API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachineSpec defines the desired state of AzureMachine",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+          "type": "object"
+        },
+        "allocatePublicIP": {
+          "description": "AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.",
+          "type": "boolean"
+        },
+        "availabilityZone": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "Image defines information about the image to use for VM creation. There are three ways to specify an image: by ID, by publisher, or by Shared Image Gallery. If specifying an image by ID, only the ID field needs to be set. If specifying an image by publisher, the Publisher, Offer, SKU, and Version fields must be set. If specifying an image from a Shared Image Gallery, the SubscriptionID, ResourceGroup, Gallery, Name, and Version fields must be set.",
+          "properties": {
+            "gallery": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "offer": {
+              "type": "string"
+            },
+            "publisher": {
+              "type": "string"
+            },
+            "resourceGroup": {
+              "type": "string"
+            },
+            "sku": {
+              "type": "string"
+            },
+            "subscriptionID": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "location": {
+          "type": "string"
+        },
+        "osDisk": {
+          "properties": {
+            "diskSizeGB": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "managedDisk": {
+              "properties": {
+                "storageAccountType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "storageAccountType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "osType": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "diskSizeGB",
+            "managedDisk",
+            "osType"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "sshPublicKey": {
+          "type": "string"
+        },
+        "vmSize": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "location",
+        "osDisk",
+        "sshPublicKey",
+        "vmSize"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureMachineStatus defines the observed state of AzureMachine",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the Azure instance associated addresses.",
+          "items": {
+            "description": "NodeAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The node address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "errorMessage": {
+          "description": "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "vmState": {
+          "description": "VMState is the provisioning state of the Azure virtual machine.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachine_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachine_v1alpha3.json
@@ -1,0 +1,436 @@
+{
+  "description": "AzureMachine is the Schema for the azuremachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachineSpec defines the desired state of AzureMachine.",
+      "properties": {
+        "acceleratedNetworking": {
+          "description": "AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.",
+          "type": "boolean"
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+          "type": "object"
+        },
+        "allocatePublicIP": {
+          "description": "AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.",
+          "type": "boolean"
+        },
+        "availabilityZone": {
+          "description": "Deprecated: use FailureDomain instead",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dataDisks": {
+          "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine",
+          "items": {
+            "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+            "properties": {
+              "cachingType": {
+                "type": "string"
+              },
+              "diskSizeGB": {
+                "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "lun": {
+                "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "managedDisk": {
+                "description": "ManagedDisk defines the managed disk options for a VM.",
+                "properties": {
+                  "diskEncryptionSet": {
+                    "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                    "properties": {
+                      "id": {
+                        "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageAccountType": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "storageAccountType"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nameSuffix": {
+                "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "diskSizeGB",
+              "nameSuffix"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "enableIPForwarding": {
+          "description": "EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.",
+          "type": "boolean"
+        },
+        "failureDomain": {
+          "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. This relates to an Azure Availability Zone",
+          "type": "string"
+        },
+        "identity": {
+          "default": "None",
+          "description": "Identity is the type of identity used for the virtual machine. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned"
+          ],
+          "type": "string"
+        },
+        "image": {
+          "description": "Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace \"capi\" offer, which is based on Ubuntu.",
+          "properties": {
+            "id": {
+              "description": "ID specifies an image to use by ID",
+              "type": "string"
+            },
+            "marketplace": {
+              "description": "Marketplace specifies an image to use from the Azure Marketplace",
+              "properties": {
+                "offer": {
+                  "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "publisher": {
+                  "description": "Publisher is the name of the organization that created the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "thirdPartyImage": {
+                  "default": false,
+                  "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                  "type": "boolean"
+                },
+                "version": {
+                  "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "offer",
+                "publisher",
+                "sku",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sharedGallery": {
+              "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery",
+              "properties": {
+                "gallery": {
+                  "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "subscriptionID": {
+                  "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "gallery",
+                "name",
+                "resourceGroup",
+                "subscriptionID",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "location": {
+          "description": "Deprecated: to support old clients, will be removed in v1alpha4/v1beta1",
+          "type": "string"
+        },
+        "osDisk": {
+          "description": "OSDisk specifies the parameters for the operating system disk of the machine",
+          "properties": {
+            "cachingType": {
+              "type": "string"
+            },
+            "diffDiskSettings": {
+              "description": "DiffDiskSettings describe ephemeral disk settings for the os disk.",
+              "properties": {
+                "option": {
+                  "description": "Option enables ephemeral OS when set to \"Local\" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details",
+                  "enum": [
+                    "Local"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "option"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "diskSizeGB": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "managedDisk": {
+              "description": "ManagedDisk defines the managed disk options for a VM.",
+              "properties": {
+                "diskEncryptionSet": {
+                  "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                  "properties": {
+                    "id": {
+                      "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "storageAccountType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "storageAccountType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "osType": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "diskSizeGB",
+            "managedDisk",
+            "osType"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "roleAssignmentName": {
+          "description": "RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.",
+          "type": "string"
+        },
+        "securityProfile": {
+          "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+          "properties": {
+            "encryptionAtHost": {
+              "description": "This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "spotVMOptions": {
+          "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM.",
+          "properties": {
+            "maxPrice": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshPublicKey": {
+          "type": "string"
+        },
+        "userAssignedIdentities": {
+          "description": "UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachine. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli",
+          "items": {
+            "description": "UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.",
+            "properties": {
+              "providerID": {
+                "description": "ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "vmSize": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "location",
+        "osDisk",
+        "sshPublicKey",
+        "vmSize"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureMachineStatus defines the observed state of AzureMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the Azure instance associated addresses.",
+          "items": {
+            "description": "NodeAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The node address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "vmState": {
+          "description": "VMState is the provisioning state of the Azure virtual machine.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachine_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachine_v1alpha4.json
@@ -1,0 +1,475 @@
+{
+  "description": "AzureMachine is the Schema for the azuremachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachineSpec defines the desired state of AzureMachine.",
+      "properties": {
+        "acceleratedNetworking": {
+          "description": "AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.",
+          "type": "boolean"
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+          "type": "object"
+        },
+        "allocatePublicIP": {
+          "description": "AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.",
+          "type": "boolean"
+        },
+        "dataDisks": {
+          "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine",
+          "items": {
+            "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+            "properties": {
+              "cachingType": {
+                "description": "CachingType specifies the caching requirements.",
+                "enum": [
+                  "None",
+                  "ReadOnly",
+                  "ReadWrite"
+                ],
+                "type": "string"
+              },
+              "diskSizeGB": {
+                "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "lun": {
+                "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "managedDisk": {
+                "description": "ManagedDisk specifies the Managed Disk parameters for the data disk.",
+                "properties": {
+                  "diskEncryptionSet": {
+                    "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                    "properties": {
+                      "id": {
+                        "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageAccountType": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nameSuffix": {
+                "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "diskSizeGB",
+              "nameSuffix"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "enableIPForwarding": {
+          "description": "EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.",
+          "type": "boolean"
+        },
+        "failureDomain": {
+          "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. This relates to an Azure Availability Zone",
+          "type": "string"
+        },
+        "identity": {
+          "default": "None",
+          "description": "Identity is the type of identity used for the virtual machine. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned"
+          ],
+          "type": "string"
+        },
+        "image": {
+          "description": "Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace \"capi\" offer, which is based on Ubuntu.",
+          "properties": {
+            "id": {
+              "description": "ID specifies an image to use by ID",
+              "type": "string"
+            },
+            "marketplace": {
+              "description": "Marketplace specifies an image to use from the Azure Marketplace",
+              "properties": {
+                "offer": {
+                  "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "publisher": {
+                  "description": "Publisher is the name of the organization that created the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "thirdPartyImage": {
+                  "default": false,
+                  "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                  "type": "boolean"
+                },
+                "version": {
+                  "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "offer",
+                "publisher",
+                "sku",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sharedGallery": {
+              "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery",
+              "properties": {
+                "gallery": {
+                  "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "offer": {
+                  "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "publisher": {
+                  "description": "Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "subscriptionID": {
+                  "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "gallery",
+                "name",
+                "resourceGroup",
+                "subscriptionID",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "osDisk": {
+          "description": "OSDisk specifies the parameters for the operating system disk of the machine",
+          "properties": {
+            "cachingType": {
+              "description": "CachingType specifies the caching requirements.",
+              "enum": [
+                "None",
+                "ReadOnly",
+                "ReadWrite"
+              ],
+              "type": "string"
+            },
+            "diffDiskSettings": {
+              "description": "DiffDiskSettings describe ephemeral disk settings for the os disk.",
+              "properties": {
+                "option": {
+                  "description": "Option enables ephemeral OS when set to \"Local\" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details",
+                  "enum": [
+                    "Local"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "option"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "diskSizeGB": {
+              "description": "DiskSizeGB is the size in GB to assign to the OS disk. Will have a default of 30GB if not provided",
+              "format": "int32",
+              "type": "integer"
+            },
+            "managedDisk": {
+              "description": "ManagedDisk specifies the Managed Disk parameters for the OS disk.",
+              "properties": {
+                "diskEncryptionSet": {
+                  "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                  "properties": {
+                    "id": {
+                      "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "storageAccountType": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "osType": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "osType"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "roleAssignmentName": {
+          "description": "RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.",
+          "type": "string"
+        },
+        "securityProfile": {
+          "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+          "properties": {
+            "encryptionAtHost": {
+              "description": "This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "spotVMOptions": {
+          "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM",
+          "properties": {
+            "maxPrice": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshPublicKey": {
+          "type": "string"
+        },
+        "subnetName": {
+          "description": "SubnetName selects the Subnet where the VM will be placed",
+          "type": "string"
+        },
+        "userAssignedIdentities": {
+          "description": "UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachine. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli",
+          "items": {
+            "description": "UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.",
+            "properties": {
+              "providerID": {
+                "description": "ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "vmSize": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "osDisk",
+        "sshPublicKey",
+        "vmSize"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureMachineStatus defines the observed state of AzureMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the Azure instance associated addresses.",
+          "items": {
+            "description": "NodeAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The node address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "vmState": {
+          "description": "VMState is the provisioning state of the Azure virtual machine.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachine_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachine_v1beta1.json
@@ -1,0 +1,691 @@
+{
+  "description": "AzureMachine is the Schema for the azuremachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachineSpec defines the desired state of AzureMachine.",
+      "properties": {
+        "acceleratedNetworking": {
+          "description": "Deprecated: AcceleratedNetworking should be set in the networkInterfaces field.",
+          "type": "boolean"
+        },
+        "additionalCapabilities": {
+          "description": "AdditionalCapabilities specifies additional capabilities enabled or disabled on the virtual machine.",
+          "properties": {
+            "ultraSSDEnabled": {
+              "description": "UltraSSDEnabled enables or disables Azure UltraSSD capability for the virtual machine. Defaults to true if Ultra SSD data disks are specified, otherwise it doesn't set the capability on the VM.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+          "type": "object"
+        },
+        "allocatePublicIP": {
+          "description": "AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.",
+          "type": "boolean"
+        },
+        "dataDisks": {
+          "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine",
+          "items": {
+            "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+            "properties": {
+              "cachingType": {
+                "description": "CachingType specifies the caching requirements.",
+                "enum": [
+                  "None",
+                  "ReadOnly",
+                  "ReadWrite"
+                ],
+                "type": "string"
+              },
+              "diskSizeGB": {
+                "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "lun": {
+                "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "managedDisk": {
+                "description": "ManagedDisk specifies the Managed Disk parameters for the data disk.",
+                "properties": {
+                  "diskEncryptionSet": {
+                    "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                    "properties": {
+                      "id": {
+                        "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageAccountType": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nameSuffix": {
+                "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "diskSizeGB",
+              "nameSuffix"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "diagnostics": {
+          "description": "Diagnostics specifies the diagnostics settings for a virtual machine. If not specified then Boot diagnostics (Managed) will be enabled.",
+          "properties": {
+            "boot": {
+              "description": "Boot configures the boot diagnostics settings for the virtual machine. This allows to configure capturing serial output from the virtual machine on boot. This is useful for debugging software based launch issues. If not specified then Boot diagnostics (Managed) will be enabled.",
+              "properties": {
+                "storageAccountType": {
+                  "description": "StorageAccountType determines if the storage account for storing the diagnostics data should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).",
+                  "enum": [
+                    "Managed",
+                    "UserManaged",
+                    "Disabled"
+                  ],
+                  "type": "string"
+                },
+                "userManaged": {
+                  "description": "UserManaged provides a reference to the user-managed storage account.",
+                  "properties": {
+                    "storageAccountURI": {
+                      "description": "StorageAccountURI is the URI of the user-managed storage account. The URI typically will be `https://<mystorageaccountname>.blob.core.windows.net/` but may differ if you are using Azure DNS zone endpoints. You can find the correct endpoint by looking for the Blob Primary Endpoint in the endpoints tab in the Azure console or with the CLI by issuing `az storage account list --query='[].{name: name, \"resource group\": resourceGroup, \"blob endpoint\": primaryEndpoints.blob}'`.",
+                      "maxLength": 1024,
+                      "pattern": "^https://",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "storageAccountURI"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "storageAccountType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dnsServers": {
+          "description": "DNSServers adds a list of DNS Server IP addresses to the VM NICs.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enableIPForwarding": {
+          "description": "EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.",
+          "type": "boolean"
+        },
+        "failureDomain": {
+          "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. This relates to an Azure Availability Zone",
+          "type": "string"
+        },
+        "identity": {
+          "default": "None",
+          "description": "Identity is the type of identity used for the virtual machine. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned"
+          ],
+          "type": "string"
+        },
+        "image": {
+          "description": "Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace \"capi\" offer, which is based on Ubuntu.",
+          "properties": {
+            "computeGallery": {
+              "description": "ComputeGallery specifies an image to use from the Azure Compute Gallery",
+              "properties": {
+                "gallery": {
+                  "description": "Gallery specifies the name of the compute image gallery that contains the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "plan": {
+                  "description": "Plan contains plan information.",
+                  "properties": {
+                    "offer": {
+                      "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "publisher": {
+                      "description": "Publisher is the name of the organization that created the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "sku": {
+                      "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "offer",
+                    "publisher",
+                    "sku"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup specifies the resource group containing the private compute gallery.",
+                  "type": "string"
+                },
+                "subscriptionID": {
+                  "description": "SubscriptionID is the identifier of the subscription that contains the private compute gallery.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "gallery",
+                "name",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID specifies an image to use by ID",
+              "type": "string"
+            },
+            "marketplace": {
+              "description": "Marketplace specifies an image to use from the Azure Marketplace",
+              "properties": {
+                "offer": {
+                  "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "publisher": {
+                  "description": "Publisher is the name of the organization that created the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "thirdPartyImage": {
+                  "default": false,
+                  "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                  "type": "boolean"
+                },
+                "version": {
+                  "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "offer",
+                "publisher",
+                "sku",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sharedGallery": {
+              "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery Deprecated: use ComputeGallery instead.",
+              "properties": {
+                "gallery": {
+                  "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "offer": {
+                  "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "publisher": {
+                  "description": "Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "subscriptionID": {
+                  "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "gallery",
+                "name",
+                "resourceGroup",
+                "subscriptionID",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "networkInterfaces": {
+          "description": "NetworkInterfaces specifies a list of network interface configurations. If left unspecified, the VM will get a single network interface with a single IPConfig in the subnet specified in the cluster's node subnet field. The primary interface will be the first networkInterface specified (index 0) in the list.",
+          "items": {
+            "description": "NetworkInterface defines a network interface.",
+            "properties": {
+              "acceleratedNetworking": {
+                "description": "AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.",
+                "type": "boolean"
+              },
+              "privateIPConfigs": {
+                "description": "PrivateIPConfigs specifies the number of private IP addresses to attach to the interface. Defaults to 1 if not specified.",
+                "type": "integer"
+              },
+              "subnetName": {
+                "description": "SubnetName specifies the subnet in which the new network interface will be placed.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "osDisk": {
+          "description": "OSDisk specifies the parameters for the operating system disk of the machine",
+          "properties": {
+            "cachingType": {
+              "description": "CachingType specifies the caching requirements.",
+              "enum": [
+                "None",
+                "ReadOnly",
+                "ReadWrite"
+              ],
+              "type": "string"
+            },
+            "diffDiskSettings": {
+              "description": "DiffDiskSettings describe ephemeral disk settings for the os disk.",
+              "properties": {
+                "option": {
+                  "description": "Option enables ephemeral OS when set to \"Local\" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details",
+                  "enum": [
+                    "Local"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "option"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "diskSizeGB": {
+              "description": "DiskSizeGB is the size in GB to assign to the OS disk. Will have a default of 30GB if not provided",
+              "format": "int32",
+              "type": "integer"
+            },
+            "managedDisk": {
+              "description": "ManagedDisk specifies the Managed Disk parameters for the OS disk.",
+              "properties": {
+                "diskEncryptionSet": {
+                  "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                  "properties": {
+                    "id": {
+                      "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "storageAccountType": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "osType": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "osType"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+          "type": "string"
+        },
+        "roleAssignmentName": {
+          "description": "Deprecated: RoleAssignmentName should be set in the systemAssignedIdentityRole field.",
+          "type": "string"
+        },
+        "securityProfile": {
+          "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+          "properties": {
+            "encryptionAtHost": {
+              "description": "This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "spotVMOptions": {
+          "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM",
+          "properties": {
+            "evictionPolicy": {
+              "description": "EvictionPolicy defines the behavior of the virtual machine when it is evicted. It can be either Delete or Deallocate.",
+              "enum": [
+                "Deallocate",
+                "Delete"
+              ],
+              "type": "string"
+            },
+            "maxPrice": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshPublicKey": {
+          "description": "SSHPublicKey is the SSH public key string, base64-encoded to add to a Virtual Machine. Linux only. Refer to documentation on how to set up SSH access on Windows instances.",
+          "type": "string"
+        },
+        "subnetName": {
+          "description": "Deprecated: SubnetName should be set in the networkInterfaces field.",
+          "type": "string"
+        },
+        "systemAssignedIdentityRole": {
+          "description": "SystemAssignedIdentityRole defines the role and scope to assign to the system-assigned identity.",
+          "properties": {
+            "definitionID": {
+              "description": "DefinitionID is the ID of the role definition to create for a system assigned identity. It can be an Azure built-in role or a custom role. Refer to built-in roles: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the role assignment to create for a system assigned identity. It can be any valid UUID. If not specified, a random UUID will be generated.",
+              "type": "string"
+            },
+            "scope": {
+              "description": "Scope is the scope that the role assignment or definition applies to. The scope can be any REST resource instance. If not specified, the scope will be the subscription.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "userAssignedIdentities": {
+          "description": "UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachine. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli",
+          "items": {
+            "description": "UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.",
+            "properties": {
+              "providerID": {
+                "description": "ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "vmExtensions": {
+          "description": "VMExtensions specifies a list of extensions to be added to the virtual machine.",
+          "items": {
+            "description": "VMExtension specifies the parameters for a custom VM extension.",
+            "properties": {
+              "name": {
+                "description": "Name is the name of the extension.",
+                "type": "string"
+              },
+              "protectedSettings": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "ProtectedSettings is a JSON formatted protected settings for the extension.",
+                "type": "object"
+              },
+              "publisher": {
+                "description": "Publisher is the name of the extension handler publisher.",
+                "type": "string"
+              },
+              "settings": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Settings is a JSON formatted public settings for the extension.",
+                "type": "object"
+              },
+              "version": {
+                "description": "Version specifies the version of the script handler.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "publisher",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "vmSize": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "osDisk",
+        "vmSize"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureMachineStatus defines the observed state of AzureMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the Azure instance associated addresses.",
+          "items": {
+            "description": "NodeAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The node address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureMachine.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "data",
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "vmState": {
+          "description": "VMState is the provisioning state of the Azure virtual machine.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachinepool_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachinepool_v1alpha3.json
@@ -1,0 +1,484 @@
+{
+  "description": "AzureMachinePool is the Schema for the azuremachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachinePoolSpec defines the desired state of AzureMachinePool.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+          "type": "object"
+        },
+        "identity": {
+          "default": "None",
+          "description": "Identity is the type of identity used for the Virtual Machine Scale Set. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned"
+          ],
+          "type": "string"
+        },
+        "location": {
+          "description": "Location is the Azure region location e.g. westus2",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Virtual Machine Scale Set",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleAssignmentName": {
+          "description": "RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.",
+          "type": "string"
+        },
+        "template": {
+          "description": "Template contains the details used to build a replica virtual machine within the Machine Pool.",
+          "properties": {
+            "acceleratedNetworking": {
+              "description": "AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.",
+              "type": "boolean"
+            },
+            "dataDisks": {
+              "description": "DataDisks specifies the list of data disks to be created for a Virtual Machine",
+              "items": {
+                "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+                "properties": {
+                  "cachingType": {
+                    "type": "string"
+                  },
+                  "diskSizeGB": {
+                    "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "lun": {
+                    "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "managedDisk": {
+                    "description": "ManagedDisk defines the managed disk options for a VM.",
+                    "properties": {
+                      "diskEncryptionSet": {
+                        "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                        "properties": {
+                          "id": {
+                            "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageAccountType": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "storageAccountType"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "nameSuffix": {
+                    "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "diskSizeGB",
+                  "nameSuffix"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "image": {
+              "description": "Image is used to provide details of an image to use during Virtual Machine creation. If image details are omitted the image will default the Azure Marketplace \"capi\" offer, which is based on Ubuntu.",
+              "properties": {
+                "id": {
+                  "description": "ID specifies an image to use by ID",
+                  "type": "string"
+                },
+                "marketplace": {
+                  "description": "Marketplace specifies an image to use from the Azure Marketplace",
+                  "properties": {
+                    "offer": {
+                      "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "publisher": {
+                      "description": "Publisher is the name of the organization that created the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "sku": {
+                      "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "thirdPartyImage": {
+                      "default": false,
+                      "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                      "type": "boolean"
+                    },
+                    "version": {
+                      "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "offer",
+                    "publisher",
+                    "sku",
+                    "version"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sharedGallery": {
+                  "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery",
+                  "properties": {
+                    "gallery": {
+                      "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "resourceGroup": {
+                      "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "subscriptionID": {
+                      "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "gallery",
+                    "name",
+                    "resourceGroup",
+                    "subscriptionID",
+                    "version"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "osDisk": {
+              "description": "OSDisk contains the operating system disk information for a Virtual Machine",
+              "properties": {
+                "cachingType": {
+                  "type": "string"
+                },
+                "diffDiskSettings": {
+                  "description": "DiffDiskSettings describe ephemeral disk settings for the os disk.",
+                  "properties": {
+                    "option": {
+                      "description": "Option enables ephemeral OS when set to \"Local\" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details",
+                      "enum": [
+                        "Local"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "option"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "diskSizeGB": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "managedDisk": {
+                  "description": "ManagedDisk defines the managed disk options for a VM.",
+                  "properties": {
+                    "diskEncryptionSet": {
+                      "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                      "properties": {
+                        "id": {
+                          "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "storageAccountType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "storageAccountType"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "osType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "diskSizeGB",
+                "managedDisk",
+                "osType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityProfile": {
+              "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+              "properties": {
+                "encryptionAtHost": {
+                  "description": "This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spotVMOptions": {
+              "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM",
+              "properties": {
+                "maxPrice": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshPublicKey": {
+              "description": "SSHPublicKey is the SSH public key string base64 encoded to add to a Virtual Machine",
+              "type": "string"
+            },
+            "terminateNotificationTimeout": {
+              "description": "TerminateNotificationTimeout enables or disables VMSS scheduled events termination notification with specified timeout allowed values are between 5 and 15 (mins)",
+              "type": "integer"
+            },
+            "vmSize": {
+              "description": "VMSize is the size of the Virtual Machine to build. See https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/createorupdate#virtualmachinesizetypes",
+              "type": "string"
+            }
+          },
+          "required": [
+            "osDisk",
+            "sshPublicKey",
+            "vmSize"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "userAssignedIdentities": {
+          "description": "UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachinePool. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli",
+          "items": {
+            "description": "UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.",
+            "properties": {
+              "providerID": {
+                "description": "ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "location",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureMachinePoolStatus defines the observed state of AzureMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instances": {
+          "description": "Instances is the VM instance status for each VM in the VMSS",
+          "items": {
+            "description": "AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.",
+            "properties": {
+              "instanceID": {
+                "description": "InstanceID is the identification of the Machine Instance within the VMSS",
+                "type": "string"
+              },
+              "instanceName": {
+                "description": "InstanceName is the name of the Machine Instance within the VMSS",
+                "type": "string"
+              },
+              "latestModelApplied": {
+                "description": "LatestModelApplied indicates the instance is running the most up-to-date VMSS model. A VMSS model describes the image version the VM is running. If the instance is not running the latest model, it means the instance may not be running the version of Kubernetes the Machine Pool has specified and needs to be updated.",
+                "type": "boolean"
+              },
+              "providerID": {
+                "description": "ProviderID is the provider identification of the VMSS Instance",
+                "type": "string"
+              },
+              "provisioningState": {
+                "description": "ProvisioningState is the provisioning state of the Azure virtual machine instance.",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the VM Instance",
+                "type": "string"
+              }
+            },
+            "required": [
+              "latestModelApplied"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "longRunningOperationState": {
+          "description": "LongRunningOperationState saves the state for an Azure long running operations so it can be continued on the next reconciliation loop.",
+          "properties": {
+            "futureData": {
+              "description": "FutureData is the base64 url encoded json Azure AutoRest Future.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the Azure resource.",
+              "type": "string"
+            },
+            "resourceGroup": {
+              "description": "ResourceGroup is the Azure resource group for the resource.",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type describes the type of future, update, create, delete, etc.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "provisioningState": {
+          "description": "ProvisioningState is the provisioning state of the Azure virtual machine.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "version": {
+          "description": "Version is the Kubernetes version for the current VMSS model",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachinepool_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachinepool_v1alpha4.json
@@ -1,0 +1,685 @@
+{
+  "description": "AzureMachinePool is the Schema for the azuremachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachinePoolSpec defines the desired state of AzureMachinePool.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+          "type": "object"
+        },
+        "identity": {
+          "default": "None",
+          "description": "Identity is the type of identity used for the Virtual Machine Scale Set. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned"
+          ],
+          "type": "string"
+        },
+        "location": {
+          "description": "Location is the Azure region location e.g. westus2",
+          "type": "string"
+        },
+        "nodeDrainTimeout": {
+          "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Virtual Machine Scale Set",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleAssignmentName": {
+          "description": "RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.",
+          "type": "string"
+        },
+        "strategy": {
+          "default": {
+            "rollingUpdate": {
+              "deletePolicy": "Oldest",
+              "maxSurge": 1,
+              "maxUnavailable": 0
+            },
+            "type": "RollingUpdate"
+          },
+          "description": "The deployment strategy to use to replace existing AzureMachinePoolMachines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+              "properties": {
+                "deletePolicy": {
+                  "default": "Oldest",
+                  "description": "DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are \"Random, \"Newest\", \"Oldest\" When no value is supplied, the default is Oldest",
+                  "enum": [
+                    "Random",
+                    "Newest",
+                    "Oldest"
+                  ],
+                  "type": "string"
+                },
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": 1,
+                  "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": 0,
+                  "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "default": "RollingUpdate",
+              "description": "Type of deployment. Currently the only supported strategy is RollingUpdate",
+              "enum": [
+                "RollingUpdate"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template contains the details used to build a replica virtual machine within the Machine Pool",
+          "properties": {
+            "acceleratedNetworking": {
+              "description": "AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.",
+              "type": "boolean"
+            },
+            "dataDisks": {
+              "description": "DataDisks specifies the list of data disks to be created for a Virtual Machine",
+              "items": {
+                "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+                "properties": {
+                  "cachingType": {
+                    "description": "CachingType specifies the caching requirements.",
+                    "enum": [
+                      "None",
+                      "ReadOnly",
+                      "ReadWrite"
+                    ],
+                    "type": "string"
+                  },
+                  "diskSizeGB": {
+                    "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "lun": {
+                    "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "managedDisk": {
+                    "description": "ManagedDisk specifies the Managed Disk parameters for the data disk.",
+                    "properties": {
+                      "diskEncryptionSet": {
+                        "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                        "properties": {
+                          "id": {
+                            "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageAccountType": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "nameSuffix": {
+                    "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "diskSizeGB",
+                  "nameSuffix"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "image": {
+              "description": "Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace \"capi\" offer, which is based on Ubuntu.",
+              "properties": {
+                "id": {
+                  "description": "ID specifies an image to use by ID",
+                  "type": "string"
+                },
+                "marketplace": {
+                  "description": "Marketplace specifies an image to use from the Azure Marketplace",
+                  "properties": {
+                    "offer": {
+                      "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "publisher": {
+                      "description": "Publisher is the name of the organization that created the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "sku": {
+                      "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "thirdPartyImage": {
+                      "default": false,
+                      "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                      "type": "boolean"
+                    },
+                    "version": {
+                      "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "offer",
+                    "publisher",
+                    "sku",
+                    "version"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sharedGallery": {
+                  "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery",
+                  "properties": {
+                    "gallery": {
+                      "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "offer": {
+                      "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                      "type": "string"
+                    },
+                    "publisher": {
+                      "description": "Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                      "type": "string"
+                    },
+                    "resourceGroup": {
+                      "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "sku": {
+                      "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                      "type": "string"
+                    },
+                    "subscriptionID": {
+                      "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "gallery",
+                    "name",
+                    "resourceGroup",
+                    "subscriptionID",
+                    "version"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "osDisk": {
+              "description": "OSDisk contains the operating system disk information for a Virtual Machine",
+              "properties": {
+                "cachingType": {
+                  "description": "CachingType specifies the caching requirements.",
+                  "enum": [
+                    "None",
+                    "ReadOnly",
+                    "ReadWrite"
+                  ],
+                  "type": "string"
+                },
+                "diffDiskSettings": {
+                  "description": "DiffDiskSettings describe ephemeral disk settings for the os disk.",
+                  "properties": {
+                    "option": {
+                      "description": "Option enables ephemeral OS when set to \"Local\" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details",
+                      "enum": [
+                        "Local"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "option"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "diskSizeGB": {
+                  "description": "DiskSizeGB is the size in GB to assign to the OS disk. Will have a default of 30GB if not provided",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "managedDisk": {
+                  "description": "ManagedDisk specifies the Managed Disk parameters for the OS disk.",
+                  "properties": {
+                    "diskEncryptionSet": {
+                      "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                      "properties": {
+                        "id": {
+                          "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "storageAccountType": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "osType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "osType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityProfile": {
+              "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+              "properties": {
+                "encryptionAtHost": {
+                  "description": "This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spotVMOptions": {
+              "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM",
+              "properties": {
+                "maxPrice": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshPublicKey": {
+              "description": "SSHPublicKey is the SSH public key string base64 encoded to add to a Virtual Machine",
+              "type": "string"
+            },
+            "subnetName": {
+              "description": "SubnetName selects the Subnet where the VMSS will be placed",
+              "type": "string"
+            },
+            "terminateNotificationTimeout": {
+              "description": "TerminateNotificationTimeout enables or disables VMSS scheduled events termination notification with specified timeout allowed values are between 5 and 15 (mins)",
+              "type": "integer"
+            },
+            "vmSize": {
+              "description": "VMSize is the size of the Virtual Machine to build. See https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/createorupdate#virtualmachinesizetypes",
+              "type": "string"
+            }
+          },
+          "required": [
+            "osDisk",
+            "sshPublicKey",
+            "vmSize"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "userAssignedIdentities": {
+          "description": "UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachinePool. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli",
+          "items": {
+            "description": "UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.",
+            "properties": {
+              "providerID": {
+                "description": "ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "location",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureMachinePoolStatus defines the observed state of AzureMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "image": {
+          "description": "Image is the current image used in the AzureMachinePool. When the spec image is nil, this image is populated with the details of the defaulted Azure Marketplace \"capi\" offer.",
+          "properties": {
+            "id": {
+              "description": "ID specifies an image to use by ID",
+              "type": "string"
+            },
+            "marketplace": {
+              "description": "Marketplace specifies an image to use from the Azure Marketplace",
+              "properties": {
+                "offer": {
+                  "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "publisher": {
+                  "description": "Publisher is the name of the organization that created the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "thirdPartyImage": {
+                  "default": false,
+                  "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                  "type": "boolean"
+                },
+                "version": {
+                  "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "offer",
+                "publisher",
+                "sku",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sharedGallery": {
+              "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery",
+              "properties": {
+                "gallery": {
+                  "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "offer": {
+                  "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "publisher": {
+                  "description": "Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "subscriptionID": {
+                  "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "gallery",
+                "name",
+                "resourceGroup",
+                "subscriptionID",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "instances": {
+          "description": "Instances is the VM instance status for each VM in the VMSS",
+          "items": {
+            "description": "AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.",
+            "properties": {
+              "instanceID": {
+                "description": "InstanceID is the identification of the Machine Instance within the VMSS",
+                "type": "string"
+              },
+              "instanceName": {
+                "description": "InstanceName is the name of the Machine Instance within the VMSS",
+                "type": "string"
+              },
+              "latestModelApplied": {
+                "description": "LatestModelApplied indicates the instance is running the most up-to-date VMSS model. A VMSS model describes the image version the VM is running. If the instance is not running the latest model, it means the instance may not be running the version of Kubernetes the Machine Pool has specified and needs to be updated.",
+                "type": "boolean"
+              },
+              "providerID": {
+                "description": "ProviderID is the provider identification of the VMSS Instance",
+                "type": "string"
+              },
+              "provisioningState": {
+                "description": "ProvisioningState is the provisioning state of the Azure virtual machine instance.",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the VM Instance",
+                "type": "string"
+              }
+            },
+            "required": [
+              "latestModelApplied"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the state for Azure long-running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "provisioningState": {
+          "description": "ProvisioningState is the provisioning state of the Azure virtual machine.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "version": {
+          "description": "Version is the Kubernetes version for the current VMSS model",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachinepool_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachinepool_v1beta1.json
@@ -1,0 +1,953 @@
+{
+  "description": "AzureMachinePool is the Schema for the azuremachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachinePoolSpec defines the desired state of AzureMachinePool.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+          "type": "object"
+        },
+        "identity": {
+          "default": "None",
+          "description": "Identity is the type of identity used for the Virtual Machine Scale Set. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned"
+          ],
+          "type": "string"
+        },
+        "location": {
+          "description": "Location is the Azure region location e.g. westus2",
+          "type": "string"
+        },
+        "nodeDrainTimeout": {
+          "description": "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+          "type": "string"
+        },
+        "orchestrationMode": {
+          "default": "Uniform",
+          "description": "OrchestrationMode specifies the orchestration mode for the Virtual Machine Scale Set",
+          "enum": [
+            "Flexible",
+            "Uniform"
+          ],
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Virtual Machine Scale Set",
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleAssignmentName": {
+          "description": "Deprecated: RoleAssignmentName should be set in the systemAssignedIdentityRole field.",
+          "type": "string"
+        },
+        "strategy": {
+          "default": {
+            "rollingUpdate": {
+              "deletePolicy": "Oldest",
+              "maxSurge": 1,
+              "maxUnavailable": 0
+            },
+            "type": "RollingUpdate"
+          },
+          "description": "The deployment strategy to use to replace existing AzureMachinePoolMachines with new ones.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.",
+              "properties": {
+                "deletePolicy": {
+                  "default": "Oldest",
+                  "description": "DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are \"Random, \"Newest\", \"Oldest\" When no value is supplied, the default is Oldest",
+                  "enum": [
+                    "Random",
+                    "Newest",
+                    "Oldest"
+                  ],
+                  "type": "string"
+                },
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": 1,
+                  "description": "The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": 0,
+                  "description": "The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "default": "RollingUpdate",
+              "description": "Type of deployment. Currently the only supported strategy is RollingUpdate",
+              "enum": [
+                "RollingUpdate"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "systemAssignedIdentityRole": {
+          "description": "SystemAssignedIdentityRole defines the role and scope to assign to the system assigned identity.",
+          "properties": {
+            "definitionID": {
+              "description": "DefinitionID is the ID of the role definition to create for a system assigned identity. It can be an Azure built-in role or a custom role. Refer to built-in roles: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the role assignment to create for a system assigned identity. It can be any valid UUID. If not specified, a random UUID will be generated.",
+              "type": "string"
+            },
+            "scope": {
+              "description": "Scope is the scope that the role assignment or definition applies to. The scope can be any REST resource instance. If not specified, the scope will be the subscription.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template contains the details used to build a replica virtual machine within the Machine Pool",
+          "properties": {
+            "acceleratedNetworking": {
+              "description": "Deprecated: AcceleratedNetworking should be set in the networkInterfaces field.",
+              "type": "boolean"
+            },
+            "dataDisks": {
+              "description": "DataDisks specifies the list of data disks to be created for a Virtual Machine",
+              "items": {
+                "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+                "properties": {
+                  "cachingType": {
+                    "description": "CachingType specifies the caching requirements.",
+                    "enum": [
+                      "None",
+                      "ReadOnly",
+                      "ReadWrite"
+                    ],
+                    "type": "string"
+                  },
+                  "diskSizeGB": {
+                    "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "lun": {
+                    "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "managedDisk": {
+                    "description": "ManagedDisk specifies the Managed Disk parameters for the data disk.",
+                    "properties": {
+                      "diskEncryptionSet": {
+                        "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                        "properties": {
+                          "id": {
+                            "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageAccountType": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "nameSuffix": {
+                    "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "diskSizeGB",
+                  "nameSuffix"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "diagnostics": {
+              "description": "Diagnostics specifies the diagnostics settings for a virtual machine. If not specified then Boot diagnostics (Managed) will be enabled.",
+              "properties": {
+                "boot": {
+                  "description": "Boot configures the boot diagnostics settings for the virtual machine. This allows to configure capturing serial output from the virtual machine on boot. This is useful for debugging software based launch issues. If not specified then Boot diagnostics (Managed) will be enabled.",
+                  "properties": {
+                    "storageAccountType": {
+                      "description": "StorageAccountType determines if the storage account for storing the diagnostics data should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).",
+                      "enum": [
+                        "Managed",
+                        "UserManaged",
+                        "Disabled"
+                      ],
+                      "type": "string"
+                    },
+                    "userManaged": {
+                      "description": "UserManaged provides a reference to the user-managed storage account.",
+                      "properties": {
+                        "storageAccountURI": {
+                          "description": "StorageAccountURI is the URI of the user-managed storage account. The URI typically will be `https://<mystorageaccountname>.blob.core.windows.net/` but may differ if you are using Azure DNS zone endpoints. You can find the correct endpoint by looking for the Blob Primary Endpoint in the endpoints tab in the Azure console or with the CLI by issuing `az storage account list --query='[].{name: name, \"resource group\": resourceGroup, \"blob endpoint\": primaryEndpoints.blob}'`.",
+                          "maxLength": 1024,
+                          "pattern": "^https://",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "storageAccountURI"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "storageAccountType"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "image": {
+              "description": "Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace \"capi\" offer, which is based on Ubuntu.",
+              "properties": {
+                "computeGallery": {
+                  "description": "ComputeGallery specifies an image to use from the Azure Compute Gallery",
+                  "properties": {
+                    "gallery": {
+                      "description": "Gallery specifies the name of the compute image gallery that contains the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "plan": {
+                      "description": "Plan contains plan information.",
+                      "properties": {
+                        "offer": {
+                          "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "publisher": {
+                          "description": "Publisher is the name of the organization that created the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "sku": {
+                          "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "offer",
+                        "publisher",
+                        "sku"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "resourceGroup": {
+                      "description": "ResourceGroup specifies the resource group containing the private compute gallery.",
+                      "type": "string"
+                    },
+                    "subscriptionID": {
+                      "description": "SubscriptionID is the identifier of the subscription that contains the private compute gallery.",
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "gallery",
+                    "name",
+                    "version"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "id": {
+                  "description": "ID specifies an image to use by ID",
+                  "type": "string"
+                },
+                "marketplace": {
+                  "description": "Marketplace specifies an image to use from the Azure Marketplace",
+                  "properties": {
+                    "offer": {
+                      "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "publisher": {
+                      "description": "Publisher is the name of the organization that created the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "sku": {
+                      "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "thirdPartyImage": {
+                      "default": false,
+                      "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                      "type": "boolean"
+                    },
+                    "version": {
+                      "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "offer",
+                    "publisher",
+                    "sku",
+                    "version"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sharedGallery": {
+                  "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery Deprecated: use ComputeGallery instead.",
+                  "properties": {
+                    "gallery": {
+                      "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "offer": {
+                      "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                      "type": "string"
+                    },
+                    "publisher": {
+                      "description": "Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                      "type": "string"
+                    },
+                    "resourceGroup": {
+                      "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "sku": {
+                      "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                      "type": "string"
+                    },
+                    "subscriptionID": {
+                      "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "gallery",
+                    "name",
+                    "resourceGroup",
+                    "subscriptionID",
+                    "version"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networkInterfaces": {
+              "description": "NetworkInterfaces specifies a list of network interface configurations. If left unspecified, the VM will get a single network interface with a single IPConfig in the subnet specified in the cluster's node subnet field. The primary interface will be the first networkInterface specified (index 0) in the list.",
+              "items": {
+                "description": "NetworkInterface defines a network interface.",
+                "properties": {
+                  "acceleratedNetworking": {
+                    "description": "AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.",
+                    "type": "boolean"
+                  },
+                  "privateIPConfigs": {
+                    "description": "PrivateIPConfigs specifies the number of private IP addresses to attach to the interface. Defaults to 1 if not specified.",
+                    "type": "integer"
+                  },
+                  "subnetName": {
+                    "description": "SubnetName specifies the subnet in which the new network interface will be placed.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "osDisk": {
+              "description": "OSDisk contains the operating system disk information for a Virtual Machine",
+              "properties": {
+                "cachingType": {
+                  "description": "CachingType specifies the caching requirements.",
+                  "enum": [
+                    "None",
+                    "ReadOnly",
+                    "ReadWrite"
+                  ],
+                  "type": "string"
+                },
+                "diffDiskSettings": {
+                  "description": "DiffDiskSettings describe ephemeral disk settings for the os disk.",
+                  "properties": {
+                    "option": {
+                      "description": "Option enables ephemeral OS when set to \"Local\" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details",
+                      "enum": [
+                        "Local"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "option"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "diskSizeGB": {
+                  "description": "DiskSizeGB is the size in GB to assign to the OS disk. Will have a default of 30GB if not provided",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "managedDisk": {
+                  "description": "ManagedDisk specifies the Managed Disk parameters for the OS disk.",
+                  "properties": {
+                    "diskEncryptionSet": {
+                      "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                      "properties": {
+                        "id": {
+                          "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "storageAccountType": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "osType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "osType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityProfile": {
+              "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+              "properties": {
+                "encryptionAtHost": {
+                  "description": "This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spotVMOptions": {
+              "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM",
+              "properties": {
+                "evictionPolicy": {
+                  "description": "EvictionPolicy defines the behavior of the virtual machine when it is evicted. It can be either Delete or Deallocate.",
+                  "enum": [
+                    "Deallocate",
+                    "Delete"
+                  ],
+                  "type": "string"
+                },
+                "maxPrice": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sshPublicKey": {
+              "description": "SSHPublicKey is the SSH public key string, base64-encoded to add to a Virtual Machine. Linux only. Refer to documentation on how to set up SSH access on Windows instances.",
+              "type": "string"
+            },
+            "subnetName": {
+              "description": "Deprecated: SubnetName should be set in the networkInterfaces field.",
+              "type": "string"
+            },
+            "terminateNotificationTimeout": {
+              "description": "TerminateNotificationTimeout enables or disables VMSS scheduled events termination notification with specified timeout allowed values are between 5 and 15 (mins)",
+              "type": "integer"
+            },
+            "vmExtensions": {
+              "description": "VMExtensions specifies a list of extensions to be added to the scale set.",
+              "items": {
+                "description": "VMExtension specifies the parameters for a custom VM extension.",
+                "properties": {
+                  "name": {
+                    "description": "Name is the name of the extension.",
+                    "type": "string"
+                  },
+                  "protectedSettings": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "ProtectedSettings is a JSON formatted protected settings for the extension.",
+                    "type": "object"
+                  },
+                  "publisher": {
+                    "description": "Publisher is the name of the extension handler publisher.",
+                    "type": "string"
+                  },
+                  "settings": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Settings is a JSON formatted public settings for the extension.",
+                    "type": "object"
+                  },
+                  "version": {
+                    "description": "Version specifies the version of the script handler.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "publisher",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "vmSize": {
+              "description": "VMSize is the size of the Virtual Machine to build. See https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/createorupdate#virtualmachinesizetypes",
+              "type": "string"
+            }
+          },
+          "required": [
+            "osDisk",
+            "vmSize"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "userAssignedIdentities": {
+          "description": "UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachinePool. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli",
+          "items": {
+            "description": "UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.",
+            "properties": {
+              "providerID": {
+                "description": "ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "location",
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureMachinePoolStatus defines the observed state of AzureMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "image": {
+          "description": "Image is the current image used in the AzureMachinePool. When the spec image is nil, this image is populated with the details of the defaulted Azure Marketplace \"capi\" offer.",
+          "properties": {
+            "computeGallery": {
+              "description": "ComputeGallery specifies an image to use from the Azure Compute Gallery",
+              "properties": {
+                "gallery": {
+                  "description": "Gallery specifies the name of the compute image gallery that contains the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "plan": {
+                  "description": "Plan contains plan information.",
+                  "properties": {
+                    "offer": {
+                      "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "publisher": {
+                      "description": "Publisher is the name of the organization that created the image",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "sku": {
+                      "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "offer",
+                    "publisher",
+                    "sku"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup specifies the resource group containing the private compute gallery.",
+                  "type": "string"
+                },
+                "subscriptionID": {
+                  "description": "SubscriptionID is the identifier of the subscription that contains the private compute gallery.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "gallery",
+                "name",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "id": {
+              "description": "ID specifies an image to use by ID",
+              "type": "string"
+            },
+            "marketplace": {
+              "description": "Marketplace specifies an image to use from the Azure Marketplace",
+              "properties": {
+                "offer": {
+                  "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "publisher": {
+                  "description": "Publisher is the name of the organization that created the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "thirdPartyImage": {
+                  "default": false,
+                  "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                  "type": "boolean"
+                },
+                "version": {
+                  "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "offer",
+                "publisher",
+                "sku",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sharedGallery": {
+              "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery Deprecated: use ComputeGallery instead.",
+              "properties": {
+                "gallery": {
+                  "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of the image",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "offer": {
+                  "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "publisher": {
+                  "description": "Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "resourceGroup": {
+                  "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "sku": {
+                  "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                  "type": "string"
+                },
+                "subscriptionID": {
+                  "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "version": {
+                  "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "gallery",
+                "name",
+                "resourceGroup",
+                "subscriptionID",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "instances": {
+          "description": "Instances is the VM instance status for each VM in the VMSS",
+          "items": {
+            "description": "AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.",
+            "properties": {
+              "instanceID": {
+                "description": "InstanceID is the identification of the Machine Instance within the VMSS",
+                "type": "string"
+              },
+              "instanceName": {
+                "description": "InstanceName is the name of the Machine Instance within the VMSS",
+                "type": "string"
+              },
+              "latestModelApplied": {
+                "description": "LatestModelApplied indicates the instance is running the most up-to-date VMSS model. A VMSS model describes the image version the VM is running. If the instance is not running the latest model, it means the instance may not be running the version of Kubernetes the Machine Pool has specified and needs to be updated.",
+                "type": "boolean"
+              },
+              "providerID": {
+                "description": "ProviderID is the provider identification of the VMSS Instance",
+                "type": "string"
+              },
+              "provisioningState": {
+                "description": "ProvisioningState is the provisioning state of the Azure virtual machine instance.",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version defines the Kubernetes version for the VM Instance",
+                "type": "string"
+              }
+            },
+            "required": [
+              "latestModelApplied"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the state for Azure long-running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "data",
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "provisioningState": {
+          "description": "ProvisioningState is the provisioning state of the Azure virtual machine.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "version": {
+          "description": "Version is the Kubernetes version for the current VMSS model",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachinepoolmachine_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachinepoolmachine_v1alpha4.json
@@ -1,0 +1,185 @@
+{
+  "description": "AzureMachinePoolMachine is the Schema for the azuremachinepoolmachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachinePoolMachineSpec defines the desired state of AzureMachinePoolMachine.",
+      "properties": {
+        "instanceID": {
+          "description": "InstanceID is the identification of the Machine Instance within the VMSS",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Virtual Machine Scale Set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceID",
+        "providerID"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureMachinePoolMachineStatus defines the observed state of AzureMachinePoolMachine.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool machine and will contain a succinct value suitable for machine interpretation. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instanceName": {
+          "description": "InstanceName is the name of the Machine Instance within the VMSS",
+          "type": "string"
+        },
+        "latestModelApplied": {
+          "description": "LatestModelApplied indicates the instance is running the most up-to-date VMSS model. A VMSS model describes the image version the VM is running. If the instance is not running the latest model, it means the instance may not be running the version of Kubernetes the Machine Pool has specified and needs to be updated.",
+          "type": "boolean"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the state for Azure long running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "nodeRef": {
+          "description": "NodeRef will point to the corresponding Node if it exists.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "provisioningState": {
+          "description": "ProvisioningState is the provisioning state of the Azure virtual machine instance.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "version": {
+          "description": "Version defines the Kubernetes version for the VM Instance",
+          "type": "string"
+        }
+      },
+      "required": [
+        "latestModelApplied"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachinepoolmachine_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachinepoolmachine_v1beta1.json
@@ -1,0 +1,183 @@
+{
+  "description": "AzureMachinePoolMachine is the Schema for the azuremachinepoolmachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachinePoolMachineSpec defines the desired state of AzureMachinePoolMachine.",
+      "properties": {
+        "instanceID": {
+          "description": "InstanceID is the identification of the Machine Instance within the VMSS",
+          "type": "string"
+        },
+        "providerID": {
+          "description": "ProviderID is the identification ID of the Virtual Machine Scale Set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "providerID"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureMachinePoolMachineStatus defines the observed state of AzureMachinePoolMachine.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureMachinePool.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool machine and will contain a succinct value suitable for machine interpretation. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instanceName": {
+          "description": "InstanceName is the name of the Machine Instance within the VMSS",
+          "type": "string"
+        },
+        "latestModelApplied": {
+          "description": "LatestModelApplied indicates the instance is running the most up-to-date VMSS model. A VMSS model describes the image version the VM is running. If the instance is not running the latest model, it means the instance may not be running the version of Kubernetes the Machine Pool has specified and needs to be updated.",
+          "type": "boolean"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the state for Azure long running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "data",
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "nodeRef": {
+          "description": "NodeRef will point to the corresponding Node if it exists.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "provisioningState": {
+          "description": "ProvisioningState is the provisioning state of the Azure virtual machine instance.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "version": {
+          "description": "Version defines the Kubernetes version for the VM Instance",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1alpha2.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1alpha2.json
@@ -1,0 +1,150 @@
+{
+  "description": "AzureMachineTemplate is the Schema for the azuremachinetemplates API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate",
+      "properties": {
+        "template": {
+          "description": "AzureMachineTemplateResource describes the data needed to create am AzureMachine from a template",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+                  "type": "object"
+                },
+                "allocatePublicIP": {
+                  "description": "AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.",
+                  "type": "boolean"
+                },
+                "availabilityZone": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "image": {
+                  "description": "Image defines information about the image to use for VM creation. There are three ways to specify an image: by ID, by publisher, or by Shared Image Gallery. If specifying an image by ID, only the ID field needs to be set. If specifying an image by publisher, the Publisher, Offer, SKU, and Version fields must be set. If specifying an image from a Shared Image Gallery, the SubscriptionID, ResourceGroup, Gallery, Name, and Version fields must be set.",
+                  "properties": {
+                    "gallery": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "offer": {
+                      "type": "string"
+                    },
+                    "publisher": {
+                      "type": "string"
+                    },
+                    "resourceGroup": {
+                      "type": "string"
+                    },
+                    "sku": {
+                      "type": "string"
+                    },
+                    "subscriptionID": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "location": {
+                  "type": "string"
+                },
+                "osDisk": {
+                  "properties": {
+                    "diskSizeGB": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "managedDisk": {
+                      "properties": {
+                        "storageAccountType": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "storageAccountType"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "osType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "diskSizeGB",
+                    "managedDisk",
+                    "osType"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "sshPublicKey": {
+                  "type": "string"
+                },
+                "vmSize": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "location",
+                "osDisk",
+                "sshPublicKey",
+                "vmSize"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1alpha3.json
@@ -1,0 +1,370 @@
+{
+  "description": "AzureMachineTemplate is the Schema for the azuremachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template.",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "acceleratedNetworking": {
+                  "description": "AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.",
+                  "type": "boolean"
+                },
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+                  "type": "object"
+                },
+                "allocatePublicIP": {
+                  "description": "AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.",
+                  "type": "boolean"
+                },
+                "availabilityZone": {
+                  "description": "Deprecated: use FailureDomain instead",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dataDisks": {
+                  "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine",
+                  "items": {
+                    "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+                    "properties": {
+                      "cachingType": {
+                        "type": "string"
+                      },
+                      "diskSizeGB": {
+                        "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "lun": {
+                        "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "managedDisk": {
+                        "description": "ManagedDisk defines the managed disk options for a VM.",
+                        "properties": {
+                          "diskEncryptionSet": {
+                            "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                            "properties": {
+                              "id": {
+                                "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "storageAccountType": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "storageAccountType"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "nameSuffix": {
+                        "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "diskSizeGB",
+                      "nameSuffix"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "enableIPForwarding": {
+                  "description": "EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.",
+                  "type": "boolean"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. This relates to an Azure Availability Zone",
+                  "type": "string"
+                },
+                "identity": {
+                  "default": "None",
+                  "description": "Identity is the type of identity used for the virtual machine. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM",
+                  "enum": [
+                    "None",
+                    "SystemAssigned",
+                    "UserAssigned"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace \"capi\" offer, which is based on Ubuntu.",
+                  "properties": {
+                    "id": {
+                      "description": "ID specifies an image to use by ID",
+                      "type": "string"
+                    },
+                    "marketplace": {
+                      "description": "Marketplace specifies an image to use from the Azure Marketplace",
+                      "properties": {
+                        "offer": {
+                          "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "publisher": {
+                          "description": "Publisher is the name of the organization that created the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "sku": {
+                          "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "thirdPartyImage": {
+                          "default": false,
+                          "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                          "type": "boolean"
+                        },
+                        "version": {
+                          "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "offer",
+                        "publisher",
+                        "sku",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sharedGallery": {
+                      "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery",
+                      "properties": {
+                        "gallery": {
+                          "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "resourceGroup": {
+                          "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "subscriptionID": {
+                          "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "gallery",
+                        "name",
+                        "resourceGroup",
+                        "subscriptionID",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "location": {
+                  "description": "Deprecated: to support old clients, will be removed in v1alpha4/v1beta1",
+                  "type": "string"
+                },
+                "osDisk": {
+                  "description": "OSDisk specifies the parameters for the operating system disk of the machine",
+                  "properties": {
+                    "cachingType": {
+                      "type": "string"
+                    },
+                    "diffDiskSettings": {
+                      "description": "DiffDiskSettings describe ephemeral disk settings for the os disk.",
+                      "properties": {
+                        "option": {
+                          "description": "Option enables ephemeral OS when set to \"Local\" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details",
+                          "enum": [
+                            "Local"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "option"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "diskSizeGB": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "managedDisk": {
+                      "description": "ManagedDisk defines the managed disk options for a VM.",
+                      "properties": {
+                        "diskEncryptionSet": {
+                          "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                          "properties": {
+                            "id": {
+                              "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "storageAccountType": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "storageAccountType"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "osType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "diskSizeGB",
+                    "managedDisk",
+                    "osType"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "roleAssignmentName": {
+                  "description": "RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.",
+                  "type": "string"
+                },
+                "securityProfile": {
+                  "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+                  "properties": {
+                    "encryptionAtHost": {
+                      "description": "This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spotVMOptions": {
+                  "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM.",
+                  "properties": {
+                    "maxPrice": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sshPublicKey": {
+                  "type": "string"
+                },
+                "userAssignedIdentities": {
+                  "description": "UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachine. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli",
+                  "items": {
+                    "description": "UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.",
+                    "properties": {
+                      "providerID": {
+                        "description": "ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "providerID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "vmSize": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "location",
+                "osDisk",
+                "sshPublicKey",
+                "vmSize"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1alpha4.json
@@ -1,0 +1,373 @@
+{
+  "description": "AzureMachineTemplate is the Schema for the azuremachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template.",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "acceleratedNetworking": {
+                  "description": "AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.",
+                  "type": "boolean"
+                },
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+                  "type": "object"
+                },
+                "allocatePublicIP": {
+                  "description": "AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.",
+                  "type": "boolean"
+                },
+                "dataDisks": {
+                  "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine",
+                  "items": {
+                    "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+                    "properties": {
+                      "cachingType": {
+                        "description": "CachingType specifies the caching requirements.",
+                        "enum": [
+                          "None",
+                          "ReadOnly",
+                          "ReadWrite"
+                        ],
+                        "type": "string"
+                      },
+                      "diskSizeGB": {
+                        "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "lun": {
+                        "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "managedDisk": {
+                        "description": "ManagedDisk specifies the Managed Disk parameters for the data disk.",
+                        "properties": {
+                          "diskEncryptionSet": {
+                            "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                            "properties": {
+                              "id": {
+                                "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "storageAccountType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "nameSuffix": {
+                        "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "diskSizeGB",
+                      "nameSuffix"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "enableIPForwarding": {
+                  "description": "EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.",
+                  "type": "boolean"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. This relates to an Azure Availability Zone",
+                  "type": "string"
+                },
+                "identity": {
+                  "default": "None",
+                  "description": "Identity is the type of identity used for the virtual machine. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM",
+                  "enum": [
+                    "None",
+                    "SystemAssigned",
+                    "UserAssigned"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace \"capi\" offer, which is based on Ubuntu.",
+                  "properties": {
+                    "id": {
+                      "description": "ID specifies an image to use by ID",
+                      "type": "string"
+                    },
+                    "marketplace": {
+                      "description": "Marketplace specifies an image to use from the Azure Marketplace",
+                      "properties": {
+                        "offer": {
+                          "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "publisher": {
+                          "description": "Publisher is the name of the organization that created the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "sku": {
+                          "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "thirdPartyImage": {
+                          "default": false,
+                          "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                          "type": "boolean"
+                        },
+                        "version": {
+                          "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "offer",
+                        "publisher",
+                        "sku",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sharedGallery": {
+                      "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery",
+                      "properties": {
+                        "gallery": {
+                          "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "offer": {
+                          "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                          "type": "string"
+                        },
+                        "publisher": {
+                          "description": "Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                          "type": "string"
+                        },
+                        "resourceGroup": {
+                          "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "sku": {
+                          "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                          "type": "string"
+                        },
+                        "subscriptionID": {
+                          "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "gallery",
+                        "name",
+                        "resourceGroup",
+                        "subscriptionID",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "osDisk": {
+                  "description": "OSDisk specifies the parameters for the operating system disk of the machine",
+                  "properties": {
+                    "cachingType": {
+                      "description": "CachingType specifies the caching requirements.",
+                      "enum": [
+                        "None",
+                        "ReadOnly",
+                        "ReadWrite"
+                      ],
+                      "type": "string"
+                    },
+                    "diffDiskSettings": {
+                      "description": "DiffDiskSettings describe ephemeral disk settings for the os disk.",
+                      "properties": {
+                        "option": {
+                          "description": "Option enables ephemeral OS when set to \"Local\" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details",
+                          "enum": [
+                            "Local"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "option"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "diskSizeGB": {
+                      "description": "DiskSizeGB is the size in GB to assign to the OS disk. Will have a default of 30GB if not provided",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "managedDisk": {
+                      "description": "ManagedDisk specifies the Managed Disk parameters for the OS disk.",
+                      "properties": {
+                        "diskEncryptionSet": {
+                          "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                          "properties": {
+                            "id": {
+                              "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "storageAccountType": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "osType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "osType"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "roleAssignmentName": {
+                  "description": "RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID. If not specified, a random GUID will be generated.",
+                  "type": "string"
+                },
+                "securityProfile": {
+                  "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+                  "properties": {
+                    "encryptionAtHost": {
+                      "description": "This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spotVMOptions": {
+                  "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM",
+                  "properties": {
+                    "maxPrice": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sshPublicKey": {
+                  "type": "string"
+                },
+                "subnetName": {
+                  "description": "SubnetName selects the Subnet where the VM will be placed",
+                  "type": "string"
+                },
+                "userAssignedIdentities": {
+                  "description": "UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachine. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli",
+                  "items": {
+                    "description": "UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.",
+                    "properties": {
+                      "providerID": {
+                        "description": "ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "providerID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "vmSize": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "osDisk",
+                "sshPublicKey",
+                "vmSize"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1beta1.json
@@ -1,0 +1,608 @@
+{
+  "description": "AzureMachineTemplate is the Schema for the azuremachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template.",
+          "properties": {
+            "metadata": {
+              "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create. This is a copy of customizable fields from metav1.ObjectMeta. \n ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`, which are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases and read-only fields which end up in the generated CRD validation, having it as a subset simplifies the API and some issues that can impact user experience. \n During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054) for v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs, specifically `spec.metadata.creationTimestamp in body must be of type string: \"null\"`. The investigation showed that `controller-tools@v2` behaves differently than its previous version when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package. \n In more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta` had validation properties, including for `creationTimestamp` (metav1.Time). The `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null` which breaks validation because the field isn't marked as nullable. \n In future versions, controller-tools@v2 might allow overriding the type and validation for embedded types. When that happens, this hack should be revisited.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "acceleratedNetworking": {
+                  "description": "Deprecated: AcceleratedNetworking should be set in the networkInterfaces field.",
+                  "type": "boolean"
+                },
+                "additionalCapabilities": {
+                  "description": "AdditionalCapabilities specifies additional capabilities enabled or disabled on the virtual machine.",
+                  "properties": {
+                    "ultraSSDEnabled": {
+                      "description": "UltraSSDEnabled enables or disables Azure UltraSSD capability for the virtual machine. Defaults to true if Ultra SSD data disks are specified, otherwise it doesn't set the capability on the VM.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "additionalTags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the AzureMachine's value takes precedence.",
+                  "type": "object"
+                },
+                "allocatePublicIP": {
+                  "description": "AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.",
+                  "type": "boolean"
+                },
+                "dataDisks": {
+                  "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine",
+                  "items": {
+                    "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+                    "properties": {
+                      "cachingType": {
+                        "description": "CachingType specifies the caching requirements.",
+                        "enum": [
+                          "None",
+                          "ReadOnly",
+                          "ReadWrite"
+                        ],
+                        "type": "string"
+                      },
+                      "diskSizeGB": {
+                        "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "lun": {
+                        "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. The value must be between 0 and 63.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "managedDisk": {
+                        "description": "ManagedDisk specifies the Managed Disk parameters for the data disk.",
+                        "properties": {
+                          "diskEncryptionSet": {
+                            "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                            "properties": {
+                              "id": {
+                                "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "storageAccountType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "nameSuffix": {
+                        "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "diskSizeGB",
+                      "nameSuffix"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "diagnostics": {
+                  "description": "Diagnostics specifies the diagnostics settings for a virtual machine. If not specified then Boot diagnostics (Managed) will be enabled.",
+                  "properties": {
+                    "boot": {
+                      "description": "Boot configures the boot diagnostics settings for the virtual machine. This allows to configure capturing serial output from the virtual machine on boot. This is useful for debugging software based launch issues. If not specified then Boot diagnostics (Managed) will be enabled.",
+                      "properties": {
+                        "storageAccountType": {
+                          "description": "StorageAccountType determines if the storage account for storing the diagnostics data should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).",
+                          "enum": [
+                            "Managed",
+                            "UserManaged",
+                            "Disabled"
+                          ],
+                          "type": "string"
+                        },
+                        "userManaged": {
+                          "description": "UserManaged provides a reference to the user-managed storage account.",
+                          "properties": {
+                            "storageAccountURI": {
+                              "description": "StorageAccountURI is the URI of the user-managed storage account. The URI typically will be `https://<mystorageaccountname>.blob.core.windows.net/` but may differ if you are using Azure DNS zone endpoints. You can find the correct endpoint by looking for the Blob Primary Endpoint in the endpoints tab in the Azure console or with the CLI by issuing `az storage account list --query='[].{name: name, \"resource group\": resourceGroup, \"blob endpoint\": primaryEndpoints.blob}'`.",
+                              "maxLength": 1024,
+                              "pattern": "^https://",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "storageAccountURI"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "storageAccountType"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dnsServers": {
+                  "description": "DNSServers adds a list of DNS Server IP addresses to the VM NICs.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "enableIPForwarding": {
+                  "description": "EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.",
+                  "type": "boolean"
+                },
+                "failureDomain": {
+                  "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. This relates to an Azure Availability Zone",
+                  "type": "string"
+                },
+                "identity": {
+                  "default": "None",
+                  "description": "Identity is the type of identity used for the virtual machine. The type 'SystemAssigned' is an implicitly created identity. The generated identity will be assigned a Subscription contributor role. The type 'UserAssigned' is a standalone Azure resource provided by the user and assigned to the VM",
+                  "enum": [
+                    "None",
+                    "SystemAssigned",
+                    "UserAssigned"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace \"capi\" offer, which is based on Ubuntu.",
+                  "properties": {
+                    "computeGallery": {
+                      "description": "ComputeGallery specifies an image to use from the Azure Compute Gallery",
+                      "properties": {
+                        "gallery": {
+                          "description": "Gallery specifies the name of the compute image gallery that contains the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "plan": {
+                          "description": "Plan contains plan information.",
+                          "properties": {
+                            "offer": {
+                              "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "publisher": {
+                              "description": "Publisher is the name of the organization that created the image",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "sku": {
+                              "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "offer",
+                            "publisher",
+                            "sku"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "resourceGroup": {
+                          "description": "ResourceGroup specifies the resource group containing the private compute gallery.",
+                          "type": "string"
+                        },
+                        "subscriptionID": {
+                          "description": "SubscriptionID is the identifier of the subscription that contains the private compute gallery.",
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "gallery",
+                        "name",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "ID specifies an image to use by ID",
+                      "type": "string"
+                    },
+                    "marketplace": {
+                      "description": "Marketplace specifies an image to use from the Azure Marketplace",
+                      "properties": {
+                        "offer": {
+                          "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "publisher": {
+                          "description": "Publisher is the name of the organization that created the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "sku": {
+                          "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "thirdPartyImage": {
+                          "default": false,
+                          "description": "ThirdPartyImage indicates the image is published by a third party publisher and a Plan will be generated for it.",
+                          "type": "boolean"
+                        },
+                        "version": {
+                          "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "offer",
+                        "publisher",
+                        "sku",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sharedGallery": {
+                      "description": "SharedGallery specifies an image to use from an Azure Shared Image Gallery Deprecated: use ComputeGallery instead.",
+                      "properties": {
+                        "gallery": {
+                          "description": "Gallery specifies the name of the shared image gallery that contains the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the image",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "offer": {
+                          "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                          "type": "string"
+                        },
+                        "publisher": {
+                          "description": "Publisher is the name of the organization that created the image. This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                          "type": "string"
+                        },
+                        "resourceGroup": {
+                          "description": "ResourceGroup specifies the resource group containing the shared image gallery",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "sku": {
+                          "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter This value will be used to add a `Plan` in the API request when creating the VM/VMSS resource. This is needed when the source image from which this SIG image was built requires the `Plan` to be used.",
+                          "type": "string"
+                        },
+                        "subscriptionID": {
+                          "description": "SubscriptionID is the identifier of the subscription that contains the shared image gallery",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "gallery",
+                        "name",
+                        "resourceGroup",
+                        "subscriptionID",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "networkInterfaces": {
+                  "description": "NetworkInterfaces specifies a list of network interface configurations. If left unspecified, the VM will get a single network interface with a single IPConfig in the subnet specified in the cluster's node subnet field. The primary interface will be the first networkInterface specified (index 0) in the list.",
+                  "items": {
+                    "description": "NetworkInterface defines a network interface.",
+                    "properties": {
+                      "acceleratedNetworking": {
+                        "description": "AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.",
+                        "type": "boolean"
+                      },
+                      "privateIPConfigs": {
+                        "description": "PrivateIPConfigs specifies the number of private IP addresses to attach to the interface. Defaults to 1 if not specified.",
+                        "type": "integer"
+                      },
+                      "subnetName": {
+                        "description": "SubnetName specifies the subnet in which the new network interface will be placed.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "osDisk": {
+                  "description": "OSDisk specifies the parameters for the operating system disk of the machine",
+                  "properties": {
+                    "cachingType": {
+                      "description": "CachingType specifies the caching requirements.",
+                      "enum": [
+                        "None",
+                        "ReadOnly",
+                        "ReadWrite"
+                      ],
+                      "type": "string"
+                    },
+                    "diffDiskSettings": {
+                      "description": "DiffDiskSettings describe ephemeral disk settings for the os disk.",
+                      "properties": {
+                        "option": {
+                          "description": "Option enables ephemeral OS when set to \"Local\" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details",
+                          "enum": [
+                            "Local"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "option"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "diskSizeGB": {
+                      "description": "DiskSizeGB is the size in GB to assign to the OS disk. Will have a default of 30GB if not provided",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "managedDisk": {
+                      "description": "ManagedDisk specifies the Managed Disk parameters for the OS disk.",
+                      "properties": {
+                        "diskEncryptionSet": {
+                          "description": "DiskEncryptionSetParameters defines disk encryption options.",
+                          "properties": {
+                            "id": {
+                              "description": "ID defines resourceID for diskEncryptionSet resource. It must be in the same subscription",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "storageAccountType": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "osType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "osType"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "providerID": {
+                  "description": "ProviderID is the unique identifier as specified by the cloud provider.",
+                  "type": "string"
+                },
+                "roleAssignmentName": {
+                  "description": "Deprecated: RoleAssignmentName should be set in the systemAssignedIdentityRole field.",
+                  "type": "string"
+                },
+                "securityProfile": {
+                  "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+                  "properties": {
+                    "encryptionAtHost": {
+                      "description": "This field indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. Default is disabled.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spotVMOptions": {
+                  "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM",
+                  "properties": {
+                    "evictionPolicy": {
+                      "description": "EvictionPolicy defines the behavior of the virtual machine when it is evicted. It can be either Delete or Deallocate.",
+                      "enum": [
+                        "Deallocate",
+                        "Delete"
+                      ],
+                      "type": "string"
+                    },
+                    "maxPrice": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sshPublicKey": {
+                  "description": "SSHPublicKey is the SSH public key string, base64-encoded to add to a Virtual Machine. Linux only. Refer to documentation on how to set up SSH access on Windows instances.",
+                  "type": "string"
+                },
+                "subnetName": {
+                  "description": "Deprecated: SubnetName should be set in the networkInterfaces field.",
+                  "type": "string"
+                },
+                "systemAssignedIdentityRole": {
+                  "description": "SystemAssignedIdentityRole defines the role and scope to assign to the system-assigned identity.",
+                  "properties": {
+                    "definitionID": {
+                      "description": "DefinitionID is the ID of the role definition to create for a system assigned identity. It can be an Azure built-in role or a custom role. Refer to built-in roles: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the role assignment to create for a system assigned identity. It can be any valid UUID. If not specified, a random UUID will be generated.",
+                      "type": "string"
+                    },
+                    "scope": {
+                      "description": "Scope is the scope that the role assignment or definition applies to. The scope can be any REST resource instance. If not specified, the scope will be the subscription.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "userAssignedIdentities": {
+                  "description": "UserAssignedIdentities is a list of standalone Azure identities provided by the user The lifecycle of a user-assigned identity is managed separately from the lifecycle of the AzureMachine. See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli",
+                  "items": {
+                    "description": "UserAssignedIdentity defines the user-assigned identities provided by the user to be assigned to Azure resources.",
+                    "properties": {
+                      "providerID": {
+                        "description": "ProviderID is the identification ID of the user-assigned Identity, the format of an identity is: 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "providerID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "vmExtensions": {
+                  "description": "VMExtensions specifies a list of extensions to be added to the virtual machine.",
+                  "items": {
+                    "description": "VMExtension specifies the parameters for a custom VM extension.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is the name of the extension.",
+                        "type": "string"
+                      },
+                      "protectedSettings": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "ProtectedSettings is a JSON formatted protected settings for the extension.",
+                        "type": "object"
+                      },
+                      "publisher": {
+                        "description": "Publisher is the name of the extension handler publisher.",
+                        "type": "string"
+                      },
+                      "settings": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Settings is a JSON formatted public settings for the extension.",
+                        "type": "object"
+                      },
+                      "version": {
+                        "description": "Version specifies the version of the script handler.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "publisher",
+                      "version"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "vmSize": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "osDisk",
+                "vmSize"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremanagedcluster_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/azuremanagedcluster_v1alpha3.json
@@ -1,0 +1,55 @@
+{
+  "description": "AzureManagedCluster is the Schema for the azuremanagedclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureManagedClusterSpec defines the desired state of AzureManagedCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureManagedClusterStatus defines the observed state of AzureManagedCluster.",
+      "properties": {
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremanagedcluster_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/azuremanagedcluster_v1alpha4.json
@@ -1,0 +1,55 @@
+{
+  "description": "AzureManagedCluster is the Schema for the azuremanagedclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureManagedClusterSpec defines the desired state of AzureManagedCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureManagedClusterStatus defines the observed state of AzureManagedCluster.",
+      "properties": {
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremanagedcluster_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azuremanagedcluster_v1beta1.json
@@ -1,0 +1,55 @@
+{
+  "description": "AzureManagedCluster is the Schema for the azuremanagedclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureManagedClusterSpec defines the desired state of AzureManagedCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureManagedClusterStatus defines the observed state of AzureManagedCluster.",
+      "properties": {
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremanagedcontrolplane_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/azuremanagedcontrolplane_v1alpha3.json
@@ -1,0 +1,182 @@
+{
+  "description": "AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.",
+      "properties": {
+        "aadProfile": {
+          "description": "AadProfile is Azure Active Directory configuration to integrate with AKS for aad authentication.",
+          "properties": {
+            "adminGroupObjectIDs": {
+              "description": "AdminGroupObjectIDs - AAD group object IDs that will have admin role of the cluster.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "managed": {
+              "description": "Managed - Whether to enable managed AAD.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "adminGroupObjectIDs",
+            "managed"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dnsServiceIP": {
+          "description": "DNSServiceIP is an IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.",
+          "type": "string"
+        },
+        "loadBalancerSKU": {
+          "description": "LoadBalancerSKU is the SKU of the loadBalancer to be provisioned.",
+          "enum": [
+            "Basic",
+            "Standard"
+          ],
+          "type": "string"
+        },
+        "location": {
+          "description": "Location is a string matching one of the canonical Azure region names. Examples: \"westus2\", \"eastus\".",
+          "type": "string"
+        },
+        "networkPlugin": {
+          "description": "NetworkPlugin used for building Kubernetes network.",
+          "enum": [
+            "azure",
+            "kubenet"
+          ],
+          "type": "string"
+        },
+        "networkPolicy": {
+          "description": "NetworkPolicy used for building Kubernetes network.",
+          "enum": [
+            "azure",
+            "calico"
+          ],
+          "type": "string"
+        },
+        "nodeResourceGroupName": {
+          "description": "NodeResourceGroupName is the name of the resource group containing cluster IaaS resources. Will be populated to default in webhook.",
+          "type": "string"
+        },
+        "resourceGroupName": {
+          "description": "ResourceGroupName is the name of the Azure resource group for this AKS Cluster.",
+          "type": "string"
+        },
+        "sshPublicKey": {
+          "description": "SSHPublicKey is a string literal containing an ssh public key base64 encoded.",
+          "type": "string"
+        },
+        "subscriptionID": {
+          "description": "SubscriotionID is the GUID of the Azure subscription to hold this cluster.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version.",
+          "minLength": 2,
+          "type": "string"
+        },
+        "virtualNetwork": {
+          "description": "VirtualNetwork describes the vnet for the AKS cluster. Will be created if it does not exist.",
+          "properties": {
+            "cidrBlock": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "subnet": {
+              "description": "ManagedControlPlaneSubnet describes a subnet for an AKS cluster.",
+              "properties": {
+                "cidrBlock": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cidrBlock",
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "cidrBlock",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "location",
+        "nodeResourceGroupName",
+        "resourceGroupName",
+        "sshPublicKey",
+        "version"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.",
+      "properties": {
+        "initialized": {
+          "description": "Initialized is true when the the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.",
+          "type": "boolean"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremanagedcontrolplane_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/azuremanagedcontrolplane_v1alpha4.json
@@ -1,0 +1,337 @@
+{
+  "description": "AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.",
+      "properties": {
+        "aadProfile": {
+          "description": "AadProfile is Azure Active Directory configuration to integrate with AKS for aad authentication.",
+          "properties": {
+            "adminGroupObjectIDs": {
+              "description": "AdminGroupObjectIDs - AAD group object IDs that will have admin role of the cluster.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "managed": {
+              "description": "Managed - Whether to enable managed AAD.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "adminGroupObjectIDs",
+            "managed"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "apiServerAccessProfile": {
+          "description": "APIServerAccessProfile is the access profile for AKS API server.",
+          "properties": {
+            "authorizedIPRanges": {
+              "description": "AuthorizedIPRanges - Authorized IP Ranges to kubernetes API server.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "enablePrivateCluster": {
+              "description": "EnablePrivateCluster - Whether to create the cluster as a private cluster or not.",
+              "type": "boolean"
+            },
+            "enablePrivateClusterPublicFQDN": {
+              "description": "EnablePrivateClusterPublicFQDN - Whether to create additional public FQDN for private cluster or not.",
+              "type": "boolean"
+            },
+            "privateDNSZone": {
+              "description": "PrivateDNSZone - Private dns zone mode for private cluster.",
+              "enum": [
+                "System",
+                "None"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dnsServiceIP": {
+          "description": "DNSServiceIP is an IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.",
+          "type": "string"
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a AzureClusterIdentity to be used when reconciling this cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "loadBalancerProfile": {
+          "description": "LoadBalancerProfile is the profile of the cluster load balancer.",
+          "properties": {
+            "allocatedOutboundPorts": {
+              "description": "AllocatedOutboundPorts - Desired number of allocated SNAT ports per VM. Allowed values must be in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "idleTimeoutInMinutes": {
+              "description": "IdleTimeoutInMinutes - Desired outbound flow idle timeout in minutes. Allowed values must be in the range of 4 to 120 (inclusive). The default value is 30 minutes.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "managedOutboundIPs": {
+              "description": "ManagedOutboundIPs - Desired managed outbound IPs for the cluster load balancer.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "outboundIPPrefixes": {
+              "description": "OutboundIPPrefixes - Desired outbound IP Prefix resources for the cluster load balancer.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "outboundIPs": {
+              "description": "OutboundIPs - Desired outbound IP resources for the cluster load balancer.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "loadBalancerSKU": {
+          "description": "LoadBalancerSKU is the SKU of the loadBalancer to be provisioned.",
+          "enum": [
+            "Basic",
+            "Standard"
+          ],
+          "type": "string"
+        },
+        "location": {
+          "description": "Location is a string matching one of the canonical Azure region names. Examples: \"westus2\", \"eastus\".",
+          "type": "string"
+        },
+        "networkPlugin": {
+          "description": "NetworkPlugin used for building Kubernetes network.",
+          "enum": [
+            "azure",
+            "kubenet"
+          ],
+          "type": "string"
+        },
+        "networkPolicy": {
+          "description": "NetworkPolicy used for building Kubernetes network.",
+          "enum": [
+            "azure",
+            "calico"
+          ],
+          "type": "string"
+        },
+        "nodeResourceGroupName": {
+          "description": "NodeResourceGroupName is the name of the resource group containing cluster IaaS resources. Will be populated to default in webhook.",
+          "type": "string"
+        },
+        "resourceGroupName": {
+          "description": "ResourceGroupName is the name of the Azure resource group for this AKS Cluster.",
+          "type": "string"
+        },
+        "sku": {
+          "description": "SKU is the AKSSku of the AKS to be provisioned.",
+          "properties": {
+            "tier": {
+              "description": "Tier - Tier of a managed cluster SKU.",
+              "enum": [
+                "Free",
+                "Paid"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "tier"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshPublicKey": {
+          "description": "SSHPublicKey is a string literal containing an ssh public key base64 encoded.",
+          "type": "string"
+        },
+        "subscriptionID": {
+          "description": "SubscriptionID is the GUID of the Azure subscription to hold this cluster.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version.",
+          "minLength": 2,
+          "type": "string"
+        },
+        "virtualNetwork": {
+          "description": "VirtualNetwork describes the vnet for the AKS cluster. Will be created if it does not exist.",
+          "properties": {
+            "cidrBlock": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "subnet": {
+              "description": "ManagedControlPlaneSubnet describes a subnet for an AKS cluster.",
+              "properties": {
+                "cidrBlock": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cidrBlock",
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "cidrBlock",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "location",
+        "resourceGroupName",
+        "sshPublicKey",
+        "version"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.",
+      "properties": {
+        "initialized": {
+          "description": "Initialized is true when the the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.",
+          "type": "boolean"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremanagedcontrolplane_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azuremanagedcontrolplane_v1beta1.json
@@ -1,0 +1,635 @@
+{
+  "description": "AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.",
+      "properties": {
+        "aadProfile": {
+          "description": "AadProfile is Azure Active Directory configuration to integrate with AKS for aad authentication.",
+          "properties": {
+            "adminGroupObjectIDs": {
+              "description": "AdminGroupObjectIDs - AAD group object IDs that will have admin role of the cluster.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "managed": {
+              "description": "Managed - Whether to enable managed AAD.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "adminGroupObjectIDs",
+            "managed"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "addonProfiles": {
+          "description": "AddonProfiles are the profiles of managed cluster add-on.",
+          "items": {
+            "description": "AddonProfile represents a managed cluster add-on.",
+            "properties": {
+              "config": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Config - Key-value pairs for configuring the add-on.",
+                "type": "object"
+              },
+              "enabled": {
+                "description": "Enabled - Whether the add-on is enabled or not.",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Name - The name of the managed cluster add-on.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "enabled",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "apiServerAccessProfile": {
+          "description": "APIServerAccessProfile is the access profile for AKS API server.",
+          "properties": {
+            "authorizedIPRanges": {
+              "description": "AuthorizedIPRanges - Authorized IP Ranges to kubernetes API server.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "enablePrivateCluster": {
+              "description": "EnablePrivateCluster - Whether to create the cluster as a private cluster or not.",
+              "type": "boolean"
+            },
+            "enablePrivateClusterPublicFQDN": {
+              "description": "EnablePrivateClusterPublicFQDN - Whether to create additional public FQDN for private cluster or not.",
+              "type": "boolean"
+            },
+            "privateDNSZone": {
+              "description": "PrivateDNSZone - Private dns zone mode for private cluster.",
+              "enum": [
+                "System",
+                "None"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "autoscalerProfile": {
+          "description": "AutoscalerProfile is the parameters to be applied to the cluster-autoscaler when enabled",
+          "properties": {
+            "balanceSimilarNodeGroups": {
+              "description": "BalanceSimilarNodeGroups - Valid values are 'true' and 'false'. The default is false.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "expander": {
+              "description": "Expander - If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information.",
+              "enum": [
+                "least-waste",
+                "most-pods",
+                "priority",
+                "random"
+              ],
+              "type": "string"
+            },
+            "maxEmptyBulkDelete": {
+              "description": "MaxEmptyBulkDelete - The default is 10.",
+              "type": "string"
+            },
+            "maxGracefulTerminationSec": {
+              "description": "MaxGracefulTerminationSec - The default is 600.",
+              "pattern": "^(\\d+)$",
+              "type": "string"
+            },
+            "maxNodeProvisionTime": {
+              "description": "MaxNodeProvisionTime - The default is '15m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+              "pattern": "^(\\d+)m$",
+              "type": "string"
+            },
+            "maxTotalUnreadyPercentage": {
+              "description": "MaxTotalUnreadyPercentage - The default is 45. The maximum is 100 and the minimum is 0.",
+              "maxLength": 3,
+              "minLength": 1,
+              "pattern": "^(\\d+)$",
+              "type": "string"
+            },
+            "newPodScaleUpDelay": {
+              "description": "NewPodScaleUpDelay - For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. The default is '0s'. Values must be an integer followed by a unit ('s' for seconds, 'm' for minutes, 'h' for hours, etc).",
+              "type": "string"
+            },
+            "okTotalUnreadyCount": {
+              "description": "OkTotalUnreadyCount - This must be an integer. The default is 3.",
+              "pattern": "^(\\d+)$",
+              "type": "string"
+            },
+            "scaleDownDelayAfterAdd": {
+              "description": "ScaleDownDelayAfterAdd - The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+              "pattern": "^(\\d+)m$",
+              "type": "string"
+            },
+            "scaleDownDelayAfterDelete": {
+              "description": "ScaleDownDelayAfterDelete - The default is the scan-interval. Values must be an integer followed by an 's'. No unit of time other than seconds (s) is supported.",
+              "pattern": "^(\\d+)s$",
+              "type": "string"
+            },
+            "scaleDownDelayAfterFailure": {
+              "description": "ScaleDownDelayAfterFailure - The default is '3m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+              "pattern": "^(\\d+)m$",
+              "type": "string"
+            },
+            "scaleDownUnneededTime": {
+              "description": "ScaleDownUnneededTime - The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+              "pattern": "^(\\d+)m$",
+              "type": "string"
+            },
+            "scaleDownUnreadyTime": {
+              "description": "ScaleDownUnreadyTime - The default is '20m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+              "pattern": "^(\\d+)m$",
+              "type": "string"
+            },
+            "scaleDownUtilizationThreshold": {
+              "description": "ScaleDownUtilizationThreshold - The default is '0.5'.",
+              "type": "string"
+            },
+            "scanInterval": {
+              "description": "ScanInterval - How often cluster is reevaluated for scale up or down. The default is '10s'.",
+              "pattern": "^(\\d+)s$",
+              "type": "string"
+            },
+            "skipNodesWithLocalStorage": {
+              "description": "SkipNodesWithLocalStorage - The default is false.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "skipNodesWithSystemPods": {
+              "description": "SkipNodesWithSystemPods - The default is true.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dnsServiceIP": {
+          "description": "DNSServiceIP is an IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.",
+          "type": "string"
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to a AzureClusterIdentity to be used when reconciling this cluster",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "loadBalancerProfile": {
+          "description": "LoadBalancerProfile is the profile of the cluster load balancer.",
+          "properties": {
+            "allocatedOutboundPorts": {
+              "description": "AllocatedOutboundPorts - Desired number of allocated SNAT ports per VM. Allowed values must be in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "idleTimeoutInMinutes": {
+              "description": "IdleTimeoutInMinutes - Desired outbound flow idle timeout in minutes. Allowed values must be in the range of 4 to 120 (inclusive). The default value is 30 minutes.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "managedOutboundIPs": {
+              "description": "ManagedOutboundIPs - Desired managed outbound IPs for the cluster load balancer.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "outboundIPPrefixes": {
+              "description": "OutboundIPPrefixes - Desired outbound IP Prefix resources for the cluster load balancer.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "outboundIPs": {
+              "description": "OutboundIPs - Desired outbound IP resources for the cluster load balancer.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "loadBalancerSKU": {
+          "description": "LoadBalancerSKU is the SKU of the loadBalancer to be provisioned.",
+          "enum": [
+            "Basic",
+            "Standard"
+          ],
+          "type": "string"
+        },
+        "location": {
+          "description": "Location is a string matching one of the canonical Azure region names. Examples: \"westus2\", \"eastus\".",
+          "type": "string"
+        },
+        "networkPlugin": {
+          "description": "NetworkPlugin used for building Kubernetes network.",
+          "enum": [
+            "azure",
+            "kubenet"
+          ],
+          "type": "string"
+        },
+        "networkPolicy": {
+          "description": "NetworkPolicy used for building Kubernetes network.",
+          "enum": [
+            "azure",
+            "calico"
+          ],
+          "type": "string"
+        },
+        "nodeResourceGroupName": {
+          "description": "NodeResourceGroupName is the name of the resource group containing cluster IaaS resources. Will be populated to default in webhook.",
+          "type": "string"
+        },
+        "outboundType": {
+          "description": "Outbound configuration used by Nodes.",
+          "enum": [
+            "loadBalancer",
+            "managedNATGateway",
+            "userAssignedNATGateway",
+            "userDefinedRouting"
+          ],
+          "type": "string"
+        },
+        "resourceGroupName": {
+          "description": "ResourceGroupName is the name of the Azure resource group for this AKS Cluster.",
+          "type": "string"
+        },
+        "sku": {
+          "description": "SKU is the SKU of the AKS to be provisioned.",
+          "properties": {
+            "tier": {
+              "description": "Tier - Tier of an AKS cluster.",
+              "enum": [
+                "Free",
+                "Paid"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "tier"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sshPublicKey": {
+          "description": "SSHPublicKey is a string literal containing an ssh public key base64 encoded.",
+          "type": "string"
+        },
+        "subscriptionID": {
+          "description": "SubscriptionID is the GUID of the Azure subscription to hold this cluster.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version defines the desired Kubernetes version.",
+          "minLength": 2,
+          "type": "string"
+        },
+        "virtualNetwork": {
+          "description": "VirtualNetwork describes the vnet for the AKS cluster. Will be created if it does not exist.",
+          "properties": {
+            "cidrBlock": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "resourceGroup": {
+              "description": "ResourceGroup is the name of the Azure resource group for the VNet and Subnet.",
+              "type": "string"
+            },
+            "subnet": {
+              "description": "ManagedControlPlaneSubnet describes a subnet for an AKS cluster.",
+              "properties": {
+                "cidrBlock": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "privateEndpoints": {
+                  "description": "PrivateEndpoints is a slice of Virtual Network private endpoints to create for the subnets.",
+                  "items": {
+                    "description": "PrivateEndpointSpec configures an Azure Private Endpoint.",
+                    "properties": {
+                      "applicationSecurityGroups": {
+                        "description": "ApplicationSecurityGroups specifies the Application security group in which the private endpoint IP configuration is included.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "customNetworkInterfaceName": {
+                        "description": "CustomNetworkInterfaceName specifies the network interface name associated with the private endpoint.",
+                        "type": "string"
+                      },
+                      "location": {
+                        "description": "Location specifies the region to create the private endpoint.",
+                        "type": "string"
+                      },
+                      "manualApproval": {
+                        "description": "ManualApproval specifies if the connection approval needs to be done manually or not. Set it true when the network admin does not have access to approve connections to the remote resource. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name specifies the name of the private endpoint.",
+                        "type": "string"
+                      },
+                      "privateIPAddresses": {
+                        "description": "PrivateIPAddresses specifies the IP addresses for the network interface associated with the private endpoint. They have to be part of the subnet where the private endpoint is linked.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "privateLinkServiceConnections": {
+                        "description": "PrivateLinkServiceConnections specifies Private Link Service Connections of the private endpoint.",
+                        "items": {
+                          "description": "PrivateLinkServiceConnection defines the specification for a private link service connection associated with a private endpoint.",
+                          "properties": {
+                            "groupIDs": {
+                              "description": "GroupIDs specifies the ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name specifies the name of the private link service.",
+                              "type": "string"
+                            },
+                            "privateLinkServiceID": {
+                              "description": "PrivateLinkServiceID specifies the resource ID of the private link service.",
+                              "type": "string"
+                            },
+                            "requestMessage": {
+                              "description": "RequestMessage specifies a message passed to the owner of the remote resource with the private endpoint connection request.",
+                              "maxLength": 140,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "serviceEndpoints": {
+                  "description": "ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.",
+                  "items": {
+                    "description": "ServiceEndpointSpec configures an Azure Service Endpoint.",
+                    "properties": {
+                      "locations": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "locations",
+                      "service"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "service"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              },
+              "required": [
+                "cidrBlock",
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "cidrBlock",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "location",
+        "resourceGroupName",
+        "sshPublicKey",
+        "version"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureManagedControlPlane.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "initialized": {
+          "description": "Initialized is true when the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.",
+          "type": "boolean"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "data",
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremanagedmachinepool_v1alpha3.json
+++ b/infrastructure.cluster.x-k8s.io/azuremanagedmachinepool_v1alpha3.json
@@ -1,0 +1,76 @@
+{
+  "description": "AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.",
+      "properties": {
+        "mode": {
+          "description": "Mode - represents mode of an agent pool. Possible values include: System, User.",
+          "enum": [
+            "System",
+            "User"
+          ],
+          "type": "string"
+        },
+        "osDiskSizeGB": {
+          "description": "OSDiskSizeGB is the disk size for every machine in this agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList is the unique identifier as specified by the cloud provider.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sku": {
+          "description": "SKU is the size of the VMs in the node pool.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "mode",
+        "sku"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.",
+      "properties": {
+        "errorMessage": {
+          "description": "Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremanagedmachinepool_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/azuremanagedmachinepool_v1alpha4.json
@@ -1,0 +1,80 @@
+{
+  "description": "AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.",
+      "properties": {
+        "mode": {
+          "description": "Mode - represents mode of an agent pool. Possible values include: System, User.",
+          "enum": [
+            "System",
+            "User"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "Name - name of the agent pool. If not specified, CAPZ uses the name of the CR as the agent pool name.",
+          "type": "string"
+        },
+        "osDiskSizeGB": {
+          "description": "OSDiskSizeGB is the disk size for every machine in this agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList is the unique identifier as specified by the cloud provider.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sku": {
+          "description": "SKU is the size of the VMs in the node pool.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "mode",
+        "sku"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.",
+      "properties": {
+        "errorMessage": {
+          "description": "Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/azuremanagedmachinepool_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/azuremanagedmachinepool_v1beta1.json
@@ -1,0 +1,582 @@
+{
+  "description": "AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.",
+          "type": "object"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones - Availability zones for nodes. Must use VirtualMachineScaleSets AgentPoolType.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enableNodePublicIP": {
+          "description": "EnableNodePublicIP controls whether or not nodes in the pool each have a public IP address.",
+          "type": "boolean"
+        },
+        "enableUltraSSD": {
+          "description": "EnableUltraSSD enables the storage type UltraSSD_LRS for the agent pool.",
+          "type": "boolean"
+        },
+        "kubeletConfig": {
+          "description": "KubeletConfig specifies the kubelet configurations for nodes.",
+          "properties": {
+            "allowedUnsafeSysctls": {
+              "description": "AllowedUnsafeSysctls - Allowlist of unsafe sysctls or unsafe sysctl patterns (ending in `*`).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "containerLogMaxFiles": {
+              "description": "ContainerLogMaxFiles - The maximum number of container log files that can be present for a container. The number must be \u2265 2.",
+              "format": "int32",
+              "minimum": 2,
+              "type": "integer"
+            },
+            "containerLogMaxSizeMB": {
+              "description": "ContainerLogMaxSizeMB - The maximum size (e.g. 10Mi) of container log file before it is rotated.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "cpuCfsQuota": {
+              "description": "CPUCfsQuota - Enable CPU CFS quota enforcement for containers that specify CPU limits.",
+              "type": "boolean"
+            },
+            "cpuCfsQuotaPeriod": {
+              "description": "CPUCfsQuotaPeriod - Sets CPU CFS quota period value.",
+              "type": "string"
+            },
+            "cpuManagerPolicy": {
+              "description": "CPUManagerPolicy - CPU Manager policy to use.",
+              "enum": [
+                "none",
+                "static"
+              ],
+              "type": "string"
+            },
+            "failSwapOn": {
+              "description": "FailSwapOn - If set to true it will make the Kubelet fail to start if swap is enabled on the node.",
+              "type": "boolean"
+            },
+            "imageGcHighThreshold": {
+              "description": "ImageGcHighThreshold - The percent of disk usage after which image garbage collection is always run.",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "imageGcLowThreshold": {
+              "description": "ImageGcLowThreshold - The percent of disk usage before which image garbage collection is never run.",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "podMaxPids": {
+              "description": "PodMaxPids - The maximum number of processes per pod.",
+              "format": "int32",
+              "minimum": -1,
+              "type": "integer"
+            },
+            "topologyManagerPolicy": {
+              "description": "TopologyManagerPolicy - Topology Manager policy to use.",
+              "enum": [
+                "none",
+                "best-effort",
+                "restricted",
+                "single-numa-node"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kubeletDiskType": {
+          "description": "KubeletDiskType specifies the kubelet disk type. Default to OS. Possible values include: 'OS', 'Temporary'. Requires kubeletDisk preview feature to be set.",
+          "enum": [
+            "OS",
+            "Temporary"
+          ],
+          "type": "string"
+        },
+        "linuxOSConfig": {
+          "description": "LinuxOSConfig specifies the custom Linux OS settings and configurations.",
+          "properties": {
+            "swapFileSizeMB": {
+              "description": "SwapFileSizeMB specifies size in MB of a swap file will be created on the agent nodes from this node pool. Max value of SwapFileSizeMB should be the size of temporary disk(/dev/sdb). Refer: https://learn.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview#temporary-disk",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "sysctls": {
+              "description": "Sysctl specifies the settings for Linux agent nodes.",
+              "properties": {
+                "fsAioMaxNr": {
+                  "description": "FsAioMaxNr specifies the maximum number of system-wide asynchronous io requests. Maps to fs.aio-max-nr.",
+                  "format": "int32",
+                  "maximum": 6553500,
+                  "minimum": 65536,
+                  "type": "integer"
+                },
+                "fsFileMax": {
+                  "description": "FsFileMax specifies the max number of file-handles that the Linux kernel will allocate, by increasing increases the maximum number of open files permitted. Maps to fs.file-max.",
+                  "format": "int32",
+                  "maximum": 12000500,
+                  "minimum": 8192,
+                  "type": "integer"
+                },
+                "fsInotifyMaxUserWatches": {
+                  "description": "FsInotifyMaxUserWatches specifies the number of file watches allowed by the system. Each watch is roughly 90 bytes on a 32-bit kernel, and roughly 160 bytes on a 64-bit kernel. Maps to fs.inotify.max_user_watches.",
+                  "format": "int32",
+                  "maximum": 2097152,
+                  "minimum": 781250,
+                  "type": "integer"
+                },
+                "fsNrOpen": {
+                  "description": "FsNrOpen specifies the maximum number of file-handles a process can allocate. Maps to fs.nr_open.",
+                  "format": "int32",
+                  "maximum": 20000500,
+                  "minimum": 8192,
+                  "type": "integer"
+                },
+                "kernelThreadsMax": {
+                  "description": "KernelThreadsMax specifies the maximum number of all threads that can be created. Maps to kernel.threads-max.",
+                  "format": "int32",
+                  "maximum": 513785,
+                  "minimum": 20,
+                  "type": "integer"
+                },
+                "netCoreNetdevMaxBacklog": {
+                  "description": "NetCoreNetdevMaxBacklog specifies maximum number of packets, queued on the INPUT side, when the interface receives packets faster than kernel can process them. Maps to net.core.netdev_max_backlog.",
+                  "format": "int32",
+                  "maximum": 3240000,
+                  "minimum": 1000,
+                  "type": "integer"
+                },
+                "netCoreOptmemMax": {
+                  "description": "NetCoreOptmemMax specifies the maximum ancillary buffer size (option memory buffer) allowed per socket. Socket option memory is used in a few cases to store extra structures relating to usage of the socket. Maps to net.core.optmem_max.",
+                  "format": "int32",
+                  "maximum": 4194304,
+                  "minimum": 20480,
+                  "type": "integer"
+                },
+                "netCoreRmemDefault": {
+                  "description": "NetCoreRmemDefault specifies the default receive socket buffer size in bytes. Maps to net.core.rmem_default.",
+                  "format": "int32",
+                  "maximum": 134217728,
+                  "minimum": 212992,
+                  "type": "integer"
+                },
+                "netCoreRmemMax": {
+                  "description": "NetCoreRmemMax specifies the maximum receive socket buffer size in bytes. Maps to net.core.rmem_max.",
+                  "format": "int32",
+                  "maximum": 134217728,
+                  "minimum": 212992,
+                  "type": "integer"
+                },
+                "netCoreSomaxconn": {
+                  "description": "NetCoreSomaxconn specifies maximum number of connection requests that can be queued for any given listening socket. An upper limit for the value of the backlog parameter passed to the listen(2)(https://man7.org/linux/man-pages/man2/listen.2.html) function. If the backlog argument is greater than the somaxconn, then it's silently truncated to this limit. Maps to net.core.somaxconn.",
+                  "format": "int32",
+                  "maximum": 3240000,
+                  "minimum": 4096,
+                  "type": "integer"
+                },
+                "netCoreWmemDefault": {
+                  "description": "NetCoreWmemDefault specifies the default send socket buffer size in bytes. Maps to net.core.wmem_default.",
+                  "format": "int32",
+                  "maximum": 134217728,
+                  "minimum": 212992,
+                  "type": "integer"
+                },
+                "netCoreWmemMax": {
+                  "description": "NetCoreWmemMax specifies the maximum send socket buffer size in bytes. Maps to net.core.wmem_max.",
+                  "format": "int32",
+                  "maximum": 134217728,
+                  "minimum": 212992,
+                  "type": "integer"
+                },
+                "netIpv4IPLocalPortRange": {
+                  "description": "NetIpv4IPLocalPortRange is used by TCP and UDP traffic to choose the local port on the agent node. PortRange should be specified in the format \"first last\". First, being an integer, must be between [1024 - 60999]. Last, being an integer, must be between [32768 - 65000]. Maps to net.ipv4.ip_local_port_range.",
+                  "type": "string"
+                },
+                "netIpv4NeighDefaultGcThresh1": {
+                  "description": "NetIpv4NeighDefaultGcThresh1 specifies the minimum number of entries that may be in the ARP cache. Garbage collection won't be triggered if the number of entries is below this setting. Maps to net.ipv4.neigh.default.gc_thresh1.",
+                  "format": "int32",
+                  "maximum": 80000,
+                  "minimum": 128,
+                  "type": "integer"
+                },
+                "netIpv4NeighDefaultGcThresh2": {
+                  "description": "NetIpv4NeighDefaultGcThresh2 specifies soft maximum number of entries that may be in the ARP cache. ARP garbage collection will be triggered about 5 seconds after reaching this soft maximum. Maps to net.ipv4.neigh.default.gc_thresh2.",
+                  "format": "int32",
+                  "maximum": 90000,
+                  "minimum": 512,
+                  "type": "integer"
+                },
+                "netIpv4NeighDefaultGcThresh3": {
+                  "description": "NetIpv4NeighDefaultGcThresh3 specified hard maximum number of entries in the ARP cache. Maps to net.ipv4.neigh.default.gc_thresh3.",
+                  "format": "int32",
+                  "maximum": 100000,
+                  "minimum": 1024,
+                  "type": "integer"
+                },
+                "netIpv4TCPFinTimeout": {
+                  "description": "NetIpv4TCPFinTimeout specifies the length of time an orphaned connection will remain in the FIN_WAIT_2 state before it's aborted at the local end. Maps to net.ipv4.tcp_fin_timeout.",
+                  "format": "int32",
+                  "maximum": 120,
+                  "minimum": 5,
+                  "type": "integer"
+                },
+                "netIpv4TCPKeepaliveProbes": {
+                  "description": "NetIpv4TCPKeepaliveProbes specifies the number of keepalive probes TCP sends out, until it decides the connection is broken. Maps to net.ipv4.tcp_keepalive_probes.",
+                  "format": "int32",
+                  "maximum": 15,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "netIpv4TCPKeepaliveTime": {
+                  "description": "NetIpv4TCPKeepaliveTime specifies the rate at which TCP sends out a keepalive message when keepalive is enabled. Maps to net.ipv4.tcp_keepalive_time.",
+                  "format": "int32",
+                  "maximum": 432000,
+                  "minimum": 30,
+                  "type": "integer"
+                },
+                "netIpv4TCPMaxSynBacklog": {
+                  "description": "NetIpv4TCPMaxSynBacklog specifies the maximum number of queued connection requests that have still not received an acknowledgment from the connecting client. If this number is exceeded, the kernel will begin dropping requests. Maps to net.ipv4.tcp_max_syn_backlog.",
+                  "format": "int32",
+                  "maximum": 3240000,
+                  "minimum": 128,
+                  "type": "integer"
+                },
+                "netIpv4TCPMaxTwBuckets": {
+                  "description": "NetIpv4TCPMaxTwBuckets specifies maximal number of timewait sockets held by system simultaneously. If this number is exceeded, time-wait socket is immediately destroyed and warning is printed. Maps to net.ipv4.tcp_max_tw_buckets.",
+                  "format": "int32",
+                  "maximum": 1440000,
+                  "minimum": 8000,
+                  "type": "integer"
+                },
+                "netIpv4TCPTwReuse": {
+                  "description": "NetIpv4TCPTwReuse is used to allow to reuse TIME-WAIT sockets for new connections when it's safe from protocol viewpoint. Maps to net.ipv4.tcp_tw_reuse.",
+                  "type": "boolean"
+                },
+                "netIpv4TCPkeepaliveIntvl": {
+                  "description": "NetIpv4TCPkeepaliveIntvl specifies the frequency of the probes sent out. Multiplied by tcpKeepaliveprobes, it makes up the time to kill a connection that isn't responding, after probes started. Maps to net.ipv4.tcp_keepalive_intvl.",
+                  "format": "int32",
+                  "maximum": 75,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "netNetfilterNfConntrackBuckets": {
+                  "description": "NetNetfilterNfConntrackBuckets specifies the size of hash table used by nf_conntrack module to record the established connection record of the TCP protocol. Maps to net.netfilter.nf_conntrack_buckets.",
+                  "format": "int32",
+                  "maximum": 147456,
+                  "minimum": 65536,
+                  "type": "integer"
+                },
+                "netNetfilterNfConntrackMax": {
+                  "description": "NetNetfilterNfConntrackMax specifies the maximum number of connections supported by the nf_conntrack module or the size of connection tracking table. Maps to net.netfilter.nf_conntrack_max.",
+                  "format": "int32",
+                  "maximum": 1048576,
+                  "minimum": 131072,
+                  "type": "integer"
+                },
+                "vmMaxMapCount": {
+                  "description": "VMMaxMapCount specifies the maximum number of memory map areas a process may have. Maps to vm.max_map_count.",
+                  "format": "int32",
+                  "maximum": 262144,
+                  "minimum": 65530,
+                  "type": "integer"
+                },
+                "vmSwappiness": {
+                  "description": "VMSwappiness specifies aggressiveness of the kernel in swapping memory pages. Higher values will increase aggressiveness, lower values decrease the amount of swap. Maps to vm.swappiness.",
+                  "format": "int32",
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "vmVfsCachePressure": {
+                  "description": "VMVfsCachePressure specifies the percentage value that controls tendency of the kernel to reclaim the memory, which is used for caching of directory and inode objects. Maps to vm.vfs_cache_pressure.",
+                  "format": "int32",
+                  "maximum": 500,
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "transparentHugePageDefrag": {
+              "description": "TransparentHugePageDefrag specifies whether the kernel should make aggressive use of memory compaction to make more hugepages available. Refer to https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge for more details.",
+              "enum": [
+                "always",
+                "defer",
+                "defer+madvise",
+                "madvise",
+                "never"
+              ],
+              "type": "string"
+            },
+            "transparentHugePageEnabled": {
+              "description": "TransparentHugePageEnabled specifies various modes of Transparent Hugepages. Refer to https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge for more details.",
+              "enum": [
+                "always",
+                "madvise",
+                "never"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "maxPods": {
+          "description": "MaxPods specifies the kubelet --max-pods configuration for the node pool.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "mode": {
+          "description": "Mode - represents mode of an agent pool. Possible values include: System, User.",
+          "enum": [
+            "System",
+            "User"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "Name - name of the agent pool. If not specified, CAPZ uses the name of the CR as the agent pool name.",
+          "type": "string"
+        },
+        "nodeLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Node labels - labels for all of the nodes present in node pool",
+          "type": "object"
+        },
+        "nodePublicIPPrefixID": {
+          "description": "NodePublicIPPrefixID specifies the public IP prefix resource ID which VM nodes should use IPs from.",
+          "type": "string"
+        },
+        "osDiskSizeGB": {
+          "description": "OSDiskSizeGB is the disk size for every machine in this agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "osDiskType": {
+          "default": "Managed",
+          "description": "OsDiskType specifies the OS disk type for each node in the pool. Allowed values are 'Ephemeral' and 'Managed'.",
+          "enum": [
+            "Ephemeral",
+            "Managed"
+          ],
+          "type": "string"
+        },
+        "osType": {
+          "description": "OSType specifies the virtual machine operating system. Default to Linux. Possible values include: 'Linux', 'Windows'",
+          "enum": [
+            "Linux",
+            "Windows"
+          ],
+          "type": "string"
+        },
+        "providerIDList": {
+          "description": "ProviderIDList is the unique identifier as specified by the cloud provider.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "scaleSetPriority": {
+          "description": "ScaleSetPriority specifies the ScaleSetPriority value. Default to Regular. Possible values include: 'Regular', 'Spot'",
+          "enum": [
+            "Regular",
+            "Spot"
+          ],
+          "type": "string"
+        },
+        "scaling": {
+          "description": "Scaling specifies the autoscaling parameters for the node pool.",
+          "properties": {
+            "maxSize": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "minSize": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sku": {
+          "description": "SKU is the size of the VMs in the node pool.",
+          "type": "string"
+        },
+        "taints": {
+          "description": "Taints specifies the taints for nodes present in this agent pool.",
+          "items": {
+            "description": "Taint represents a Kubernetes taint.",
+            "properties": {
+              "effect": {
+                "description": "Effect specifies the effect for the taint",
+                "enum": [
+                  "NoSchedule",
+                  "NoExecute",
+                  "PreferNoSchedule"
+                ],
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the key of the taint",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value is the value of the taint",
+                "type": "string"
+              }
+            },
+            "required": [
+              "effect",
+              "key",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "mode",
+        "sku"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the AzureManagedControlPlane.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "errorMessage": {
+          "description": "Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "longRunningOperationStates": {
+          "description": "LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.",
+          "items": {
+            "description": "Future contains the data needed for an Azure long-running operation to continue across reconcile loops.",
+            "properties": {
+              "data": {
+                "description": "Data is the base64 url encoded json Azure AutoRest Future.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "resourceGroup": {
+                "description": "ResourceGroup is the Azure resource group for the resource.",
+                "type": "string"
+              },
+              "serviceName": {
+                "description": "ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type describes the type of future, such as update, create, delete, etc.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "data",
+              "name",
+              "serviceName",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds schemas for all CRs currently defined by the [Cluster API Provider Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure).

CRD sources:

```
# current/main

$ kustomize build github.com/kubernetes-sigs/cluster-api-provider-azure/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to azureclusteridentity_v1alpha3.json
JSON schema written to azureclusteridentity_v1alpha4.json
JSON schema written to azureclusteridentity_v1beta1.json
JSON schema written to azurecluster_v1alpha3.json
JSON schema written to azurecluster_v1alpha4.json
JSON schema written to azurecluster_v1beta1.json
JSON schema written to azureclustertemplate_v1beta1.json
JSON schema written to azuremachinepoolmachine_v1alpha4.json
JSON schema written to azuremachinepoolmachine_v1beta1.json
JSON schema written to azuremachinepool_v1alpha3.json
JSON schema written to azuremachinepool_v1alpha4.json
JSON schema written to azuremachinepool_v1beta1.json
JSON schema written to azuremachine_v1alpha3.json
JSON schema written to azuremachine_v1alpha4.json
JSON schema written to azuremachine_v1beta1.json
JSON schema written to azuremachinetemplate_v1alpha3.json
JSON schema written to azuremachinetemplate_v1alpha4.json
JSON schema written to azuremachinetemplate_v1beta1.json
JSON schema written to azuremanagedcluster_v1alpha3.json
JSON schema written to azuremanagedcluster_v1alpha4.json
JSON schema written to azuremanagedcluster_v1beta1.json
JSON schema written to azuremanagedcontrolplane_v1alpha3.json
JSON schema written to azuremanagedcontrolplane_v1alpha4.json
JSON schema written to azuremanagedcontrolplane_v1beta1.json
JSON schema written to azuremanagedmachinepool_v1alpha3.json
JSON schema written to azuremanagedmachinepool_v1alpha4.json
JSON schema written to azuremanagedmachinepool_v1beta1.json

# v1alpha2 (deprecated)

$ kustomize build 'github.com/kubernetes-sigs/cluster-api-provider-azure/config/crd?ref=v0.4.15' | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to azureclusteridentity_v1alpha3.json      # skipped
JSON schema written to azurecluster_v1alpha2.json
JSON schema written to azurecluster_v1alpha3.json              # skipped
JSON schema written to azuremachinepool_v1alpha3.json          # skipped
JSON schema written to azuremachine_v1alpha2.json
JSON schema written to azuremachine_v1alpha3.json              # skipped
JSON schema written to azuremachinetemplate_v1alpha2.json
JSON schema written to azuremachinetemplate_v1alpha3.json      # skipped
JSON schema written to azuremanagedcluster_v1alpha3.json       # skipped
JSON schema written to azuremanagedcontrolplane_v1alpha3.json  # skipped
JSON schema written to azuremanagedmachinepool_v1alpha3.json   # skipped

# v1alpha1 (deprecated)

$ curl -fsSL https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/bd86562830f2a618456e841586ba658ef263556e/config/crds/azureprovider_v1alpha1_azureclusterproviderspec.yaml > crd_0.yml
$ curl -fsSL https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/bd86562830f2a618456e841586ba658ef263556e/config/crds/azureprovider_v1alpha1_azureclusterproviderstatus.yaml > crd_1.yml
$ curl -fsSL https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/bd86562830f2a618456e841586ba658ef263556e/config/crds/azureprovider_v1alpha1_azuremachineproviderspec.yaml > crd_2.yml
$ curl -fsSL https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/bd86562830f2a618456e841586ba658ef263556e/config/crds/azureprovider_v1alpha1_azuremachineproviderstatus.yaml > crd_3.yml
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to azureclusterproviderspec_v1alpha1.json
JSON schema written to azureclusterproviderstatus_v1alpha1.json
JSON schema written to azuremachineproviderspec_v1alpha1.json
JSON schema written to azuremachineproviderstatus_v1alpha1.json
```