### PR TITLE
fix: adding istio security peerauthentication

### DIFF
--- a/security.istio.io/peerauthentication_v1beta1.json
+++ b/security.istio.io/peerauthentication_v1beta1.json
@@ -1,0 +1,66 @@
+{
+  "properties": {
+    "spec": {
+      "description": "PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.",
+      "properties": {
+        "mtls": {
+          "description": "Mutual TLS settings for workload.",
+          "properties": {
+            "mode": {
+              "description": "Defines the mTLS mode used for peer authentication.",
+              "enum": [
+                "UNSET",
+                "DISABLE",
+                "PERMISSIVE",
+                "STRICT"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "portLevelMtls": {
+          "additionalProperties": {
+            "properties": {
+              "mode": {
+                "description": "Defines the mTLS mode used for peer authentication.",
+                "enum": [
+                  "UNSET",
+                  "DISABLE",
+                  "PERMISSIVE",
+                  "STRICT"
+                ],
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "Port specific mutual TLS settings.",
+          "type": "object"
+        },
+        "selector": {
+          "description": "The selector determines the workloads to apply the ChannelAuthentication on.",
+          "properties": {
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
The Istio PeerAuthentication actually has a different group than the networking.

```
apiVersion: security.istio.io/v1beta1
kind: PeerAuthentication
```

https://istio.io/latest/docs/tasks/security/authentication/authn-policy/#globally-enabling-istio-mutual-tls-in-strict-mode

I left the other file in networking in case that is a deprecated group from an earlier version.