### PR TITLE
Add Tinkerbell schemas

### DIFF
--- a/bmc.tinkerbell.org/job_v1alpha1.json
+++ b/bmc.tinkerbell.org/job_v1alpha1.json
@@ -1,0 +1,154 @@
+{
+  "description": "Job is the Schema for the bmcjobs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "JobSpec defines the desired state of Job",
+      "properties": {
+        "machineRef": {
+          "description": "MachineRef represents the Machine resource to execute the job. All the tasks in the job are executed for the same Machine.",
+          "properties": {
+            "name": {
+              "description": "Name of the Machine.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace the Machine resides in.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tasks": {
+          "description": "Tasks represents a list of baseboard management actions to be executed. The tasks are executed sequentially. Controller waits for one task to complete before executing the next. If a single task fails, job execution stops and sets condition Failed. Condition Completed is set only if all the tasks were successful.",
+          "items": {
+            "description": "Action represents the action to be performed. A single task can only perform one type of action. For example either PowerAction or OneTimeBootDeviceAction.",
+            "maxProperties": 1,
+            "properties": {
+              "oneTimeBootDeviceAction": {
+                "description": "OneTimeBootDeviceAction represents a baseboard management one time set boot device operation.",
+                "properties": {
+                  "device": {
+                    "description": "Devices represents the boot devices, in order for setting one time boot. Currently only the first device in the slice is used to set one time boot.",
+                    "items": {
+                      "description": "BootDevice represents boot device of the Machine.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "efiBoot": {
+                    "description": "EFIBoot instructs the machine to use EFI boot.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "device"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "powerAction": {
+                "description": "PowerAction represents a baseboard management power operation.",
+                "enum": [
+                  "on",
+                  "off",
+                  "soft",
+                  "status",
+                  "cycle",
+                  "reset"
+                ],
+                "type": "string"
+              },
+              "virtualMediaAction": {
+                "description": "VirtualMediaAction represents a baseboard management virtual media insert/eject.",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "mediaURL": {
+                    "description": "mediaURL represents the URL of the image to be inserted into the virtual media, or empty to eject media.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "machineRef",
+        "tasks"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "JobStatus defines the observed state of Job",
+      "properties": {
+        "completionTime": {
+          "description": "CompletionTime represents time when the job was completed. The completion time is only set when the job finishes successfully.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions represents the latest available observations of an object's current state.",
+          "items": {
+            "properties": {
+              "message": {
+                "description": "Message represents human readable message indicating details about last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the status of the Job condition. Can be True or False.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of the Job condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "startTime": {
+          "description": "StartTime represents time when the Job controller started processing a job.",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bmc.tinkerbell.org/machine_v1alpha1.json
+++ b/bmc.tinkerbell.org/machine_v1alpha1.json
@@ -1,0 +1,116 @@
+{
+  "description": "Machine is the Schema for the machines API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineSpec defines desired machine state",
+      "properties": {
+        "connection": {
+          "description": "Connection contains connection data for a Baseboard Management Controller.",
+          "properties": {
+            "authSecretRef": {
+              "description": "AuthSecretRef is the SecretReference that contains authentication information of the Machine. The Secret must contain username and password keys.",
+              "properties": {
+                "name": {
+                  "description": "name is unique within a namespace to reference a secret resource.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace defines the space within which the secret name must be unique.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "host": {
+              "description": "Host is the host IP address or hostname of the Machine.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "insecureTLS": {
+              "description": "InsecureTLS specifies trusted TLS connections.",
+              "type": "boolean"
+            },
+            "port": {
+              "default": 623,
+              "description": "Port is the port number for connecting with the Machine.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "authSecretRef",
+            "host",
+            "insecureTLS",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "connection"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineStatus defines the observed state of Machine",
+      "properties": {
+        "conditions": {
+          "description": "Conditions represents the latest available observations of an object's current state.",
+          "items": {
+            "description": "MachineCondition defines an observed condition of a Machine.",
+            "properties": {
+              "lastUpdateTime": {
+                "description": "LastUpdateTime of the condition.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "Message is a human readable message indicating with details of the last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of the Machine condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "powerState": {
+          "description": "Power is the current power state of the Machine.",
+          "enum": [
+            "on",
+            "off"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/bmc.tinkerbell.org/task_v1alpha1.json
+++ b/bmc.tinkerbell.org/task_v1alpha1.json
@@ -1,0 +1,171 @@
+{
+  "description": "Task is the Schema for the Task API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TaskSpec defines the desired state of Task.",
+      "properties": {
+        "connection": {
+          "description": "Connection represents the Machine connectivity information.",
+          "properties": {
+            "authSecretRef": {
+              "description": "AuthSecretRef is the SecretReference that contains authentication information of the Machine. The Secret must contain username and password keys.",
+              "properties": {
+                "name": {
+                  "description": "name is unique within a namespace to reference a secret resource.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace defines the space within which the secret name must be unique.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "host": {
+              "description": "Host is the host IP address or hostname of the Machine.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "insecureTLS": {
+              "description": "InsecureTLS specifies trusted TLS connections.",
+              "type": "boolean"
+            },
+            "port": {
+              "default": 623,
+              "description": "Port is the port number for connecting with the Machine.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "authSecretRef",
+            "host",
+            "insecureTLS",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "task": {
+          "description": "Task defines the specific action to be performed.",
+          "maxProperties": 1,
+          "properties": {
+            "oneTimeBootDeviceAction": {
+              "description": "OneTimeBootDeviceAction represents a baseboard management one time set boot device operation.",
+              "properties": {
+                "device": {
+                  "description": "Devices represents the boot devices, in order for setting one time boot. Currently only the first device in the slice is used to set one time boot.",
+                  "items": {
+                    "description": "BootDevice represents boot device of the Machine.",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "efiBoot": {
+                  "description": "EFIBoot instructs the machine to use EFI boot.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "device"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "powerAction": {
+              "description": "PowerAction represents a baseboard management power operation.",
+              "enum": [
+                "on",
+                "off",
+                "soft",
+                "status",
+                "cycle",
+                "reset"
+              ],
+              "type": "string"
+            },
+            "virtualMediaAction": {
+              "description": "VirtualMediaAction represents a baseboard management virtual media insert/eject.",
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "mediaURL": {
+                  "description": "mediaURL represents the URL of the image to be inserted into the virtual media, or empty to eject media.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "task"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TaskStatus defines the observed state of Task",
+      "properties": {
+        "completionTime": {
+          "description": "CompletionTime represents time when the task was completed. The completion time is only set when the task finishes successfully.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions represents the latest available observations of an object's current state.",
+          "items": {
+            "properties": {
+              "message": {
+                "description": "Message represents human readable message indicating details about last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the status of the Task condition. Can be True or False.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of the Task condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "startTime": {
+          "description": "StartTime represents time when the Task started processing.",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/tinkerbell.org/hardware_v1alpha1.json
+++ b/tinkerbell.org/hardware_v1alpha1.json
@@ -1,0 +1,526 @@
+{
+  "description": "Hardware is the Schema for the Hardware API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "HardwareSpec defines the desired state of Hardware.",
+      "properties": {
+        "bmcRef": {
+          "description": "BMCRef contains a relation to a BMC state management type in the same namespace as the Hardware. This may be used for BMC management by orchestrators.",
+          "properties": {
+            "apiGroup": {
+              "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is the type of resource being referenced",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of resource being referenced",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "disks": {
+          "items": {
+            "description": "Disk represents a disk device for Tinkerbell Hardware.",
+            "properties": {
+              "device": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "interfaces": {
+          "items": {
+            "description": "Interface represents a network interface configuration for Hardware.",
+            "properties": {
+              "dhcp": {
+                "description": "DHCP configuration.",
+                "properties": {
+                  "arch": {
+                    "type": "string"
+                  },
+                  "hostname": {
+                    "type": "string"
+                  },
+                  "iface_name": {
+                    "type": "string"
+                  },
+                  "ip": {
+                    "description": "IP configuration.",
+                    "properties": {
+                      "address": {
+                        "type": "string"
+                      },
+                      "family": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "gateway": {
+                        "type": "string"
+                      },
+                      "netmask": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "lease_time": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "mac": {
+                    "pattern": "([0-9a-f]{2}[:]){5}([0-9a-f]{2})",
+                    "type": "string"
+                  },
+                  "name_servers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "time_servers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "uefi": {
+                    "type": "boolean"
+                  },
+                  "vlan_id": {
+                    "description": "validation pattern for VLANDID is a string number between 0-4096",
+                    "pattern": "^(([0-9][0-9]{0,2}|[1-3][0-9][0-9][0-9]|40([0-8][0-9]|9[0-6]))(,[1-9][0-9]{0,2}|[1-3][0-9][0-9][0-9]|40([0-8][0-9]|9[0-6]))*)$",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "netboot": {
+                "description": "Netboot configuration.",
+                "properties": {
+                  "allowPXE": {
+                    "type": "boolean"
+                  },
+                  "allowWorkflow": {
+                    "type": "boolean"
+                  },
+                  "ipxe": {
+                    "description": "IPXE configuration.",
+                    "properties": {
+                      "contents": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "osie": {
+                    "description": "OSIE configuration.",
+                    "properties": {
+                      "baseURL": {
+                        "type": "string"
+                      },
+                      "initrd": {
+                        "type": "string"
+                      },
+                      "kernel": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "properties": {
+            "bonding_mode": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "custom": {
+              "properties": {
+                "preinstalled_operating_system_version": {
+                  "properties": {
+                    "distro": {
+                      "type": "string"
+                    },
+                    "image_tag": {
+                      "type": "string"
+                    },
+                    "os_slug": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "private_subnets": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "facility": {
+              "properties": {
+                "facility_code": {
+                  "type": "string"
+                },
+                "plan_slug": {
+                  "type": "string"
+                },
+                "plan_version_slug": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "instance": {
+              "properties": {
+                "allow_pxe": {
+                  "type": "boolean"
+                },
+                "always_pxe": {
+                  "type": "boolean"
+                },
+                "crypted_root_password": {
+                  "type": "string"
+                },
+                "hostname": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "ips": {
+                  "items": {
+                    "properties": {
+                      "address": {
+                        "type": "string"
+                      },
+                      "family": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "gateway": {
+                        "type": "string"
+                      },
+                      "management": {
+                        "type": "boolean"
+                      },
+                      "netmask": {
+                        "type": "string"
+                      },
+                      "public": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "ipxe_script_url": {
+                  "type": "string"
+                },
+                "network_ready": {
+                  "type": "boolean"
+                },
+                "operating_system": {
+                  "properties": {
+                    "distro": {
+                      "type": "string"
+                    },
+                    "image_tag": {
+                      "type": "string"
+                    },
+                    "os_slug": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "rescue": {
+                  "type": "boolean"
+                },
+                "ssh_keys": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "storage": {
+                  "properties": {
+                    "disks": {
+                      "items": {
+                        "properties": {
+                          "device": {
+                            "type": "string"
+                          },
+                          "partitions": {
+                            "items": {
+                              "properties": {
+                                "label": {
+                                  "type": "string"
+                                },
+                                "number": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "size": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "start": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "type_guid": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "wipe_table": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "filesystems": {
+                      "items": {
+                        "properties": {
+                          "mount": {
+                            "properties": {
+                              "create": {
+                                "properties": {
+                                  "force": {
+                                    "type": "boolean"
+                                  },
+                                  "options": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "device": {
+                                "type": "string"
+                              },
+                              "files": {
+                                "items": {
+                                  "properties": {
+                                    "contents": {
+                                      "type": "string"
+                                    },
+                                    "gid": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "mode": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "uid": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "format": {
+                                "type": "string"
+                              },
+                              "point": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "raid": {
+                      "items": {
+                        "properties": {
+                          "devices": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "spare": {
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "userdata": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "manufacturer": {
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "slug": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "state": {
+              "default": "provisioning",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+            "x-kubernetes-int-or-string": true
+          },
+          "description": "Resources represents known resources that are available on a machine. Resources may be used for scheduling by orchestrators.",
+          "type": "object"
+        },
+        "tinkVersion": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "userData": {
+          "description": "UserData is the user data to configure in the hardware's metadata",
+          "type": "string"
+        },
+        "vendorData": {
+          "description": "VendorData is the vendor data to configure in the hardware's metadata",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "HardwareStatus defines the observed state of Hardware.",
+      "properties": {
+        "state": {
+          "description": "HardwareState represents the hardware state.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/tinkerbell.org/template_v1alpha1.json
+++ b/tinkerbell.org/template_v1alpha1.json
@@ -1,0 +1,38 @@
+{
+  "description": "Template is the Schema for the Templates API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TemplateSpec defines the desired state of Template.",
+      "properties": {
+        "data": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TemplateStatus defines the observed state of Template.",
+      "properties": {
+        "state": {
+          "description": "TemplateState represents the template state.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/tinkerbell.org/workflow_v1alpha1.json
+++ b/tinkerbell.org/workflow_v1alpha1.json
@@ -1,0 +1,144 @@
+{
+  "description": "Workflow is the Schema for the Workflows API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "WorkflowSpec defines the desired state of Workflow.",
+      "properties": {
+        "hardwareMap": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A mapping of template devices to hadware mac addresses",
+          "type": "object"
+        },
+        "hardwareRef": {
+          "description": "Name of the Hardware associated with this workflow.",
+          "type": "string"
+        },
+        "templateRef": {
+          "description": "Name of the Template associated with this workflow.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "WorkflowStatus defines the observed state of Workflow.",
+      "properties": {
+        "globalTimeout": {
+          "description": "GlobalTimeout represents the max execution time",
+          "format": "int64",
+          "type": "integer"
+        },
+        "state": {
+          "description": "State is the state of the workflow in Tinkerbell.",
+          "type": "string"
+        },
+        "tasks": {
+          "description": "Tasks are the tasks to be completed",
+          "items": {
+            "description": "Task represents a series of actions to be completed by a worker.",
+            "properties": {
+              "actions": {
+                "items": {
+                  "description": "Action represents a workflow action.",
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "environment": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "pid": {
+                      "type": "string"
+                    },
+                    "seconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "startedAt": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "volumes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "environment": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              },
+              "volumes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "worker": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "actions",
+              "name",
+              "worker"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds schemas for all CRs currently defined by the `tink` and `rufio` subprojects of [Tinkerbell](https://github.com/tinkerbell).

CRD sources:

```
$ kustomize build github.com/tinkerbell/tink/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to hardware_v1alpha1.json
JSON schema written to template_v1alpha1.json
JSON schema written to workflow_v1alpha1.json

$ kustomize build github.com/tinkerbell/rufio/config/crd | yq -s '"crd_" + $index'
$ openapi2jsonschema $(pwd)/*.yml
JSON schema written to job_v1alpha1.json
JSON schema written to machine_v1alpha1.json
JSON schema written to task_v1alpha1.json
```