### PR TITLE
Add Cluster API Provider Tinkerbell schemas

### DIFF
--- a/infrastructure.cluster.x-k8s.io/tinkerbellcluster_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/tinkerbellcluster_v1beta1.json
@@ -1,0 +1,73 @@
+{
+  "description": "TinkerbellCluster is the Schema for the tinkerbellclusters API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TinkerbellClusterSpec defines the desired state of TinkerbellCluster.",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint is a required field by ClusterAPI v1beta1. \n See https://cluster-api.sigs.k8s.io/developer/architecture/controllers/cluster.html for more details.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "imageLookupBaseRegistry": {
+          "default": "ghcr.io/tinkerbell/cluster-api-provider-tinkerbell",
+          "description": "ImageLookupBaseRegistry is the base Registry URL that is used for pulling images, if not set, the default will be to use ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the URL naming format to use for machine images when a machine does not specify. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupFormat. Supports substitutions for {{.BaseRegistry}}, {{.OSDistro}}, {{.OSVersion}} and {{.KubernetesVersion}} with the basse URL, OS distribution, OS version, and kubernetes version, respectively. BaseRegistry will be the value in ImageLookupBaseRegistry or ghcr.io/tinkerbell/cluster-api-provider-tinkerbell (the default), OSDistro will be the value in ImageLookupOSDistro or ubuntu (the default), OSVersion will be the value in ImageLookupOSVersion or default based on the OSDistro (if known), and the kubernetes version as defined by the packages produced by kubernetes/release: v1.13.0, v1.12.5-mybuild.1, or v1.17.3. For example, the default image format of {{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz will attempt to pull the image from that location. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOSDistro": {
+          "default": "ubuntu",
+          "description": "ImageLookupOSDistro is the name of the OS distro to use when fetching machine images, if not set it will default to ubuntu.",
+          "type": "string"
+        },
+        "imageLookupOSVersion": {
+          "description": "ImageLookupOSVersion is the version of the OS distribution to use when fetching machine images. If not set it will default based on ImageLookupOSDistro.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TinkerbellClusterStatus defines the observed state of TinkerbellCluster.",
+      "properties": {
+        "ready": {
+          "description": "Ready denotes that the cluster (infrastructure) is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/tinkerbellmachine_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/tinkerbellmachine_v1beta1.json
@@ -1,0 +1,240 @@
+{
+  "description": "TinkerbellMachine is the Schema for the tinkerbellmachines API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TinkerbellMachineSpec defines the desired state of TinkerbellMachine.",
+      "properties": {
+        "hardwareAffinity": {
+          "description": "HardwareAffinity allows filtering for hardware.",
+          "properties": {
+            "preferred": {
+              "description": "Preferred are the preferred hardware affinity terms. Hardware matching these terms are preferred according to the weights provided, but are not required.",
+              "items": {
+                "description": "WeightedHardwareAffinityTerm is a HardwareAffinityTerm with an associated weight.  The weights of all the matched WeightedHardwareAffinityTerm fields are added per-hardware to find the most preferred hardware.",
+                "properties": {
+                  "hardwareAffinityTerm": {
+                    "description": "HardwareAffinityTerm is the term associated with the corresponding weight.",
+                    "properties": {
+                      "labelSelector": {
+                        "description": "LabelSelector is used to select for particular hardware by label.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "labelSelector"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "weight": {
+                    "description": "Weight associated with matching the corresponding hardwareAffinityTerm, in the range 1-100.",
+                    "format": "int32",
+                    "maximum": 100,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "hardwareAffinityTerm",
+                  "weight"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "required": {
+              "description": "Required are the required hardware affinity terms.  The terms are OR'd together, hardware must match one term to be considered.",
+              "items": {
+                "description": "HardwareAffinityTerm is used to select for a particular existing hardware resource.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to select for particular hardware by label.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "labelSelector"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "hardwareName": {
+          "description": "Those fields are set programmatically, but they cannot be re-constructed from \"state of the world\", so we put them in spec instead of status.",
+          "type": "string"
+        },
+        "imageLookupBaseRegistry": {
+          "description": "ImageLookupBaseRegistry is the base Registry URL that is used for pulling images, if not set, the default will be to use ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.",
+          "type": "string"
+        },
+        "imageLookupFormat": {
+          "description": "ImageLookupFormat is the URL naming format to use for machine images when a machine does not specify. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupFormat. Supports substitutions for {{.BaseRegistry}}, {{.OSDistro}}, {{.OSVersion}} and {{.KubernetesVersion}} with the basse URL, OS distribution, OS version, and kubernetes version, respectively. BaseRegistry will be the value in ImageLookupBaseRegistry or ghcr.io/tinkerbell/cluster-api-provider-tinkerbell (the default), OSDistro will be the value in ImageLookupOSDistro or ubuntu (the default), OSVersion will be the value in ImageLookupOSVersion or default based on the OSDistro (if known), and the kubernetes version as defined by the packages produced by kubernetes/release: v1.13.0, v1.12.5-mybuild.1, or v1.17.3. For example, the default image format of {{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz will attempt to pull the image from that location. See also: https://golang.org/pkg/text/template/",
+          "type": "string"
+        },
+        "imageLookupOSDistro": {
+          "description": "ImageLookupOSDistro is the name of the OS distro to use when fetching machine images, if not set it will default to ubuntu.",
+          "type": "string"
+        },
+        "imageLookupOSVersion": {
+          "description": "ImageLookupOSVersion is the version of the OS distribution to use when fetching machine images. If not set it will default based on ImageLookupOSDistro.",
+          "type": "string"
+        },
+        "providerID": {
+          "type": "string"
+        },
+        "templateOverride": {
+          "description": "TemplateOverride overrides the default Tinkerbell template used by CAPT. You can learn more about Tinkerbell templates here: https://docs.tinkerbell.org/templates/",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TinkerbellMachineStatus defines the observed state of TinkerbellMachine.",
+      "properties": {
+        "addresses": {
+          "description": "Addresses contains the Tinkerbell device associated addresses.",
+          "items": {
+            "description": "NodeAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The node address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "errorMessage": {
+          "description": "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "errorReason": {
+          "description": "Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "type": "string"
+        },
+        "instanceStatus": {
+          "description": "InstanceStatus is the status of the Tinkerbell device instance for this machine.",
+          "type": "integer"
+        },
+        "ready": {
+          "description": "Ready is true when the provider resource is ready.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/tinkerbellmachinetemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/tinkerbellmachinetemplate_v1beta1.json
@@ -1,0 +1,214 @@
+{
+  "description": "TinkerbellMachineTemplate is the Schema for the tinkerbellmachinetemplates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TinkerbellMachineTemplateSpec defines the desired state of TinkerbellMachineTemplate.",
+      "properties": {
+        "template": {
+          "description": "TinkerbellMachineTemplateResource describes the data needed to create am TinkerbellMachine from a template.",
+          "properties": {
+            "spec": {
+              "description": "Spec is the specification of the desired behavior of the machine.",
+              "properties": {
+                "hardwareAffinity": {
+                  "description": "HardwareAffinity allows filtering for hardware.",
+                  "properties": {
+                    "preferred": {
+                      "description": "Preferred are the preferred hardware affinity terms. Hardware matching these terms are preferred according to the weights provided, but are not required.",
+                      "items": {
+                        "description": "WeightedHardwareAffinityTerm is a HardwareAffinityTerm with an associated weight.  The weights of all the matched WeightedHardwareAffinityTerm fields are added per-hardware to find the most preferred hardware.",
+                        "properties": {
+                          "hardwareAffinityTerm": {
+                            "description": "HardwareAffinityTerm is the term associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "LabelSelector is used to select for particular hardware by label.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "labelSelector"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding hardwareAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "hardwareAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "required": {
+                      "description": "Required are the required hardware affinity terms.  The terms are OR'd together, hardware must match one term to be considered.",
+                      "items": {
+                        "description": "HardwareAffinityTerm is used to select for a particular existing hardware resource.",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "LabelSelector is used to select for particular hardware by label.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "labelSelector"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "hardwareName": {
+                  "description": "Those fields are set programmatically, but they cannot be re-constructed from \"state of the world\", so we put them in spec instead of status.",
+                  "type": "string"
+                },
+                "imageLookupBaseRegistry": {
+                  "description": "ImageLookupBaseRegistry is the base Registry URL that is used for pulling images, if not set, the default will be to use ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.",
+                  "type": "string"
+                },
+                "imageLookupFormat": {
+                  "description": "ImageLookupFormat is the URL naming format to use for machine images when a machine does not specify. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupFormat. Supports substitutions for {{.BaseRegistry}}, {{.OSDistro}}, {{.OSVersion}} and {{.KubernetesVersion}} with the basse URL, OS distribution, OS version, and kubernetes version, respectively. BaseRegistry will be the value in ImageLookupBaseRegistry or ghcr.io/tinkerbell/cluster-api-provider-tinkerbell (the default), OSDistro will be the value in ImageLookupOSDistro or ubuntu (the default), OSVersion will be the value in ImageLookupOSVersion or default based on the OSDistro (if known), and the kubernetes version as defined by the packages produced by kubernetes/release: v1.13.0, v1.12.5-mybuild.1, or v1.17.3. For example, the default image format of {{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz will attempt to pull the image from that location. See also: https://golang.org/pkg/text/template/",
+                  "type": "string"
+                },
+                "imageLookupOSDistro": {
+                  "description": "ImageLookupOSDistro is the name of the OS distro to use when fetching machine images, if not set it will default to ubuntu.",
+                  "type": "string"
+                },
+                "imageLookupOSVersion": {
+                  "description": "ImageLookupOSVersion is the version of the OS distribution to use when fetching machine images. If not set it will default based on ImageLookupOSDistro.",
+                  "type": "string"
+                },
+                "providerID": {
+                  "type": "string"
+                },
+                "templateOverride": {
+                  "description": "TemplateOverride overrides the default Tinkerbell template used by CAPT. You can learn more about Tinkerbell templates here: https://docs.tinkerbell.org/templates/",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds schemas for all CRs currently defined by the [Cluster API Provider Tinkerbell](https://github.com/tinkerbell/cluster-api-provider-tinkerbell).

CRD sources:

```
$ kubectl kustomize github.com/tinkerbell/cluster-api-provider-tinkerbell/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to tinkerbellcluster_v1beta1.json
JSON schema written to tinkerbellmachine_v1beta1.json
JSON schema written to tinkerbellmachinetemplate_v1beta1.json
```