### PR TITLE
Add Cluster API Provider Nested schemas

### DIFF
--- a/infrastructure.cluster.x-k8s.io/nestedcluster_v1alpha4.json
+++ b/infrastructure.cluster.x-k8s.io/nestedcluster_v1alpha4.json
@@ -1,0 +1,55 @@
+{
+  "description": "NestedCluster is the Schema for the nestedclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "NestedClusterSpec defines the desired state of NestedCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "NestedClusterStatus defines the observed state of NestedCluster.",
+      "properties": {
+        "ready": {
+          "description": "Ready is when the NestedControlPlane has a API server URL.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds schemas for all CRs currently defined by the [Cluster API Provider Nested](https://github.com/kubernetes-sigs/cluster-api-provider-nested).

CRD sources:

```
$ kustomize build github.com/kubernetes-sigs/cluster-api-provider-nested/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to nestedcluster_v1alpha4.json
```