### PR TITLE
Add Confluent Operator schemas

### DIFF
--- a/platform.confluent.io/clusterlink_v1beta1.json
+++ b/platform.confluent.io/clusterlink_v1beta1.json
@@ -1,0 +1,724 @@
+{
+  "description": "ClusterLink is the schema for the ClusterLink API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the cluster link.",
+      "properties": {
+        "aclFilters": {
+          "description": "aclFilters specify the list of ACLs to be migrated from the source cluster to the destination cluster.",
+          "items": {
+            "description": "AclFilter defines the configuration for the ACLs filter. This follows the same pattern as defined in the cluster linking documentation. More info: https://docs.confluent.io/platform/current/multi-dc-deployments/cluster-linking/security.html#cluster-link-acls-migrate",
+            "properties": {
+              "accessFilter": {
+                "description": "AclSyncAccessFilter defines the access filter for ACLs.",
+                "properties": {
+                  "host": {
+                    "description": "host is the host for which operations can be coming from. The default value is `*` that matches all hosts.",
+                    "type": "string"
+                  },
+                  "operation": {
+                    "description": "operation specifies the operation type of the filter. It can be `ANY` or operations based on resource type defined in the following Confluent documentation: https://docs.confluent.io/platform/current/kafka/authorization.html#acl-operations",
+                    "type": "string"
+                  },
+                  "permissionType": {
+                    "description": "permissionType is the permission type of the filter. Valid options are `any`, `allow`, and `deny`.",
+                    "enum": [
+                      "any",
+                      "allow",
+                      "deny"
+                    ],
+                    "type": "string"
+                  },
+                  "principal": {
+                    "description": "principal is the name of the principal. The default value is `*`.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation",
+                  "permissionType"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "resourceFilter": {
+                "description": "AclSyncResourceFilter specifies the resource filter for ACLs.",
+                "properties": {
+                  "name": {
+                    "description": "name is the name of the resource associated with this filter. The default value is `*`.",
+                    "type": "string"
+                  },
+                  "patternType": {
+                    "description": "patternType is the pattern of the resource. Valid options are `prefixed`, `literal`, `any`, and `match`.",
+                    "enum": [
+                      "prefixed",
+                      "literal",
+                      "any",
+                      "match"
+                    ],
+                    "type": "string"
+                  },
+                  "resourceType": {
+                    "description": "resourceType is the type of the filter. Valid options are `any`, `cluster`, `group`, `topic`, `transactionId`, and `delegationToken`.",
+                    "enum": [
+                      "any",
+                      "cluster",
+                      "group",
+                      "topic",
+                      "transcationId",
+                      "delegationToken"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "patternType",
+                  "resourceType"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "accessFilter",
+              "resourceFilter"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "configs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "configs is a map of string key and value pairs. It specifies additional configurations for the cluster link. More info: https://docs.confluent.io/platform/current/multi-dc-deployments/cluster-linking/configs.html",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "consumerGroupFilters": {
+          "description": "consumerGroupFilters specify a list of consumer groups to be migrated from the source cluster to the destination cluster.",
+          "items": {
+            "description": "ClusterLinkOptionsFilter defines the scheme for a filter",
+            "properties": {
+              "filterType": {
+                "description": "filterType specifies the filter type. Valid options are `INCLUDE` and `EXCLUDE`.",
+                "enum": [
+                  "INCLUDE",
+                  "EXCLUDE"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "name is the resource name associated with this filter.",
+                "type": "string"
+              },
+              "patternType": {
+                "description": "patternType is the pattern of the resource. Valid options are `PREFIXED` and `LITERAL`.",
+                "enum": [
+                  "PREFIXED",
+                  "LITERAL"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "filterType",
+              "name",
+              "patternType"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "destinationKafkaCluster": {
+          "description": "destinationKafkaCluster specifies the destination Kafka cluster and its REST API configuration.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication for the Kafka cluster.",
+              "properties": {
+                "jaasConfig": {
+                  "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "jaasConfigPassThrough": {
+                  "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "oauthbearer": {
+                  "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                  "enum": [
+                    "plain",
+                    "oauthbearer",
+                    "digest",
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bootstrapEndpoint": {
+              "description": "bootstrapEndpoint specifies the bootstrap endpoint for the Kafka cluster. When `spec.sourceInitiatedLink.linkMode` is configured as `Source`, this is required for `spec.destinationKafkaCluster` and not required for `spec.sourceKafkaCluster`. For other cluster links this is required for `spec.sourceKafkaCluster` and not required for `spec.destinationKafkaCluster`.",
+              "minLength": 1,
+              "pattern": ".+:[0-9]+",
+              "type": "string"
+            },
+            "clusterID": {
+              "description": "clusterID specifies the id of the Kafka cluster. If clusterID is defined for the Kafka cluster, it takes precedence over using the REST API for getting the cluster ID.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "kafkaRestClassRef": {
+              "description": "kafkaRestClassRef references the KafkaRestClass application resource which defines the Kafka REST API connection information. When `spec.sourceInitiatedLink.linkMode` is configured as `Source`, this is required for `spec.sourceKafkaCluster` and optional for `spec.destinationKafkaCluster` if `spec.clusterID` is set. For other cluster links this is required for 'spec.destinationKafkaCluster` and optional for `spec.sourceKafkaCluster` if the `spec.clusterID` is set.",
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of the KafkaRestClass application resource.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace specifies the namespace of the KafkaRestClass.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "tls specifies the client-side TLS configuration for the Kafka cluster.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer contains the directory path in the container where `fullchain.pem`, `privkey.pem`, `cacerts.pem` or `tls.crt`, `tls.key`, `ca.crt` keys are mounted.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies whether to enable the TLS configuration for the cluster link. The default value is `false`.",
+                  "type": "boolean"
+                },
+                "keyPassword": {
+                  "description": "keyPassword references the secret containing the SSL key password if the private key passed in the secretRef above is encrypted.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mirrorTopicOptions": {
+          "description": "mirrorTopicOptions specify configuration options for mirror topics.",
+          "properties": {
+            "autoCreateTopics": {
+              "description": "autoCreateTopics specifies configurations for the cluster link to automatically create mirror topics on the destination cluster for topics that exist on the source cluster based on defined filters. More info: https://docs.confluent.io/platform/current/multi-dc-deployments/cluster-linking/mirror-topics-cp.html#auto-create-mirror-topics",
+              "properties": {
+                "enabled": {
+                  "description": "enabled specifies whether to auto-create mirror topics based on topics on the source cluster. When set to \u201ctrue\u201d, mirror topics will be auto-created. Setting this option to \u201cfalse\u201d disables mirror topic creation and clears any existing filters.",
+                  "type": "boolean"
+                },
+                "topicFilters": {
+                  "description": "topicFilter contains an array of filters to apply to indicate which topics should be mirrored.",
+                  "items": {
+                    "description": "ClusterLinkOptionsFilter defines the scheme for a filter",
+                    "properties": {
+                      "filterType": {
+                        "description": "filterType specifies the filter type. Valid options are `INCLUDE` and `EXCLUDE`.",
+                        "enum": [
+                          "INCLUDE",
+                          "EXCLUDE"
+                        ],
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "name is the resource name associated with this filter.",
+                        "type": "string"
+                      },
+                      "patternType": {
+                        "description": "patternType is the pattern of the resource. Valid options are `PREFIXED` and `LITERAL`.",
+                        "enum": [
+                          "PREFIXED",
+                          "LITERAL"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "filterType",
+                      "name",
+                      "patternType"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prefix": {
+              "description": "prefix specifies prefix for the mirror topics of the cluster link. If configured, the valid mirror topic name should be defined with `<prefix><sourceTopicName>` format which mirrors the topic name of the format `<sourceTopicName>` from source cluster. When auto-create is enabled and the prefix is configured then the topics created on the destination will automatically contain the prefix. Otherwise, `spec.mirrorTopic.name` should be defined with `<prefix><sourceTopicName>` format.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9\\._\\-]*$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mirrorTopics": {
+          "description": "mirrorTopics specify the mirror topics under this cluster link.",
+          "items": {
+            "description": "MirrorTopic defines the mirror topic configuration.",
+            "properties": {
+              "configs": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "configs is a map of string key and value pairs. It specifies any additional configuration or configuration overrides for the mirror topic.",
+                "type": "object",
+                "x-kubernetes-map-type": "granular"
+              },
+              "name": {
+                "description": "name is the mirror topic name. If the sourceTopicName is not configured, we assume that the sourceTopicName is the same as mirrorTopicName, so a topic with the exact same name must exist on the source cluster and no topic with this name should exist on the destination cluster. When `spec.mirrorTopicOptions.prefix: <prefix>` is configured for the cluster link, the name has to be of the format `<prefix><sourceTopicName>`.",
+                "maxLength": 255,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z0-9\\._\\-]*$",
+                "type": "string"
+              },
+              "replicationFactor": {
+                "description": "replicationFactor specifies the replication factor for the mirror topic on the destination cluster. If this is not configured, mirror topic will inherit the broker `default.replication.factor` configuration.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "sourceTopicName": {
+                "description": "sourceTopicName is topic name on the source cluster that will be mirrored to the destination cluster. When `spec.mirrorTopicOptions.prefix: <prefix>` is not configured, you should not configure this field. If it is configured, a topic with the exact same name must exist on the source cluster.",
+                "maxLength": 255,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z0-9\\._\\-]*$",
+                "type": "string"
+              },
+              "state": {
+                "description": "state specifies the desired state for this mirror topic. Valid options are `ACTIVE`, `FAILOVER`, `PAUSE`, and `PROMOTE`. The default value is `ACTIVE`.",
+                "enum": [
+                  "PAUSE",
+                  "PROMOTE",
+                  "FAILOVER",
+                  "ACTIVE"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "name specifies the cluster link name. If not configured, then ClusterLink CR name is used as the cluster link name.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9\\._\\-]*$",
+          "type": "string"
+        },
+        "sourceInitiatedLink": {
+          "description": "sourceInitiatedLink specify configs for source initiated cluster links.",
+          "properties": {
+            "linkMode": {
+              "description": "linkMode specifies if this source initiated cluster link is in Source or Destination mode.",
+              "enum": [
+                "Source",
+                "Destination"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "linkMode"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sourceKafkaCluster": {
+          "description": "sourceKafkaCluster specifies the source Kafka cluster and its REST API configuration.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication for the Kafka cluster.",
+              "properties": {
+                "jaasConfig": {
+                  "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "jaasConfigPassThrough": {
+                  "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "oauthbearer": {
+                  "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                  "enum": [
+                    "plain",
+                    "oauthbearer",
+                    "digest",
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bootstrapEndpoint": {
+              "description": "bootstrapEndpoint specifies the bootstrap endpoint for the Kafka cluster. When `spec.sourceInitiatedLink.linkMode` is configured as `Source`, this is required for `spec.destinationKafkaCluster` and not required for `spec.sourceKafkaCluster`. For other cluster links this is required for `spec.sourceKafkaCluster` and not required for `spec.destinationKafkaCluster`.",
+              "minLength": 1,
+              "pattern": ".+:[0-9]+",
+              "type": "string"
+            },
+            "clusterID": {
+              "description": "clusterID specifies the id of the Kafka cluster. If clusterID is defined for the Kafka cluster, it takes precedence over using the REST API for getting the cluster ID.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "kafkaRestClassRef": {
+              "description": "kafkaRestClassRef references the KafkaRestClass application resource which defines the Kafka REST API connection information. When `spec.sourceInitiatedLink.linkMode` is configured as `Source`, this is required for `spec.sourceKafkaCluster` and optional for `spec.destinationKafkaCluster` if `spec.clusterID` is set. For other cluster links this is required for 'spec.destinationKafkaCluster` and optional for `spec.sourceKafkaCluster` if the `spec.clusterID` is set.",
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of the KafkaRestClass application resource.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace specifies the namespace of the KafkaRestClass.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "tls specifies the client-side TLS configuration for the Kafka cluster.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer contains the directory path in the container where `fullchain.pem`, `privkey.pem`, `cacerts.pem` or `tls.crt`, `tls.key`, `ca.crt` keys are mounted.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies whether to enable the TLS configuration for the cluster link. The default value is `false`.",
+                  "type": "boolean"
+                },
+                "keyPassword": {
+                  "description": "keyPassword references the secret containing the SSL key password if the private key passed in the secretRef above is encrypted.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "destinationKafkaCluster",
+        "sourceKafkaCluster"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the cluster link.",
+      "properties": {
+        "appState": {
+          "default": "Unknown",
+          "description": "appState is the current state of the cluster link application.",
+          "enum": [
+            "Unknown",
+            "Created",
+            "Failed",
+            "Deleted"
+          ],
+          "type": "string"
+        },
+        "clusterLinkID": {
+          "description": "clusterLinkID is the id of the cluster link.",
+          "type": "string"
+        },
+        "clusterLinkName": {
+          "description": "clusterLinkName is the name of the cluster link.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions are the latest available observations of the cluster link's state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "destinationKafkaClusterID": {
+          "description": "destinationKafkaClusterID is the ID of the destination Kafka cluster.",
+          "type": "string"
+        },
+        "kafkaCluster": {
+          "description": "kafkaCluster is the Kafka cluster this cluster link belongs to. The format is: `<Kafka namespace>/<Kafka name>`",
+          "type": "string"
+        },
+        "mirrorTopics": {
+          "additionalProperties": {
+            "description": "MirrorTopicStatus specifies the status reported for each mirror topic as part of the cluster link status.",
+            "properties": {
+              "observedGeneration": {
+                "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "replicationFactor": {
+                "description": "replicationFactor specifies the replication factor for the mirror topic on the destination cluster.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "sourceTopicName": {
+                "description": "sourceTopicName is the name of the topic being mirrored on the source cluster.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status is the status of the mirror topic. It can be `ACTIVE`, `FAILED`, `PAUSED`, `STOPPED`, and `PENDING_STOPPED`.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "mirrorTopics is a map of mirror topic name to its status",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "numMirrorTopics": {
+          "description": "numMirrorTopics is the number of mirror topics for the cluster link.",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "sourceKafkaClusterID": {
+          "description": "sourceKafkaClusterID is the ID of the source Kafka cluster.",
+          "type": "string"
+        },
+        "state": {
+          "description": "state is the current state of the cluster link.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/confluentrolebinding_v1beta1.json
+++ b/platform.confluent.io/confluentrolebinding_v1beta1.json
@@ -1,0 +1,269 @@
+{
+  "description": "ConfluentRolebinding is the schema for the ConfluentRolebinding API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the ConfluentRolebinding.",
+      "properties": {
+        "clustersScopeByIds": {
+          "description": "clustersScopeByIds specify the scope of the Confluent component cluster(s) via cluster id(s).",
+          "properties": {
+            "connectClusterId": {
+              "description": "connectClusterId specifies the Connect cluster id.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "kafkaClusterId": {
+              "description": "kafkaClusterId specifies the id of the Kafka cluster id.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "ksqlClusterId": {
+              "description": "ksqlClusterId specifies the ksqlDB cluster id.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "schemaRegistryClusterId": {
+              "description": "schemaRegistryClusterId specifies the Schema Registry cluster id.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "clustersScopeByRegistryName": {
+          "description": "clustersScopeByRegistryName specifies the unique cluster name you registered in the cluster registry.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "kafkaRestClassRef": {
+          "description": "kafkaRestClassRef references the KafkaRestClass that defines the Kafka REST API connection information.",
+          "properties": {
+            "name": {
+              "description": "name specifies the name of the KafkaRestClass application resource.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace specifies the namespace of the KafkaRestClass.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "principal": {
+          "description": "RolebindingPrincipal defines the principal(user/group) the rolebinding belongs to.",
+          "properties": {
+            "name": {
+              "description": "name specifies the name of the principal.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "type": {
+              "description": "type specifies the type of the principal. Valid options are `user` and `group`.",
+              "enum": [
+                "user",
+                "group"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resourcePatterns": {
+          "description": "resourcePatterns specify the qualified resources associated with this rolebinding.",
+          "items": {
+            "description": "ResourcePattern specifies the qualified resource info associated with this rolebinding.",
+            "properties": {
+              "name": {
+                "description": "name specifies the name of the resource associated with this rolebinding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "patternType": {
+                "description": "patternType specifies the pattern of the resource. Valid options are `PREFIXED` or `LITERAL`. The default value is `LITERAL`.",
+                "enum": [
+                  "PREFIXED",
+                  "LITERAL"
+                ],
+                "type": "string"
+              },
+              "resourceType": {
+                "description": "resourceType refers to the type of the resource. Valid options are `Topic`, `Group`, `Subject`, `KsqlCluster`, `Cluster`, `TransactionalId`, etc.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "resourceType"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "role": {
+          "description": "role specifies the name of the role.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "principal",
+        "role"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status is the observed state of the ConfluentRolebinding.",
+      "properties": {
+        "appState": {
+          "default": "Unknown",
+          "description": "appState is the current state of the rolebinding application.",
+          "enum": [
+            "Unknown",
+            "Created",
+            "Failed",
+            "Deleted"
+          ],
+          "type": "string"
+        },
+        "clusterRegistryName": {
+          "description": "clusterRegistryName is the cluster registry name the rolebinding associated with.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions are the latest available observations of the rolebinding's state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "kafkaCluster": {
+          "description": "kafkaCluster is the Kafka cluster the rolebinding belongs to. The format is: `<Kafka namespace>/<Kafka name>`.",
+          "type": "string"
+        },
+        "kafkaClusterID": {
+          "description": "kafkaClusterID is the id of the Kafka cluster.",
+          "type": "string"
+        },
+        "kafkaRestClass": {
+          "description": "kafkaRestClass is the kafkaRestClass this rolebinding uses. The format is: `<kafkaRestClass namespace>/<kafkaRestClass name>`.",
+          "type": "string"
+        },
+        "mdsEndpoint": {
+          "description": "mdsEndpoint is the MDS endpoint.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "principal": {
+          "description": "principal is the principal the rolebinding belongs to. The format is: `<principal type>:<principal name>`.",
+          "type": "string"
+        },
+        "resourcePatterns": {
+          "description": "resourcePatterns are the resource patterns this rolebinding is associated with.",
+          "items": {
+            "description": "ResourcePattern specifies the qualified resource info associated with this rolebinding.",
+            "properties": {
+              "name": {
+                "description": "name specifies the name of the resource associated with this rolebinding.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "patternType": {
+                "description": "patternType specifies the pattern of the resource. Valid options are `PREFIXED` or `LITERAL`. The default value is `LITERAL`.",
+                "enum": [
+                  "PREFIXED",
+                  "LITERAL"
+                ],
+                "type": "string"
+              },
+              "resourceType": {
+                "description": "resourceType refers to the type of the resource. Valid options are `Topic`, `Group`, `Subject`, `KsqlCluster`, `Cluster`, `TransactionalId`, etc.",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "resourceType"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "role": {
+          "description": "role is the role this rolebinding is associated with.",
+          "type": "string"
+        },
+        "state": {
+          "description": "state is the state of this rolebinding.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/connect_v1beta1.json
+++ b/platform.confluent.io/connect_v1beta1.json
@@ -1,0 +1,5254 @@
+{
+  "description": "Connect is the schema for the Connect API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the Connect cluster.",
+      "properties": {
+        "authentication": {
+          "description": "authentication specifies authentication configuration.",
+          "properties": {
+            "basic": {
+              "description": "basic specifies the configuration for basic authentication.",
+              "properties": {
+                "debug": {
+                  "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                  "type": "boolean"
+                },
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "restrictedRoles": {
+                  "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "roles": {
+                  "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "secretRef": {
+                  "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the authentication scheme for the REST API server. Valid options are `basic` and `mtls`.",
+              "enum": [
+                "basic",
+                "mtls"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "authorization": {
+          "description": "authorization specifies the authorization configuration.",
+          "properties": {
+            "kafkaRestClassRef": {
+              "description": "kafkaRestClassRef references the KafkaRestClass which specifies the Kafka REST API connection configuration.",
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of the KafkaRestClass application resource.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace specifies the namespace of the KafkaRestClass.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the client-side authorization type. The valid option is `rbac`.",
+              "enum": [
+                "rbac"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "build": {
+          "description": "build defines the build configurations for connector plugins.",
+          "properties": {
+            "onDemand": {
+              "description": "OnDemand defines the build configurations for the `onDemand` build type.",
+              "properties": {
+                "plugins": {
+                  "description": "plugins define the installation information for connector plugins.",
+                  "properties": {
+                    "confluentHub": {
+                      "description": "confluentHub contains a list of connector plugins you get from Confluent Hub.",
+                      "items": {
+                        "description": "ConfluentHubPlugin contains the required information to get the connector plugin from Confluent Hub.",
+                        "properties": {
+                          "name": {
+                            "description": "name specifies the name of the connector plugin.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "owner": {
+                            "description": "owner specifies the individual or organization that provides the connector plugin, for example, `confluentinc`.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "version specifies the version of the connector plugin, which can be either the version of the plugin or the literal `latest`.",
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "owner",
+                          "version"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "locationType": {
+                      "description": "locationType specifies where to get connector plugins. Valid options are `confluentHub` and `url`.",
+                      "enum": [
+                        "confluentHub",
+                        "url"
+                      ],
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "url contains a list of URL plugins you get from external URLs.",
+                      "items": {
+                        "description": "URLPlugin defines the information to get the connector plugin from an external URL.",
+                        "properties": {
+                          "archivePath": {
+                            "description": "archivePath specifies the archive path of the connector plugin. Currently, only support ZIP archives.",
+                            "minLength": 1,
+                            "pattern": "^https?://.*",
+                            "type": "string"
+                          },
+                          "checksum": {
+                            "description": "checksum defines the sha512sum checksum of the connector plugin's remote file. It is used to verify the remote file after it is downloaded.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "name specifies the connector plugin name.",
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "archivePath",
+                          "checksum",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "locationType"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "storageLimit": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "storageLimit specifies the max amount of node volume that can be used to store connector plugins. The default value is `4G`.",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "required": [
+                "plugins"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the build type for connector plugins. Currently only the `onDemand` type is supported.",
+              "enum": [
+                "onDemand"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "configOverrides": {
+          "description": "configOverrides specifies the configs to override the server, JVM, Log4j properties for the Connect cluster.",
+          "properties": {
+            "jvm": {
+              "description": "jvm is a list of JVM configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "log4j": {
+              "description": "log4j is a list of Log4J configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "server": {
+              "description": "server is a list of server configuration supported by the Confluent Platform component. This will either add or update existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "connectorOverridePolicy": {
+          "description": "connectorOverridePolicy allows the policy to permit per-connector override configuration for producer/consumer/admin prefix. More info: https://docs.confluent.io/platform/current/connect/security.html#separate-principals",
+          "enum": [
+            "All",
+            "Principal"
+          ],
+          "type": "string"
+        },
+        "connectorTLSCerts": {
+          "description": "connectorTLSCerts are the custom TLS certificates injected into the Connect cluster for connectors to use. Check the Connect status for the mount path of the certificates. A change will roll the cluster.",
+          "items": {
+            "description": "MountedCustomTLSCertificate defines the mounted custom TLS structure for the Confluent Platform component.",
+            "properties": {
+              "directoryPathInContainer": {
+                "description": "directoryPathInContainer contains the directory path in the container where `keystore.jks`, `truststore.jks`, `jksPassword.txt` keys are mounted.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "jksPassword": {
+                "description": "jksPassword specifies the secret name that contains the JKS password.",
+                "properties": {
+                  "secretRef": {
+                    "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                    "maxLength": 30,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "secretRef"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "secretRef": {
+                "description": "secretRef specifies the secret name that contains the certificates. More info about certificates key/value format: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                "maxLength": 30,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "dependencies": {
+          "description": "ConnectDependencies contains the dependencies the Connect requires or can enable.",
+          "properties": {
+            "admin": {
+              "description": "admin contains the security configuration to connect to the admin client. If `bootstrapEndpoint` is not configured, the security is configured based on the Kafka dependency configuration. Configure this property if different bootstrap endpoint is required for the admin client.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication defines the authentication for the Kafka cluster.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "digest",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bootstrapEndpoint": {
+                  "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "discovery": {
+                  "description": "discovery specifies the capability to discover the Kafka cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name is the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "consumer": {
+              "description": "consumer contains the security configuration to connect to the Kafka cluster. It is used for sink connectors. If `bootstrapEndpoint` is not configured, the security is configured based on the Kafka dependency configuration. Configure this property if different bootstrap endpoint is required for the consumer.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication defines the authentication for the Kafka cluster.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "digest",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bootstrapEndpoint": {
+                  "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "discovery": {
+                  "description": "discovery specifies the capability to discover the Kafka cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name is the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "interceptor": {
+              "description": "interceptor contains the dependency configuration for the monitoring interceptor.",
+              "properties": {
+                "configs": {
+                  "description": "configs describe the configurations for the Confluent Platform interceptor. The config override feature can be used to pass the configuration settings.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "consumer": {
+                  "description": "consumer specifies the consumer configuration for the interceptor. If not configured, it uses the Kafka dependency configuration.",
+                  "properties": {
+                    "authentication": {
+                      "description": "authentication defines the authentication for the Kafka cluster.",
+                      "properties": {
+                        "jaasConfig": {
+                          "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "jaasConfigPassThrough": {
+                          "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauthbearer": {
+                          "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": {
+                          "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                          "enum": [
+                            "plain",
+                            "oauthbearer",
+                            "digest",
+                            "mtls"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "bootstrapEndpoint": {
+                      "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                      "minLength": 1,
+                      "pattern": ".+:[0-9]+",
+                      "type": "string"
+                    },
+                    "discovery": {
+                      "description": "discovery specifies the capability to discover the Kafka cluster.",
+                      "properties": {
+                        "name": {
+                          "description": "name is the name of the Confluent Platform component cluster.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tls": {
+                      "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "ignoreTrustStoreConfig": {
+                          "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "jksPassword": {
+                          "description": "jksPassword references the secret containing the JKS password.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "enabled": {
+                  "description": "enabled indicates whether the Confluent Platform interceptor is enabled or disabled.",
+                  "type": "boolean"
+                },
+                "producer": {
+                  "description": "producer specifies the producer configuration for the interceptor. If not configured, it uses the Kafka dependency configuration.",
+                  "properties": {
+                    "authentication": {
+                      "description": "authentication defines the authentication for the Kafka cluster.",
+                      "properties": {
+                        "jaasConfig": {
+                          "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "jaasConfigPassThrough": {
+                          "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauthbearer": {
+                          "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": {
+                          "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                          "enum": [
+                            "plain",
+                            "oauthbearer",
+                            "digest",
+                            "mtls"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "bootstrapEndpoint": {
+                      "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                      "minLength": 1,
+                      "pattern": ".+:[0-9]+",
+                      "type": "string"
+                    },
+                    "discovery": {
+                      "description": "discovery specifies the capability to discover the Kafka cluster.",
+                      "properties": {
+                        "name": {
+                          "description": "name is the name of the Confluent Platform component cluster.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tls": {
+                      "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "ignoreTrustStoreConfig": {
+                          "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "jksPassword": {
+                          "description": "jksPassword references the secret containing the JKS password.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "publishMs": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kafka": {
+              "description": "kafka contains the Connect dependency for connecting to Kafka. The discovery method is used if this is not specified.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication defines the authentication for the Kafka cluster.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "digest",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bootstrapEndpoint": {
+                  "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "discovery": {
+                  "description": "discovery specifies the capability to discover the Kafka cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name is the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mds": {
+              "description": "mds contains the configuration for MDS dependency when RBAC is enabled.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the client side authentication configuration for the MDS.",
+                  "properties": {
+                    "bearer": {
+                      "description": "bearer specifies the bearer authentication settings.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication method for the MDS. The valid option is `bearer`.",
+                      "enum": [
+                        "bearer"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bearer",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "endpoint": {
+                  "description": "endpoint specifies the MDS endpoint.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tokenKeyPair": {
+                  "description": "tokenKeyPair specifies the token keypair to configure the MDS.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret that contains the MDS token key pair.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "authentication",
+                "endpoint",
+                "tokenKeyPair"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "producer": {
+              "description": "producer contains the security configuration to connect to the Kafka cluster. It is used for source connectors. If `bootstrapEndpoint` is not configured, the security is configured based on the Kafka dependency configuration. Configure this property if different bootstrap endpoint of security is required for the producer.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication defines the authentication for the Kafka cluster.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "digest",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bootstrapEndpoint": {
+                  "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "discovery": {
+                  "description": "discovery specifies the capability to discover the Kafka cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name is the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "schemaRegistry": {
+              "description": "schemaRegistry contains the dependency configuration for the Schema Registry cluster.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the authentication for the Schema Registry cluster.",
+                  "properties": {
+                    "basic": {
+                      "description": "basic specifies the configuration for basic authentication.",
+                      "properties": {
+                        "debug": {
+                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                          "type": "boolean"
+                        },
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "restrictedRoles": {
+                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "roles": {
+                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretRef": {
+                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                      "enum": [
+                        "basic",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Schema Registry cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "description": "url specifies the URL endpoint of the Schema Registry cluster.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "enableSchemas": {
+          "description": "enableSchemas indicates whether to enable scheme or not.",
+          "type": "boolean"
+        },
+        "externalAccess": {
+          "description": "CPExternalAccess holds all external access policies for the non-Kafka component clusters.",
+          "properties": {
+            "loadBalancer": {
+              "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain is the domain name of the component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "loadBalancerSourceRanges": {
+                  "description": "loadBalancerSourceRanges specify the source ranges.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "port": {
+                  "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "prefix": {
+                  "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify the user-provided service port(s).",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodePort": {
+              "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "host": {
+                  "description": "host defines the host name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "nodePortOffset": {
+                  "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "host",
+                "nodePortOffset"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "route": {
+              "description": "route specifies the configuration to create a route service in OpenShift.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain specifies the domain name of the Confluent component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "prefix": {
+                  "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "wildcardPolicy": {
+                  "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                  "enum": [
+                    "Subdomain",
+                    "None"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+              "enum": [
+                "loadBalancer",
+                "nodePort",
+                "route"
+              ],
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "headlessService": {
+          "description": "headlessService specifies the configuration of the Kubernetes headless service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs. It specifies the annotations to be added to the CFK-created headless service. These annotations are merged with the injectAnnotations and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs. It specifies the labels to be added to the CFK-created headless service. These labels are merged with the injectLabels and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "publishNotReadyAddresses": {
+              "description": "publishNotReadyAddresses specifies the publishNotReadyAddresses field. For Kafka, this value must be true. The default value is true.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "image specifies the application and the init docker image configurations. A change to this setting will roll the cluster.",
+          "properties": {
+            "application": {
+              "description": "application is the Docker image name of the application. Specify `<Docker-registry FQDN>/<docker-repository-name>/<component-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "init": {
+              "description": "init is the init-container name. Specify `<Docker-registry FQDN>/<docker-repository-name>/<init-container-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "description": "pullPolicy is the policy for pulling images. Valid options are `Always`, `Never`, and `IfNotPresent`. The default value is `IfNotPresent`.",
+              "enum": [
+                "Always",
+                "Never",
+                "IfNotPresent"
+              ],
+              "type": "string"
+            },
+            "pullSecretRef": {
+              "description": "pullSecretRef references the secrets in the same namespace to be used for pulling images. Image pull secrets are distinct from secrets because secrets can be mounted in the pod, but image pull secrets are only accessed by `kubelet`. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "application",
+            "init"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "injectAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectAnnotations are the annotations injected to the internal resources that CFK created. The internal annotations are preserved and cannot be overridden. For pod annotations, use `podTemplate.annotations`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "injectLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectLabels are the labels injected to the internal resources that CFK created. The internal labels are preserved and cannot be overridden. For pod labels, use `podTemplate.labels`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "internalTopicReplicationFactor": {
+          "description": "internalTopicReplicationFactor specifies the replication factor for the internal topics. The default value is `3`.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "k8sClusterDomain": {
+          "description": "k8sClusterDomain specifies the configuration of the Kubernetes cluster domain. The default is the `cluster.local` domain.",
+          "type": "string"
+        },
+        "keyConverterType": {
+          "description": "keyConverterType specifies the supported key converters package for the Confluent Platform. For the supported converter types, see https://docs.confluent.io/current/connect/concepts.html#connect-converters. The default value is `org.apache.kafka.connect.json.JsonConverter`.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "license": {
+          "description": "license specifies the license configuration for the Confluent Platform component.",
+          "properties": {
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where the license key is mounted. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "minLength": 1,
+              "type": "string"
+            },
+            "globalLicense": {
+              "description": "globalLicense specifies whether the Confluent Platform component shares the common global license.",
+              "type": "boolean"
+            },
+            "secretRef": {
+              "description": "secretRef references the secret that provides the license for the Confluent Platform component. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metrics": {
+          "description": "metrics specify the security settings for the metric services.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication configuration for the metrics.",
+              "properties": {
+                "type": {
+                  "description": "type specifies the metrics authentication method. The valid option is `mtls`.",
+                  "enum": [
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prometheus": {
+              "description": "prometheus specifies the configuration overrides for the JMX-Prometheus exporter.",
+              "properties": {
+                "blacklist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "rules": {
+                  "items": {
+                    "description": "Rule defines the Prometheus Exporter rule override.",
+                    "properties": {
+                      "attrNameSnakeCase": {
+                        "type": "boolean"
+                      },
+                      "cache": {
+                        "type": "boolean"
+                      },
+                      "help": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "granular"
+                      },
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "type": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "valueFactor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": 1,
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "whitelist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "tls specifies the TLS configuration for the metrics.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "ignoreTrustStoreConfig": {
+                  "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "jksPassword": {
+                  "description": "jksPassword references the secret containing the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mountedSecrets": {
+          "description": "mountedSecrets list the secrets injected to the underlying statefulset configuration. The secret reference is mounted in the default path `/mnt/secrets/<secret-name>`. The underlying resources will follow the secret as a file configuration. More info: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod. A change to this setting will roll the cluster.",
+          "items": {
+            "description": "MountedSecrets provides a way to inject a custom secret to the underlying statefulset.",
+            "properties": {
+              "keyItems": {
+                "description": "keyItems are key and path names.",
+                "items": {
+                  "description": "Maps a string key to a path within a volume.",
+                  "properties": {
+                    "key": {
+                      "description": "The key to project.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "path": {
+                      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "path"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "secretRef": {
+                "description": "secretRef references the name of the secret.",
+                "maxLength": 30,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "secretRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mountedVolumes": {
+          "description": "mountedVolumes list the custom volumes that need to be mounted into the underlying statefulset. A change to this setting will roll the cluster.",
+          "properties": {
+            "volumeMounts": {
+              "description": "volumeMounts specify the list of volume mounts for the pods in the statefulset.",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                    "type": "boolean"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "volumes specify the list of volumes that can be mounted into the pods of statefulset.",
+              "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureDisk": {
+                    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "cachingMode": {
+                        "description": "Host Caching mode: None, Read Only, Read Write.",
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "description": "The Name of the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "description": "The URI the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureFile": {
+                    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "the name of secret that contains Azure Storage Account Name and Key",
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "description": "Share Name",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cephfs": {
+                    "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "monitors": {
+                        "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cinder": {
+                    "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeID": {
+                        "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "configMap": {
+                    "description": "ConfigMap represents a configMap that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its keys must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "csi": {
+                    "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "readOnly": {
+                        "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "downwardAPI": {
+                    "description": "DownwardAPI represents downward API about the pod that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "Items is a list of downward API volume file",
+                        "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                          "properties": {
+                            "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "emptyDir": {
+                    "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "properties": {
+                      "medium": {
+                        "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ephemeral": {
+                    "description": "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                            "properties": {
+                              "accessModes": {
+                                "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dataSource": {
+                                "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "description": "Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "description": "Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "description": "A label query over volumes to consider for binding.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fc": {
+                    "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "Optional: FC target lun number",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "description": "Optional: FC target worldwide names (WWNs)",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "wwids": {
+                        "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flexVolume": {
+                    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the driver to use for this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Optional: Extra command options if any.",
+                        "type": "object"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flocker": {
+                    "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                    "properties": {
+                      "datasetName": {
+                        "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcePersistentDisk": {
+                    "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "pdName": {
+                        "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "pdName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitRepo": {
+                    "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                    "properties": {
+                      "directory": {
+                        "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "Repository URL",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "Commit hash for the specified revision.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repository"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "glusterfs": {
+                    "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                    "properties": {
+                      "endpoints": {
+                        "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostPath": {
+                    "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                    "properties": {
+                      "path": {
+                        "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "iscsi": {
+                    "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "description": "whether support iSCSI Discovery CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "description": "whether support iSCSI Session CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "description": "Target iSCSI Qualified Name.",
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "iSCSI Target Lun number.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "portals": {
+                        "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "CHAP Secret for iSCSI target and initiator authentication",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "targetPortal": {
+                        "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "properties": {
+                      "path": {
+                        "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "properties": {
+                      "claimName": {
+                        "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "claimName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "photonPersistentDisk": {
+                    "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "description": "ID that identifies Photon Controller persistent disk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pdID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "portworxVolume": {
+                    "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "VolumeID uniquely identifies a Portworx volume",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "projected": {
+                    "description": "Items for all in one resources secrets, configmaps, and downward API",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "sources": {
+                        "description": "list of volume projections",
+                        "items": {
+                          "description": "Projection that may be projected along with other supported volume types",
+                          "properties": {
+                            "configMap": {
+                              "description": "information about the configMap data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                              "description": "information about the downwardAPI data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secret": {
+                              "description": "information about the secret data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountToken": {
+                              "description": "information about the serviceAccountToken data to project",
+                              "properties": {
+                                "audience": {
+                                  "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "quobyte": {
+                    "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "group": {
+                        "description": "Group to map volume access to Default is no group",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User to map volume access to Defaults to serivceaccount user",
+                        "type": "string"
+                      },
+                      "volume": {
+                        "description": "Volume is a string that references an already created Quobyte volume by name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbd": {
+                    "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "image": {
+                        "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "pool": {
+                        "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scaleIO": {
+                    "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "description": "The host address of the ScaleIO API Gateway.",
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "sslEnabled": {
+                        "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                        "type": "string"
+                      },
+                      "system": {
+                        "description": "The name of the storage system as configured in ScaleIO.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its keys must be defined",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageos": {
+                    "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeName": {
+                        "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "vsphereVolume": {
+                    "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "description": "Storage Policy Based Management (SPBM) profile name.",
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "description": "Path that identifies vSphere volume vmdk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumePath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "volumeMounts",
+            "volumes"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oneReplicaPerNode": {
+          "description": "oneReplicaPerNode controls whether to run 1 pod per node using the pod anti-affinity capability. Enabling this configuration in an existing cluster will roll the cluster.",
+          "type": "boolean"
+        },
+        "podTemplate": {
+          "description": "podTemplate specifies the statefulset pod template configuration.",
+          "properties": {
+            "affinity": {
+              "description": "affinity specifies a group of affinity scheduling rules. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.",
+              "properties": {
+                "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                        "properties": {
+                          "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs stored with the resource and may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "envVars": {
+              "description": "envVars contain environment variables to be injected into containers. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs that can be used to organize and categorize (scope and select) objects. More info: http://kubernetes.io/docs/user-guide/labels.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "podSecurityContext": {
+              "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+              "properties": {
+                "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
+                    "properties": {
+                      "name": {
+                        "description": "Name of a property to set",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of a property to set",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "priorityClassName": {
+              "description": "priorityClassName specifies the priority class for the pod (if any).",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "probe": {
+              "description": "probe contains the fields for standard Kubernetes readiness/liveness probe configuration.",
+              "properties": {
+                "liveness": {
+                  "description": "liveness configures the Kubernetes probe settings. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "readiness": {
+                  "description": "readiness configures the Kubernetes probe setting. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "resources": {
+              "description": "resources describe the compute resource requirements.",
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityContext": {
+              "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "description": "ServiceAccountName is the name of the service account used to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account.",
+              "type": "string"
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "terminationGracePeriodSeconds is the grace period before the pod is deleted.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "tolerations": {
+              "description": "tolerations specify the pods to schedule onto the nodes with matching taints, using the triple `<key,value,effect>` and the matching operator `<operator>`.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "topologySpreadConstraints describe how a group of pods ought to spread across topology domains. Scheduler will schedule pods based on the constraints. All topologySpreadConstraints are ANDed.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas. A change to this setting will roll the cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "telemetry": {
+          "description": "telemetry specifies the Confluent telemetry reporter configuration.",
+          "properties": {
+            "global": {
+              "description": "global allows disabling telemetry configuration. If CFK is deployed with telemetry, this field is only used to disable telemetry. The default value is `true` if telemetry is enabled at the global level.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tls": {
+          "description": "tls specifies the global-level TLS configuration.",
+          "properties": {
+            "autoGeneratedCerts": {
+              "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
+              "type": "boolean"
+            },
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "ignoreTrustStoreConfig": {
+              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+              "type": "boolean"
+            },
+            "jksPassword": {
+              "description": "jksPassword references the secret containing the JKS password.",
+              "properties": {
+                "secretRef": {
+                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "valueConverterType": {
+          "description": "valueConverterType specifies the supported value converters package for the Confluent Platform. For the supported converter types, see https://docs.confluent.io/current/connect/concepts.html#connect-converters. The default value is `org.apache.kafka.connect.json.JsonConverter`.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "image",
+        "replicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the Connect cluster.",
+      "properties": {
+        "arbitraryData": {
+          "description": "arbitraryData is the map for any arbitrary data associated with this Confluent component.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "authorizationType": {
+          "description": "authorizationType is the authorization type for this Confluent component.",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "clusterName is the name of the Confluent Platform component cluster.",
+          "type": "string"
+        },
+        "clusterNamespace": {
+          "description": "clusterNamespace is the namespace where the Confluent Platform component cluster is running.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions specify the latest available observations of the current state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "connectorPlugins": {
+          "description": "connectorPlugins are the installed connector plugins.",
+          "items": {
+            "description": "ConnectorPluginStatus defines the state of the connector plugin.",
+            "properties": {
+              "class": {
+                "description": "class specifies the class name of the connector plugin.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type is the connector plugin type, which can be `SOURCE`, `SINK` or `UNKNOWN`.",
+                "type": "string"
+              },
+              "version": {
+                "description": "version is the current version of the connector plugin.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "class"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "connectorTLSFilePaths": {
+          "description": "connectorTLSFilePaths are the connector TLS file paths.",
+          "items": {
+            "description": "CustomTLSFilePathStatus specifies the file paths of the custom TLS certificates.",
+            "properties": {
+              "jksPasswordPath": {
+                "description": "jksPasswordPath contains the absolute path of the `jksPassword.txt` file.",
+                "type": "string"
+              },
+              "keyStorePath": {
+                "description": "keyStorePath contains the absolute path of the keystore file, `.jks` or `.p12`.",
+                "type": "string"
+              },
+              "trustStorePath": {
+                "description": "trustStorePath contains the absolute path of the truststore file, `.jks` or `.p12`.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of currently running replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "groupID": {
+          "description": "groupID is the group id of the Connect cluster.",
+          "type": "string"
+        },
+        "internalSecrets": {
+          "description": "internalSecrets are internal secrets created by CFK for this Confluent component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "internalTopicNames": {
+          "description": "internalTopicNames are the topics used by the component for internal use.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kafka": {
+          "description": "kafka is the Kafka client side status for the Connect cluster.",
+          "properties": {
+            "authenticationType": {
+              "description": "authenticationType describes the authentication method for the Kafka cluster.",
+              "type": "string"
+            },
+            "bootstrapEndpoint": {
+              "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls indicates whether TLS is enabled for the Kafka dependency.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "description": "operatorVersion is the internal version of CFK.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "phase describes the state of the Confluent Platform component. This can either be 'PROVISIONING' or 'RUNNING' 'PROVISIONING' means the Confluent Platform component is currently getting deployed and not ready yet. 'RUNNING' means the Confluent Platform component has been successfully deployed.",
+          "type": "string"
+        },
+        "rbac": {
+          "description": "rbac contains the RBAC-related status when RBAC is enabled.",
+          "properties": {
+            "clusterID": {
+              "description": "clusterID specifies the id of the cluster.",
+              "type": "string"
+            },
+            "internalRolebindings": {
+              "description": "internalRolebindings specifies the internal rolebindings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of currently ready replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "restConfig": {
+          "description": "restConfig is the REST configuration of the Connect cluster.",
+          "properties": {
+            "advertisedExternalEndpoints": {
+              "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "authenticationType": {
+              "description": "authenticationType shows the authentication type configured by the listener.",
+              "type": "string"
+            },
+            "externalAccessType": {
+              "description": "externalAccessType shows the external access type used for the listener.",
+              "type": "string"
+            },
+            "externalEndpoint": {
+              "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "internalEndpoint": {
+              "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls shows whether TLS is configured for the listener.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "selector gets the label selector of the child pod. The Horizontal Pod Autoscaler(HPA) will scale using the label selector of the child pod.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/connector_v1beta1.json
+++ b/platform.confluent.io/connector_v1beta1.json
@@ -1,0 +1,375 @@
+{
+  "description": "Connector is the schema for the Connector API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the Connector.",
+      "properties": {
+        "class": {
+          "description": "class specifies the class name of the connector. The Connect cluster displays the supported class names in its status.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "configs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "configs is a map of string key and value pairs. It specifies the additional configurations for the connector.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "connectClusterRef": {
+          "description": "connectClusterRef references the CFK managed Connect cluster.",
+          "properties": {
+            "name": {
+              "description": "name specifies the name of the Confluent Platform component cluster.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace specifies the namespace where the Confluent Platform component cluster is running.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "connectRest": {
+          "description": "connectRest specifies the Connect REST API connection configuration.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the REST API authentication mechanism.",
+              "properties": {
+                "basic": {
+                  "description": "basic specifies the basic authentication settings for the REST API client.",
+                  "properties": {
+                    "debug": {
+                      "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                      "type": "boolean"
+                    },
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "restrictedRoles": {
+                      "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "roles": {
+                      "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "secretRef": {
+                      "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bearer": {
+                  "description": "bearer specifies the bearer authentication settings for the REST API client.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "type specifies the REST API authentication type. Valid options are `basic`, `bearer`, and `mtls`.",
+                  "enum": [
+                    "basic",
+                    "bearer",
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "endpoint": {
+              "description": "endpoint specifies where Confluent REST API is running.",
+              "minLength": 1,
+              "pattern": "^https?://.*",
+              "type": "string"
+            },
+            "kafkaClusterID": {
+              "description": "kafkaClusterID specifies the id of Kafka cluster. It takes precedence over using the Kafka REST API to get the cluster id.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls specifies the custom TLS structure for the application resources, e.g. connector, topic, schema, of the Confluent Platform components.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer contains the directory path in the container where `keystore.jks`, `truststore.jks`, `jksPassword.txt` keys are mounted.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "jksPassword": {
+                  "description": "jksPassword specifies the secret name that contains the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef specifies the secret name that contains the certificates. More info about certificates key/value format: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "name": {
+          "description": "name specifies the connector name. If not configured, the Connector CR name is used as the connector name.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9\\._\\-]*$",
+          "type": "string"
+        },
+        "restartPolicy": {
+          "description": "restartPolicy specifies the policy to restart failed tasks of the connector.",
+          "properties": {
+            "maxRetry": {
+              "description": "maxRetry specifies the max number of tries to restart failed tasks when the `restartPolicy` type is `OnFailure`. The default value is `10`.",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "type": {
+              "description": "type specifies the policy type to restart connector tasks. Valid options are `OnFailure` and `Never`. Default value is `OnFailure`, which means it will restart automatically when a task fails if the `maxRetry` value is not reached.",
+              "enum": [
+                "OnFailure",
+                "Never"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "taskMax": {
+          "description": "taskMax specifies the maximum number of tasks for the connector. It must be greater than 0. The connector may create fewer tasks if it cannot achieve this level of parallelism.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "class",
+        "taskMax"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the Connector.",
+      "properties": {
+        "appState": {
+          "default": "Unknown",
+          "description": "appState is the current state of the connector application.",
+          "enum": [
+            "Unknown",
+            "Created",
+            "Failed",
+            "Deleted"
+          ],
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions are the latest available observations of the connector state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "connectRestEndpoint": {
+          "description": "connectRestEndpoint is the REST endpoint of the Connect cluster.",
+          "type": "string"
+        },
+        "connectorState": {
+          "description": "connectorState is the status of the connector instance.",
+          "type": "string"
+        },
+        "failedTasks": {
+          "additionalProperties": {
+            "description": "TaskStatus defines the connector task status.",
+            "properties": {
+              "id": {
+                "description": "Id is the id of the task.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "retryCount": {
+                "description": "retryCount is the number of retry attempts to restart the failed task.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "workerID": {
+                "description": "workerID is the workerId for the task.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "failedTasks is the map of connector tasks in the `FAILED` state. Error messages of failed tasks are logged in the CFK logs as `INFO`. You can also get the error message via Connect REST API calls.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "failedTasksCount": {
+          "description": "failedTasksCount is the number of failed tasks.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "kafkaClusterID": {
+          "description": "kafkaClusterID is the Kafka cluster id the connector belongs to.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "restartPolicy": {
+          "description": "restartPolicy is the policy to restart failed tasks of the connector.",
+          "properties": {
+            "maxRetry": {
+              "description": "maxRetry specifies the max number of tries to restart failed tasks when the `restartPolicy` type is `OnFailure`. The default value is `10`.",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "type": {
+              "description": "type specifies the policy type to restart connector tasks. Valid options are `OnFailure` and `Never`. Default value is `OnFailure`, which means it will restart automatically when a task fails if the `maxRetry` value is not reached.",
+              "enum": [
+                "OnFailure",
+                "Never"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "state": {
+          "description": "state is the custom resource state of the connector. This is not the connector state, which can be `CREATED`, `ERROR`, etc.",
+          "type": "string"
+        },
+        "tasksReady": {
+          "description": "tasksReady is the number of running tasks based on `taskMax`. The value is in the following format: `<number of running tasks>/<taskMax>`",
+          "type": "string"
+        },
+        "trace": {
+          "description": "trace is the error trace message for the connector instance.",
+          "type": "string"
+        },
+        "workerID": {
+          "description": "workerID is the workerId of the connector instance.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/controlcenter_v1beta1.json
+++ b/platform.confluent.io/controlcenter_v1beta1.json
@@ -1,0 +1,4947 @@
+{
+  "description": "ControlCenter is the schema for the Control Center API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the Control Center cluster.",
+      "properties": {
+        "authentication": {
+          "description": "authentication specifies the authentication configurations.",
+          "properties": {
+            "basic": {
+              "description": "basic specifies the configuration for basic authentication.",
+              "properties": {
+                "debug": {
+                  "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                  "type": "boolean"
+                },
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "restrictedRoles": {
+                  "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "roles": {
+                  "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "secretRef": {
+                  "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ldap": {
+              "description": "ldap specifies the configuration for Control Center LDAP authentication.",
+              "properties": {
+                "debug": {
+                  "description": "debug enables basic authentication debug logs for JaaS configuration.",
+                  "type": "boolean"
+                },
+                "property": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "property is a map of string key and value pairs that specifies the LDAP configuration. Use a secret object to pass username/password.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "restrictedRoles": {
+                  "description": "restrictedRoles specify the restricted access roles.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "roles": {
+                  "description": "roles specify the roles on the server side only.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret to pass required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#ldap-authentication-for-c3",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the authentication type of the Control Center. Valid options are `basic`, `ldap`, and `mtls`.",
+              "enum": [
+                "basic",
+                "ldap",
+                "mtls"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "authorization": {
+          "description": "authorization specifies the authorization configurations.",
+          "properties": {
+            "kafkaRestClassRef": {
+              "description": "kafkaRestClassRef references the KafkaRestClass which specifies the Kafka REST API connection configuration.",
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of the KafkaRestClass application resource.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace specifies the namespace of the KafkaRestClass.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the client-side authorization type. The valid option is `rbac`.",
+              "enum": [
+                "rbac"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "configOverrides": {
+          "description": "configOverrides specifies the configs to override the server, JVM, Log4j properties for the Control Center.",
+          "properties": {
+            "jvm": {
+              "description": "jvm is a list of JVM configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "log4j": {
+              "description": "log4j is a list of Log4J configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "server": {
+              "description": "server is a list of server configuration supported by the Confluent Platform component. This will either add or update existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dataVolumeCapacity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "dataVolumeCapacity specifies the data size for the persistent volume.",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
+        "dependencies": {
+          "description": "dependencies specify the dependencies configurations.",
+          "properties": {
+            "connect": {
+              "description": "connect defines the Connect worker dependency configurations.",
+              "items": {
+                "description": "ControlCenterConnectDependency defines the Connect dependency settings.",
+                "properties": {
+                  "authentication": {
+                    "description": "authentication specifies the authentication configuration for the Connect cluster.",
+                    "properties": {
+                      "basic": {
+                        "description": "basic specifies the configuration for basic authentication.",
+                        "properties": {
+                          "debug": {
+                            "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                            "type": "boolean"
+                          },
+                          "directoryPathInContainer": {
+                            "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "restrictedRoles": {
+                            "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "roles": {
+                            "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "secretRef": {
+                            "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                            "maxLength": 30,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                        "enum": [
+                          "basic",
+                          "mtls"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "name specifies the Connect cluster name.",
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "tls": {
+                    "description": "tls specifies the client-side TLS setting for the Connect cluster.",
+                    "properties": {
+                      "directoryPathInContainer": {
+                        "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "enabled": {
+                        "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                        "type": "boolean"
+                      },
+                      "ignoreTrustStoreConfig": {
+                        "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                        "type": "boolean"
+                      },
+                      "jksPassword": {
+                        "description": "jksPassword references the secret containing the JKS password.",
+                        "properties": {
+                          "secretRef": {
+                            "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                            "maxLength": 30,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretRef"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secretRef": {
+                        "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                        "maxLength": 30,
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "enabled"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "url": {
+                    "description": "url specifies the URL endpoint of the Connect cluster.",
+                    "minLength": 1,
+                    "pattern": "^https?://.*",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "url"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "kafka": {
+              "description": "kafka defines the Kafka dependency configurations.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication defines the authentication for the Kafka cluster.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "digest",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bootstrapEndpoint": {
+                  "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "discovery": {
+                  "description": "discovery specifies the capability to discover the Kafka cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name is the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ksqldb": {
+              "description": "ksqldb defines the ksqlDB dependency configurations.",
+              "items": {
+                "description": "ControlCenterKSQLDependency defines the ksqlDB dependency settings.",
+                "properties": {
+                  "advertisedUrl": {
+                    "description": "advertisedUrl specifies the advertised URL to use in the browser.",
+                    "minLength": 1,
+                    "pattern": "^https?://.*",
+                    "type": "string"
+                  },
+                  "authentication": {
+                    "description": "authentication specifies the authentication for the ksqlDB cluster.",
+                    "properties": {
+                      "basic": {
+                        "description": "basic specifies the configuration for basic authentication.",
+                        "properties": {
+                          "debug": {
+                            "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                            "type": "boolean"
+                          },
+                          "directoryPathInContainer": {
+                            "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "restrictedRoles": {
+                            "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "roles": {
+                            "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "secretRef": {
+                            "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                            "maxLength": 30,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                        "enum": [
+                          "basic",
+                          "mtls"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "name specifies the ksqlDB cluster name.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "tls": {
+                    "description": "tls specifies the client-side TLS setting for the ksqlDB cluster.",
+                    "properties": {
+                      "directoryPathInContainer": {
+                        "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "enabled": {
+                        "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                        "type": "boolean"
+                      },
+                      "ignoreTrustStoreConfig": {
+                        "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                        "type": "boolean"
+                      },
+                      "jksPassword": {
+                        "description": "jksPassword references the secret containing the JKS password.",
+                        "properties": {
+                          "secretRef": {
+                            "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                            "maxLength": 30,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretRef"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secretRef": {
+                        "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                        "maxLength": 30,
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "enabled"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "url": {
+                    "description": "url specifies the URL endpoint of the ksqlDB cluster.",
+                    "minLength": 1,
+                    "pattern": "^https?://.*",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "url"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "mds": {
+              "description": "mds defines the RBAC dependency configurations.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the client side authentication configuration for the MDS.",
+                  "properties": {
+                    "bearer": {
+                      "description": "bearer specifies the bearer authentication settings.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication method for the MDS. The valid option is `bearer`.",
+                      "enum": [
+                        "bearer"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bearer",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "endpoint": {
+                  "description": "endpoint specifies the MDS endpoint.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tokenKeyPair": {
+                  "description": "tokenKeyPair specifies the token keypair to configure the MDS.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret that contains the MDS token key pair.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "authentication",
+                "endpoint",
+                "tokenKeyPair"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "schemaRegistry": {
+              "description": "schemaRegistry defines the Schema Registry dependency configurations.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the authentication for the Schema Registry cluster.",
+                  "properties": {
+                    "basic": {
+                      "description": "basic specifies the configuration for basic authentication.",
+                      "properties": {
+                        "debug": {
+                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                          "type": "boolean"
+                        },
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "restrictedRoles": {
+                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "roles": {
+                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretRef": {
+                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                      "enum": [
+                        "basic",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusters": {
+                  "items": {
+                    "description": "ControlCenterMultiSchemaRegistryDependency defines the Schema Registry dependency List.",
+                    "properties": {
+                      "authentication": {
+                        "description": "authentication specifies the authentication for the Schema Registry cluster.",
+                        "properties": {
+                          "basic": {
+                            "description": "basic specifies the configuration for basic authentication.",
+                            "properties": {
+                              "debug": {
+                                "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                                "type": "boolean"
+                              },
+                              "directoryPathInContainer": {
+                                "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "restrictedRoles": {
+                                "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "minItems": 1,
+                                "type": "array"
+                              },
+                              "roles": {
+                                "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "secretRef": {
+                                "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                                "maxLength": 30,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": {
+                            "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                            "enum": [
+                              "basic",
+                              "mtls"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "description": "name defines the Schema Registry cluster name.",
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      },
+                      "tls": {
+                        "description": "tls defines the client-side TLS setting for the Schema Registry cluster.",
+                        "properties": {
+                          "directoryPathInContainer": {
+                            "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "enabled": {
+                            "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                            "type": "boolean"
+                          },
+                          "ignoreTrustStoreConfig": {
+                            "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                            "type": "boolean"
+                          },
+                          "jksPassword": {
+                            "description": "jksPassword references the secret containing the JKS password.",
+                            "properties": {
+                              "secretRef": {
+                                "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                                "maxLength": 30,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "secretRef"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "secretRef": {
+                            "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                            "maxLength": 30,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "enabled"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "url": {
+                        "description": "url specifies the URL endpoint of the Schema Registry cluster.",
+                        "minLength": 1,
+                        "pattern": "^https?://.*",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "url"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Schema Registry cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "description": "url specifies the URL endpoint of the Schema Registry cluster.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalAccess": {
+          "description": "externalAccess specifies the external access configuration for the Control Center cluster.",
+          "properties": {
+            "loadBalancer": {
+              "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain is the domain name of the component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "loadBalancerSourceRanges": {
+                  "description": "loadBalancerSourceRanges specify the source ranges.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "port": {
+                  "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "prefix": {
+                  "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify the user-provided service port(s).",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodePort": {
+              "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "host": {
+                  "description": "host defines the host name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "nodePortOffset": {
+                  "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "host",
+                "nodePortOffset"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "route": {
+              "description": "route specifies the configuration to create a route service in OpenShift.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain specifies the domain name of the Confluent component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "prefix": {
+                  "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "wildcardPolicy": {
+                  "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                  "enum": [
+                    "Subdomain",
+                    "None"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+              "enum": [
+                "loadBalancer",
+                "nodePort",
+                "route"
+              ],
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "headlessService": {
+          "description": "headlessService specifies the configuration of the Kubernetes headless service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs. It specifies the annotations to be added to the CFK-created headless service. These annotations are merged with the injectAnnotations and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs. It specifies the labels to be added to the CFK-created headless service. These labels are merged with the injectLabels and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "publishNotReadyAddresses": {
+              "description": "publishNotReadyAddresses specifies the publishNotReadyAddresses field. For Kafka, this value must be true. The default value is true.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "id": {
+          "description": "id specifies the prefix used for this instance of Control Center when multiple instances of Control Center co-exist.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "image": {
+          "description": "image specifies the application and the init docker image configurations. A change to this setting will roll the cluster.",
+          "properties": {
+            "application": {
+              "description": "application is the Docker image name of the application. Specify `<Docker-registry FQDN>/<docker-repository-name>/<component-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "init": {
+              "description": "init is the init-container name. Specify `<Docker-registry FQDN>/<docker-repository-name>/<init-container-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "description": "pullPolicy is the policy for pulling images. Valid options are `Always`, `Never`, and `IfNotPresent`. The default value is `IfNotPresent`.",
+              "enum": [
+                "Always",
+                "Never",
+                "IfNotPresent"
+              ],
+              "type": "string"
+            },
+            "pullSecretRef": {
+              "description": "pullSecretRef references the secrets in the same namespace to be used for pulling images. Image pull secrets are distinct from secrets because secrets can be mounted in the pod, but image pull secrets are only accessed by `kubelet`. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "application",
+            "init"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "injectAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectAnnotations are the annotations injected to the internal resources that CFK created. The internal annotations are preserved and cannot be overridden. For pod annotations, use `podTemplate.annotations`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "injectLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectLabels are the labels injected to the internal resources that CFK created. The internal labels are preserved and cannot be overridden. For pod labels, use `podTemplate.labels`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "internalTopicReplicatorFactor": {
+          "description": "internalTopicReplicationFactor specifies the replication factor for internal topics.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "k8sClusterDomain": {
+          "description": "k8sClusterDomain specifies the configuration of the Kubernetes cluster domain. The default is the `cluster.local` domain.",
+          "type": "string"
+        },
+        "license": {
+          "description": "license specifies the license configuration for the Confluent Platform component.",
+          "properties": {
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where the license key is mounted. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "minLength": 1,
+              "type": "string"
+            },
+            "globalLicense": {
+              "description": "globalLicense specifies whether the Confluent Platform component shares the common global license.",
+              "type": "boolean"
+            },
+            "secretRef": {
+              "description": "secretRef references the secret that provides the license for the Confluent Platform component. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mail": {
+          "description": "mail specifies the settings that control the SMTP server and account used when an alert triggers an email action.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication for SMTP. SMP only supports basic authentication. For other types of authentication, use the config overrides capability.",
+              "properties": {
+                "basic": {
+                  "description": "basic specifies the configuration for basic authentication.",
+                  "properties": {
+                    "debug": {
+                      "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                      "type": "boolean"
+                    },
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "restrictedRoles": {
+                      "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "roles": {
+                      "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "secretRef": {
+                      "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                  "enum": [
+                    "basic",
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "checkServerIdentity": {
+              "description": "checkServerIdentity forces validation of server\u2019s certificate when using STARTTLS or SSL.",
+              "type": "boolean"
+            },
+            "hostname": {
+              "description": "hostname is the hostname of the outgoing SMTP server.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "mailBounceAddress": {
+              "description": "mailBounceAddress is the override for the `mailFrom` config to send message.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "mailFrom": {
+              "description": "mailFrom is the originating address for emails sent from the Control Center.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "port": {
+              "description": "port is the SMTP port open on the hostname.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "startTLSRequired": {
+              "description": "startTLSRequired forces using STARTTLS.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "hostname"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metrics": {
+          "description": "metrics specify the security settings for the metric services.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication configuration for the metrics.",
+              "properties": {
+                "type": {
+                  "description": "type specifies the metrics authentication method. The valid option is `mtls`.",
+                  "enum": [
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prometheus": {
+              "description": "prometheus specifies the configuration overrides for the JMX-Prometheus exporter.",
+              "properties": {
+                "blacklist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "rules": {
+                  "items": {
+                    "description": "Rule defines the Prometheus Exporter rule override.",
+                    "properties": {
+                      "attrNameSnakeCase": {
+                        "type": "boolean"
+                      },
+                      "cache": {
+                        "type": "boolean"
+                      },
+                      "help": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "granular"
+                      },
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "type": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "valueFactor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": 1,
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "whitelist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "tls specifies the TLS configuration for the metrics.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "ignoreTrustStoreConfig": {
+                  "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "jksPassword": {
+                  "description": "jksPassword references the secret containing the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "monitoringKafkaClusters": {
+          "description": "monitoringKafkaClusters specify the configurations for the Kafka clusters that this Control Center monitors.",
+          "items": {
+            "description": "MonitoringKafkaClusters defines the configuration of the additional Kafka clusters the Control Center monitors.",
+            "properties": {
+              "authentication": {
+                "description": "authentication defines the authentication for the Kafka cluster.",
+                "properties": {
+                  "jaasConfig": {
+                    "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                    "properties": {
+                      "secretRef": {
+                        "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                        "maxLength": 30,
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretRef"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "jaasConfigPassThrough": {
+                    "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                    "properties": {
+                      "directoryPathInContainer": {
+                        "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                        "maxLength": 30,
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "oauthbearer": {
+                    "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                    "properties": {
+                      "directoryPathInContainer": {
+                        "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                        "maxLength": 30,
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                    "enum": [
+                      "plain",
+                      "oauthbearer",
+                      "digest",
+                      "mtls"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "bootstrapEndpoint": {
+                "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                "minLength": 1,
+                "pattern": ".+:[0-9]+",
+                "type": "string"
+              },
+              "discovery": {
+                "description": "discovery specifies the capability to discover the Kafka cluster.",
+                "properties": {
+                  "name": {
+                    "description": "name is the name of the Confluent Platform component cluster.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                    "maxLength": 30,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "name defines the Kafka cluster name.",
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              },
+              "tls": {
+                "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                "properties": {
+                  "directoryPathInContainer": {
+                    "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                    "type": "boolean"
+                  },
+                  "ignoreTrustStoreConfig": {
+                    "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                    "type": "boolean"
+                  },
+                  "jksPassword": {
+                    "description": "jksPassword references the secret containing the JKS password.",
+                    "properties": {
+                      "secretRef": {
+                        "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                        "maxLength": 30,
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretRef"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secretRef": {
+                    "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                    "maxLength": 30,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "enabled"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mountedSecrets": {
+          "description": "mountedSecrets list the secrets injected to the underlying statefulset configuration. The secret reference is mounted in the default path `/mnt/secrets/<secret-name>`. The underlying resources will follow the secret as a file configuration. More info: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod. A change to this setting will roll the cluster.",
+          "items": {
+            "description": "MountedSecrets provides a way to inject a custom secret to the underlying statefulset.",
+            "properties": {
+              "keyItems": {
+                "description": "keyItems are key and path names.",
+                "items": {
+                  "description": "Maps a string key to a path within a volume.",
+                  "properties": {
+                    "key": {
+                      "description": "The key to project.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "path": {
+                      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "path"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "secretRef": {
+                "description": "secretRef references the name of the secret.",
+                "maxLength": 30,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "secretRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mountedVolumes": {
+          "description": "mountedVolumes list the custom volumes that need to be mounted into the underlying statefulset. A change to this setting will roll the cluster.",
+          "properties": {
+            "volumeMounts": {
+              "description": "volumeMounts specify the list of volume mounts for the pods in the statefulset.",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                    "type": "boolean"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "volumes specify the list of volumes that can be mounted into the pods of statefulset.",
+              "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureDisk": {
+                    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "cachingMode": {
+                        "description": "Host Caching mode: None, Read Only, Read Write.",
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "description": "The Name of the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "description": "The URI the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureFile": {
+                    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "the name of secret that contains Azure Storage Account Name and Key",
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "description": "Share Name",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cephfs": {
+                    "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "monitors": {
+                        "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cinder": {
+                    "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeID": {
+                        "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "configMap": {
+                    "description": "ConfigMap represents a configMap that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its keys must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "csi": {
+                    "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "readOnly": {
+                        "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "downwardAPI": {
+                    "description": "DownwardAPI represents downward API about the pod that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "Items is a list of downward API volume file",
+                        "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                          "properties": {
+                            "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "emptyDir": {
+                    "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "properties": {
+                      "medium": {
+                        "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ephemeral": {
+                    "description": "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                            "properties": {
+                              "accessModes": {
+                                "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dataSource": {
+                                "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "description": "Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "description": "Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "description": "A label query over volumes to consider for binding.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fc": {
+                    "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "Optional: FC target lun number",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "description": "Optional: FC target worldwide names (WWNs)",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "wwids": {
+                        "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flexVolume": {
+                    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the driver to use for this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Optional: Extra command options if any.",
+                        "type": "object"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flocker": {
+                    "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                    "properties": {
+                      "datasetName": {
+                        "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcePersistentDisk": {
+                    "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "pdName": {
+                        "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "pdName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitRepo": {
+                    "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                    "properties": {
+                      "directory": {
+                        "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "Repository URL",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "Commit hash for the specified revision.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repository"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "glusterfs": {
+                    "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                    "properties": {
+                      "endpoints": {
+                        "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostPath": {
+                    "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                    "properties": {
+                      "path": {
+                        "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "iscsi": {
+                    "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "description": "whether support iSCSI Discovery CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "description": "whether support iSCSI Session CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "description": "Target iSCSI Qualified Name.",
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "iSCSI Target Lun number.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "portals": {
+                        "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "CHAP Secret for iSCSI target and initiator authentication",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "targetPortal": {
+                        "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "properties": {
+                      "path": {
+                        "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "properties": {
+                      "claimName": {
+                        "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "claimName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "photonPersistentDisk": {
+                    "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "description": "ID that identifies Photon Controller persistent disk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pdID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "portworxVolume": {
+                    "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "VolumeID uniquely identifies a Portworx volume",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "projected": {
+                    "description": "Items for all in one resources secrets, configmaps, and downward API",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "sources": {
+                        "description": "list of volume projections",
+                        "items": {
+                          "description": "Projection that may be projected along with other supported volume types",
+                          "properties": {
+                            "configMap": {
+                              "description": "information about the configMap data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                              "description": "information about the downwardAPI data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secret": {
+                              "description": "information about the secret data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountToken": {
+                              "description": "information about the serviceAccountToken data to project",
+                              "properties": {
+                                "audience": {
+                                  "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "quobyte": {
+                    "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "group": {
+                        "description": "Group to map volume access to Default is no group",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User to map volume access to Defaults to serivceaccount user",
+                        "type": "string"
+                      },
+                      "volume": {
+                        "description": "Volume is a string that references an already created Quobyte volume by name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbd": {
+                    "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "image": {
+                        "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "pool": {
+                        "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scaleIO": {
+                    "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "description": "The host address of the ScaleIO API Gateway.",
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "sslEnabled": {
+                        "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                        "type": "string"
+                      },
+                      "system": {
+                        "description": "The name of the storage system as configured in ScaleIO.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its keys must be defined",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageos": {
+                    "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeName": {
+                        "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "vsphereVolume": {
+                    "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "description": "Storage Policy Based Management (SPBM) profile name.",
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "description": "Path that identifies vSphere volume vmdk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumePath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "volumeMounts",
+            "volumes"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "name": {
+          "description": "name is the Control Center cluster name.",
+          "type": "string"
+        },
+        "oneReplicaPerNode": {
+          "description": "oneReplicaPerNode controls whether to run 1 pod per node using the pod anti-affinity capability. Enabling this configuration in an existing cluster will roll the cluster.",
+          "type": "boolean"
+        },
+        "podTemplate": {
+          "description": "podTemplate specifies the statefulset pod template configuration.",
+          "properties": {
+            "affinity": {
+              "description": "affinity specifies a group of affinity scheduling rules. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.",
+              "properties": {
+                "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                        "properties": {
+                          "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs stored with the resource and may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "envVars": {
+              "description": "envVars contain environment variables to be injected into containers. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs that can be used to organize and categorize (scope and select) objects. More info: http://kubernetes.io/docs/user-guide/labels.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "podSecurityContext": {
+              "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+              "properties": {
+                "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
+                    "properties": {
+                      "name": {
+                        "description": "Name of a property to set",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of a property to set",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "priorityClassName": {
+              "description": "priorityClassName specifies the priority class for the pod (if any).",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "probe": {
+              "description": "probe contains the fields for standard Kubernetes readiness/liveness probe configuration.",
+              "properties": {
+                "liveness": {
+                  "description": "liveness configures the Kubernetes probe settings. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "readiness": {
+                  "description": "readiness configures the Kubernetes probe setting. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "resources": {
+              "description": "resources describe the compute resource requirements.",
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityContext": {
+              "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "description": "ServiceAccountName is the name of the service account used to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account.",
+              "type": "string"
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "terminationGracePeriodSeconds is the grace period before the pod is deleted.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "tolerations": {
+              "description": "tolerations specify the pods to schedule onto the nodes with matching taints, using the triple `<key,value,effect>` and the matching operator `<operator>`.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "topologySpreadConstraints describe how a group of pods ought to spread across topology domains. Scheduler will schedule pods based on the constraints. All topologySpreadConstraints are ANDed.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas. A change to this setting will roll the cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "storageClass": {
+          "description": "storageClass references the user-provided storage class.",
+          "properties": {
+            "name": {
+              "description": "name is the storage class name.",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "telemetry": {
+          "description": "telemetry specifies the Confluent telemetry reporter configuration.",
+          "properties": {
+            "global": {
+              "description": "global allows disabling telemetry configuration. If CFK is deployed with telemetry, this field is only used to disable telemetry. The default value is `true` if telemetry is enabled at the global level.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tls": {
+          "description": "tls specifies the TLS configurations.",
+          "properties": {
+            "autoGeneratedCerts": {
+              "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
+              "type": "boolean"
+            },
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "ignoreTrustStoreConfig": {
+              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+              "type": "boolean"
+            },
+            "jksPassword": {
+              "description": "jksPassword references the secret containing the JKS password.",
+              "properties": {
+                "secretRef": {
+                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "dataVolumeCapacity",
+        "image",
+        "replicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the Control Center cluster.",
+      "properties": {
+        "arbitraryData": {
+          "description": "arbitraryData is the map for any arbitrary data associated with this Confluent component.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "authorizationType": {
+          "description": "authorizationType is the authorization type for this Confluent component.",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "clusterName is the name of the Confluent Platform component cluster.",
+          "type": "string"
+        },
+        "clusterNamespace": {
+          "description": "clusterNamespace is the namespace where the Confluent Platform component cluster is running.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions specify the latest available observations of the current state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlCenterName": {
+          "description": "name is the name of the Control Center cluster.",
+          "type": "string"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of currently running replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "id": {
+          "description": "id is the identifier of the Control Center cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "internalSecrets": {
+          "description": "internalSecrets are internal secrets created by CFK for this Confluent component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "internalTopicNames": {
+          "description": "internalTopicNames are the topics used by the component for internal use.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kafka": {
+          "description": "kafka is the Kafka client side status for the Control Center cluster.",
+          "properties": {
+            "authenticationType": {
+              "description": "authenticationType describes the authentication method for the Kafka cluster.",
+              "type": "string"
+            },
+            "bootstrapEndpoint": {
+              "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls indicates whether TLS is enabled for the Kafka dependency.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "description": "operatorVersion is the internal version of CFK.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "phase describes the state of the Confluent Platform component. This can either be 'PROVISIONING' or 'RUNNING' 'PROVISIONING' means the Confluent Platform component is currently getting deployed and not ready yet. 'RUNNING' means the Confluent Platform component has been successfully deployed.",
+          "type": "string"
+        },
+        "rbac": {
+          "description": "rbac contains the RBAC-related status when RBAC is enabled.",
+          "properties": {
+            "clusterID": {
+              "description": "clusterID specifies the id of the cluster.",
+              "type": "string"
+            },
+            "internalRolebindings": {
+              "description": "internalRolebindings specifies the internal rolebindings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of currently ready replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "restConfig": {
+          "description": "restConfig is the REST API configuration of the Control Center cluster.",
+          "properties": {
+            "advertisedExternalEndpoints": {
+              "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "authenticationType": {
+              "description": "authenticationType shows the authentication type configured by the listener.",
+              "type": "string"
+            },
+            "externalAccessType": {
+              "description": "externalAccessType shows the external access type used for the listener.",
+              "type": "string"
+            },
+            "externalEndpoint": {
+              "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "internalEndpoint": {
+              "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls shows whether TLS is configured for the listener.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "selector gets the label selector of the child pod. The Horizontal Pod Autoscaler(HPA) will scale using the label selector of the child pod.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/kafka_v1beta1.json
+++ b/platform.confluent.io/kafka_v1beta1.json
@@ -1,0 +1,6777 @@
+{
+  "description": "Kafka is the schema for the Kafka API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the Kafka cluster.",
+      "properties": {
+        "authorization": {
+          "description": "authorization specifies the authorization configuration.",
+          "properties": {
+            "superUsers": {
+              "description": "superUsers specify the super users to give the admin privilege on the Kafka Cluster. This list takes the format as `User:<user-name>`",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "description": "type specifies the authorization type. The valid options are `rbac` and `simple`.",
+              "enum": [
+                "rbac",
+                "simple"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "configOverrides": {
+          "description": "configOverrides specifies the configs to override the server, JVM, Log4j properties for the Kafka cluster.",
+          "properties": {
+            "jvm": {
+              "description": "jvm is a list of JVM configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "log4j": {
+              "description": "log4j is a list of Log4J configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "server": {
+              "description": "server is a list of server configuration supported by the Confluent Platform component. This will either add or update existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dataVolumeCapacity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "dataVolumeCapacity specifies the persistent volume capacity for the Kafka cluster.",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
+        "dependencies": {
+          "description": "dependencies specify the Kafka dependencies, such as Zookeeper and centralized MDS.",
+          "properties": {
+            "kafkaRest": {
+              "description": "kafkaRest provides the REST client configuration for the MDS when RBAC is enabled.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the Kafka authentication for Kafka REST API or MDS.",
+                  "properties": {
+                    "bearer": {
+                      "description": "bearer is the authentication mechanism to provide principals. Only supported in RBAC deployment. Required when authentication type is set to `bearer`. This field will be deprecated, please configure oauthbearer instead.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provide principals. Only supported in RBAC deployment. Required when authentication type is set to `oauthbearer`.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `bearer`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "bearer",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bootstrapEndpoint": {
+                  "description": "bootstrapEndpoint specifies Kafka bootstrap endpoint for the admin REST API. It is not needed when RBAC is enabled. If not configured, then default to the replication listener endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "endpoint": {
+                  "description": "endpoint specifies the custom MDS http|s endpoint. Not required to configure in most of the scenarios.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "tls specifies the client-side TLS configuration to connect to the Kafka REST API.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mds": {
+              "description": "mds specifies the dependency configuration for the primary MDS.",
+              "properties": {
+                "endpoint": {
+                  "description": "endpoint defines the primary Kafka cluster boostrap endpoint.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                },
+                "kafka": {
+                  "description": "kafka specifies the dependency configuration for Kafka cluster.",
+                  "properties": {
+                    "authentication": {
+                      "description": "authentication defines the authentication for the Kafka cluster.",
+                      "properties": {
+                        "jaasConfig": {
+                          "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "jaasConfigPassThrough": {
+                          "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauthbearer": {
+                          "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": {
+                          "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                          "enum": [
+                            "plain",
+                            "oauthbearer",
+                            "digest",
+                            "mtls"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "bootstrapEndpoint": {
+                      "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                      "minLength": 1,
+                      "pattern": ".+:[0-9]+",
+                      "type": "string"
+                    },
+                    "discovery": {
+                      "description": "discovery specifies the capability to discover the Kafka cluster.",
+                      "properties": {
+                        "name": {
+                          "description": "name is the name of the Confluent Platform component cluster.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tls": {
+                      "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "ignoreTrustStoreConfig": {
+                          "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "jksPassword": {
+                          "description": "jksPassword references the secret containing the JKS password.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the primary MDS.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tokenKeyPair": {
+                  "description": "tokenKeyPair specifies the token key pair for the MDS.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret that contains the MDS token key pair.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "endpoint",
+                "kafka",
+                "tokenKeyPair"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "schemaRegistry": {
+              "description": "schemaRegistry specifies the dependency configuration for the Schema Registry cluster.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the authentication for the Schema Registry cluster.",
+                  "properties": {
+                    "basic": {
+                      "description": "basic specifies the configuration for basic authentication.",
+                      "properties": {
+                        "debug": {
+                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                          "type": "boolean"
+                        },
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "restrictedRoles": {
+                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "roles": {
+                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretRef": {
+                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                      "enum": [
+                        "basic",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Schema Registry cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "description": "url specifies the URL endpoint of the Schema Registry cluster.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "zookeeper": {
+              "description": "zookeeper specifies the dependency configuration for Zookeeper.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the client side authentication configuration of Zookeeper for Kafka cluster.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "digest",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "discovery": {
+                  "description": "discovery specifies the capability to discover the Zookeeper cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name is the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "endpoint": {
+                  "description": "endpoint specifies the Zookeeper endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration of Zookeeper for Kafka cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "fips": {
+          "description": "fips specifies the configuration of FIPS compliant Bouncy Castle type Java Keystores for the Kafka cluster's TLS settings. TLS Secrets must have the keys keystore.bcfks, truststore.bcfks, and jksPassword.txt",
+          "properties": {
+            "enabled": {
+              "description": "enabled specifies whether to enable the FIPS configuration for Kafka.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "headlessService": {
+          "description": "headlessService specifies the configuration of the Kubernetes headless service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs. It specifies the annotations to be added to the CFK-created headless service. These annotations are merged with the injectAnnotations and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs. It specifies the labels to be added to the CFK-created headless service. These labels are merged with the injectLabels and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "publishNotReadyAddresses": {
+              "description": "publishNotReadyAddresses specifies the publishNotReadyAddresses field. For Kafka, this value must be true. The default value is true.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "identityProvider": {
+          "description": "identityProvider specifies the identity provider configuration. It is only required for the Kafka authentication type `ldap`. When the MDS is enabled, this property is ignored, and the LDAP configuration in `spec.services.mds.provider` will be used.",
+          "properties": {
+            "ldap": {
+              "description": "ldap defines the LDAP service configuration.",
+              "properties": {
+                "address": {
+                  "description": "address defines the LDAP server address.",
+                  "type": "string"
+                },
+                "authentication": {
+                  "description": "LdapAuthentication specifies the LDAP authentication configuration.",
+                  "properties": {
+                    "simple": {
+                      "description": "simple specifies simple authentication configuration for the LDAP.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer defines the directory path in the container where the credentials are mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret that contains the credentials.",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type defines the authentication method for LDAP. Valid options are `simple` and `mtls`.",
+                      "enum": [
+                        "simple",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "configurations": {
+                  "description": "configurations defines the LDAP configurations for Confluent RBAC.",
+                  "properties": {
+                    "groupMemberAttribute": {
+                      "description": "groupMemberAttribute specifies the LDAP group member attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupMemberAttributePattern": {
+                      "description": "groupMemberAttributePattern specifies the regular expression pattern for the LDAP group member attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupNameAttribute": {
+                      "description": "groupNameAttribute specifies the LDAP group name attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupObjectClass": {
+                      "description": "groupObjectClass specifies the LDAP group object class.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupSearchBase": {
+                      "description": "groupSearchBase specifies the LDAP search base for the group-based search.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupSearchFilter": {
+                      "description": "groupSearchFilter specifies the LDAP search filter for the group-based search.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupSearchScope": {
+                      "description": "groupSearchScope specifies the LDAP search scope for the group-based search.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "userMemberOfAttributePattern": {
+                      "description": "userMemberOfAttributePattern specifies the regular expression pattern for the LDAP user member attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userNameAttribute": {
+                      "description": "userNameAttribute specifies the LDAP username attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userObjectClass": {
+                      "description": "userObjectClass specifies the LDAP user object class.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userSearchBase": {
+                      "description": "userSearchBase specifies the LDAP search base for the user-based search.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userSearchFilter": {
+                      "description": "userSearchFilter specifies the LDAP search filter for the user-based search.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userSearchScope": {
+                      "description": "userSearchScope specifies the LDAP search scope for the user-based search.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the LDAP.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "address",
+                "authentication",
+                "configurations"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type defines the identity provider type. The valid option is `ldap`.",
+              "enum": [
+                "ldap"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "ldap",
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "image specifies the application and the init docker image configurations. A change to this setting will roll the cluster.",
+          "properties": {
+            "application": {
+              "description": "application is the Docker image name of the application. Specify `<Docker-registry FQDN>/<docker-repository-name>/<component-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "init": {
+              "description": "init is the init-container name. Specify `<Docker-registry FQDN>/<docker-repository-name>/<init-container-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "description": "pullPolicy is the policy for pulling images. Valid options are `Always`, `Never`, and `IfNotPresent`. The default value is `IfNotPresent`.",
+              "enum": [
+                "Always",
+                "Never",
+                "IfNotPresent"
+              ],
+              "type": "string"
+            },
+            "pullSecretRef": {
+              "description": "pullSecretRef references the secrets in the same namespace to be used for pulling images. Image pull secrets are distinct from secrets because secrets can be mounted in the pod, but image pull secrets are only accessed by `kubelet`. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "application",
+            "init"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "injectAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectAnnotations are the annotations injected to the internal resources that CFK created. The internal annotations are preserved and cannot be overridden. For pod annotations, use `podTemplate.annotations`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "injectLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectLabels are the labels injected to the internal resources that CFK created. The internal labels are preserved and cannot be overridden. For pod labels, use `podTemplate.labels`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "k8sClusterDomain": {
+          "description": "k8sClusterDomain specifies the configuration of the Kubernetes cluster domain. The default is the `cluster.local` domain.",
+          "type": "string"
+        },
+        "license": {
+          "description": "license specifies the license configuration for the Confluent Platform component.",
+          "properties": {
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where the license key is mounted. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "minLength": 1,
+              "type": "string"
+            },
+            "globalLicense": {
+              "description": "globalLicense specifies whether the Confluent Platform component shares the common global license.",
+              "type": "boolean"
+            },
+            "secretRef": {
+              "description": "secretRef references the secret that provides the license for the Confluent Platform component. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "listeners": {
+          "description": "listeners specify the listeners configurations.",
+          "properties": {
+            "custom": {
+              "description": "custom defines the list of KafkaCustomListener.",
+              "items": {
+                "description": "KafkaCustomListener defines the Kafka custom listener.",
+                "properties": {
+                  "authentication": {
+                    "description": "authentication specifies the authentication configuration for the listener.",
+                    "properties": {
+                      "jaasConfig": {
+                        "description": "jaasConfig specifies the JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                        "properties": {
+                          "secretRef": {
+                            "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                            "maxLength": 30,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretRef"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "jaasConfigPassThrough": {
+                        "description": "jaasConfigPassThrough specifies another way to provide JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                        "properties": {
+                          "directoryPathInContainer": {
+                            "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                            "maxLength": 30,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "principalMappingRules": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "type": {
+                        "description": "type specifies the Kafka or Zookeeper authentication type. Valid options are `plain`, `digest`, `mtls`, and `ldap`.",
+                        "enum": [
+                          "plain",
+                          "digest",
+                          "mtls",
+                          "ldap"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "externalAccess": {
+                    "description": "externalAccess defines the external access configuration for the Kafka cluster.",
+                    "properties": {
+                      "loadBalancer": {
+                        "description": "loadBalancer specifies the configuration to create Kubernetes load balancer services.",
+                        "properties": {
+                          "advertisedPort": {
+                            "description": "advertisedPort specifies the advertised port for Kafka external access. If not configured, it will be the same as the listener port. Information about the advertised port can be retrieved through the status API.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                            "type": "object",
+                            "x-kubernetes-map-type": "granular"
+                          },
+                          "bootstrapPrefix": {
+                            "description": "bootstrapPrefix specifies the prefix for the Kafka bootstrap advertised endpoint and will be added as `bootstrapPrefix.domain`. The default value is the Kafka cluster name.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "brokerPrefix": {
+                            "description": "brokerPrefix specifies the prefix for the Kafka broker advertised endpoint and will be added as `brokerPrefix.domain`. The default value is `b`, such as `b#.domain` where `#` starts from `0` to the replicas count.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "domain": {
+                            "description": "domain is the domain name of the component cluster.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "externalTrafficPolicy": {
+                            "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                            "enum": [
+                              "Local",
+                              "Cluster"
+                            ],
+                            "type": "string"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                            "type": "object",
+                            "x-kubernetes-map-type": "granular"
+                          },
+                          "loadBalancerSourceRanges": {
+                            "description": "loadBalancerSourceRanges specify the source ranges.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "servicePorts": {
+                            "description": "servicePorts specify the user-provided service port(s).",
+                            "items": {
+                              "description": "ServicePort contains information on service's port.",
+                              "properties": {
+                                "appProtocol": {
+                                  "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                  "type": "string"
+                                },
+                                "nodePort": {
+                                  "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "port": {
+                                  "description": "The port that will be exposed by this service.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "protocol": {
+                                  "default": "TCP",
+                                  "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                  "type": "string"
+                                },
+                                "targetPort": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "sessionAffinity": {
+                            "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                            "enum": [
+                              "ClientIP",
+                              "None"
+                            ],
+                            "type": "string"
+                          },
+                          "sessionAffinityConfig": {
+                            "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                            "properties": {
+                              "clientIP": {
+                                "description": "clientIP contains the configurations of Client IP based session affinity.",
+                                "properties": {
+                                  "timeoutSeconds": {
+                                    "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "domain"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "nodePort": {
+                        "description": "nodePort specifies the configuration to create Kubernetes node port services.",
+                        "properties": {
+                          "advertisedURL": {
+                            "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                            "properties": {
+                              "enabled": {
+                                "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                                "type": "boolean"
+                              },
+                              "prefix": {
+                                "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "enabled"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                            "type": "object",
+                            "x-kubernetes-map-type": "granular"
+                          },
+                          "externalTrafficPolicy": {
+                            "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                            "enum": [
+                              "Local",
+                              "Cluster"
+                            ],
+                            "type": "string"
+                          },
+                          "host": {
+                            "description": "host defines the host name of the cluster.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                            "type": "object",
+                            "x-kubernetes-map-type": "granular"
+                          },
+                          "nodePortOffset": {
+                            "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "servicePorts": {
+                            "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                            "items": {
+                              "description": "ServicePort contains information on service's port.",
+                              "properties": {
+                                "appProtocol": {
+                                  "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                  "type": "string"
+                                },
+                                "nodePort": {
+                                  "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "port": {
+                                  "description": "The port that will be exposed by this service.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "protocol": {
+                                  "default": "TCP",
+                                  "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                  "type": "string"
+                                },
+                                "targetPort": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "sessionAffinity": {
+                            "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                            "enum": [
+                              "ClientIP",
+                              "None"
+                            ],
+                            "type": "string"
+                          },
+                          "sessionAffinityConfig": {
+                            "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                            "properties": {
+                              "clientIP": {
+                                "description": "clientIP contains the configurations of Client IP based session affinity.",
+                                "properties": {
+                                  "timeoutSeconds": {
+                                    "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "host",
+                          "nodePortOffset"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "route": {
+                        "description": "route specifies the configuration to create route services in OpenShift.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                            "type": "object",
+                            "x-kubernetes-map-type": "granular"
+                          },
+                          "bootstrapPrefix": {
+                            "description": "bootstrapPrefix specifies the prefix for the Kafka bootstrap advertised endpoint and will be added as `bootstrapPrefix.domain`. The default value is the Kafka cluster name.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "brokerPrefix": {
+                            "description": "brokerPrefix specifies the prefix for the Kafka broker advertised endpoint and will be added as `brokerPrefix.domain`. The default value is `b`, such as `b#.domain` where `#` starts from `0` to the replicas count.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "domain": {
+                            "description": "domain specifies the domain name of the Confluent component cluster.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                            "type": "object",
+                            "x-kubernetes-map-type": "granular"
+                          },
+                          "wildcardPolicy": {
+                            "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                            "enum": [
+                              "Subdomain",
+                              "None"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "domain"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "staticForHostBasedRouting": {
+                        "description": "staticForHostBasedRouting enables external access by doing host based routing through the SNI capability. With this schema, CFK only configures Kafka advertised listeners, and no Kubernetes external service is created.",
+                        "properties": {
+                          "brokerPrefix": {
+                            "description": "brokerPrefix specifies the prefix for the broker advertised endpoints and are added as `brokerPrefix.domain`. If not configured, it will add `b` as a prefix, such as `b#.domain` where `#` will start from `0` to the replicas count.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "domain": {
+                            "description": "domain specifies the domain name for the Kafka cluster.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "port specifies the port to be used in the advertised listener for a broker.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "domain",
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "staticForPortBasedRouting": {
+                        "description": "staticForPortBasedRouting enables external access by port routing. With this schema, CFK only configures Kafka advertised listeners, and no Kubernetes external service is created.",
+                        "properties": {
+                          "host": {
+                            "description": "host defines the host name to be used in the advertised listener for a broker.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "portOffset": {
+                            "description": "portOffset specifies the starting port number. The port numbers go in ascending order with respect to the replicas count.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "host",
+                          "portOffset"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "description": "type specifies the Kubernetes service for external access. Valid options are `loadBalancer`, `nodePort`, `route`, `staticForPortBasedRouting`, and `staticForHostBasedRouting`.",
+                        "enum": [
+                          "loadBalancer",
+                          "nodePort",
+                          "route",
+                          "staticForPortBasedRouting",
+                          "staticForHostBasedRouting"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "name specifies the name of the custom listener. `internal`, `external`, and `token` are reserved by CFK and can't be used for this property.",
+                    "maxLength": 30,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "port binds the given port to the custom listener. Port numbers lower than `9093` are reserved by CFK.",
+                    "format": "int32",
+                    "minimum": 9093,
+                    "type": "integer"
+                  },
+                  "tls": {
+                    "description": "tls specifies the TLS configuration for the listener.",
+                    "properties": {
+                      "directoryPathInContainer": {
+                        "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "enabled": {
+                        "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                        "type": "boolean"
+                      },
+                      "ignoreTrustStoreConfig": {
+                        "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                        "type": "boolean"
+                      },
+                      "jksPassword": {
+                        "description": "jksPassword references the secret containing the JKS password.",
+                        "properties": {
+                          "secretRef": {
+                            "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                            "maxLength": 30,
+                            "minLength": 1,
+                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretRef"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secretRef": {
+                        "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                        "maxLength": 30,
+                        "minLength": 1,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "enabled"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name",
+                  "port"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "external": {
+              "description": "external specifies the Kafka external listener.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the authentication configuration for the listener.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "principalMappingRules": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka or Zookeeper authentication type. Valid options are `plain`, `digest`, `mtls`, and `ldap`.",
+                      "enum": [
+                        "plain",
+                        "digest",
+                        "mtls",
+                        "ldap"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "externalAccess": {
+                  "description": "externalAccess defines the external access configuration for the Kafka cluster.",
+                  "properties": {
+                    "loadBalancer": {
+                      "description": "loadBalancer specifies the configuration to create Kubernetes load balancer services.",
+                      "properties": {
+                        "advertisedPort": {
+                          "description": "advertisedPort specifies the advertised port for Kafka external access. If not configured, it will be the same as the listener port. Information about the advertised port can be retrieved through the status API.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "bootstrapPrefix": {
+                          "description": "bootstrapPrefix specifies the prefix for the Kafka bootstrap advertised endpoint and will be added as `bootstrapPrefix.domain`. The default value is the Kafka cluster name.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "brokerPrefix": {
+                          "description": "brokerPrefix specifies the prefix for the Kafka broker advertised endpoint and will be added as `brokerPrefix.domain`. The default value is `b`, such as `b#.domain` where `#` starts from `0` to the replicas count.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "domain": {
+                          "description": "domain is the domain name of the component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "loadBalancerSourceRanges": {
+                          "description": "loadBalancerSourceRanges specify the source ranges.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify the user-provided service port(s).",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodePort": {
+                      "description": "nodePort specifies the configuration to create Kubernetes node port services.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "host": {
+                          "description": "host defines the host name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "nodePortOffset": {
+                          "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                          "format": "int32",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "nodePortOffset"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "route": {
+                      "description": "route specifies the configuration to create route services in OpenShift.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "bootstrapPrefix": {
+                          "description": "bootstrapPrefix specifies the prefix for the Kafka bootstrap advertised endpoint and will be added as `bootstrapPrefix.domain`. The default value is the Kafka cluster name.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "brokerPrefix": {
+                          "description": "brokerPrefix specifies the prefix for the Kafka broker advertised endpoint and will be added as `brokerPrefix.domain`. The default value is `b`, such as `b#.domain` where `#` starts from `0` to the replicas count.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "domain": {
+                          "description": "domain specifies the domain name of the Confluent component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "wildcardPolicy": {
+                          "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                          "enum": [
+                            "Subdomain",
+                            "None"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "staticForHostBasedRouting": {
+                      "description": "staticForHostBasedRouting enables external access by doing host based routing through the SNI capability. With this schema, CFK only configures Kafka advertised listeners, and no Kubernetes external service is created.",
+                      "properties": {
+                        "brokerPrefix": {
+                          "description": "brokerPrefix specifies the prefix for the broker advertised endpoints and are added as `brokerPrefix.domain`. If not configured, it will add `b` as a prefix, such as `b#.domain` where `#` will start from `0` to the replicas count.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "domain": {
+                          "description": "domain specifies the domain name for the Kafka cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "port specifies the port to be used in the advertised listener for a broker.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "domain",
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "staticForPortBasedRouting": {
+                      "description": "staticForPortBasedRouting enables external access by port routing. With this schema, CFK only configures Kafka advertised listeners, and no Kubernetes external service is created.",
+                      "properties": {
+                        "host": {
+                          "description": "host defines the host name to be used in the advertised listener for a broker.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "portOffset": {
+                          "description": "portOffset specifies the starting port number. The port numbers go in ascending order with respect to the replicas count.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "portOffset"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kubernetes service for external access. Valid options are `loadBalancer`, `nodePort`, `route`, `staticForPortBasedRouting`, and `staticForHostBasedRouting`.",
+                      "enum": [
+                        "loadBalancer",
+                        "nodePort",
+                        "route",
+                        "staticForPortBasedRouting",
+                        "staticForHostBasedRouting"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the listener.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "internal": {
+              "description": "internal specifies the internal listener.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the authentication configuration for the listener.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "principalMappingRules": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka or Zookeeper authentication type. Valid options are `plain`, `digest`, `mtls`, and `ldap`.",
+                      "enum": [
+                        "plain",
+                        "digest",
+                        "mtls",
+                        "ldap"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the listener.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metricReporter": {
+          "description": "metricsReporter specifies the configuration of the metric reporter. The metric reporter is enabled by default. If authentication and TLS are not set, the metrics reporter uses internal listener's authentication and TLS .",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the Kafka client-side authentication configuration.",
+              "properties": {
+                "jaasConfig": {
+                  "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "jaasConfigPassThrough": {
+                  "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "oauthbearer": {
+                  "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                  "enum": [
+                    "plain",
+                    "oauthbearer",
+                    "digest",
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bootstrapEndpoint": {
+              "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "enabled specifies whether to enable or disable the metric reporter.",
+              "type": "boolean"
+            },
+            "replicationFactor": {
+              "description": "replicationFactor specifies the number of replicas in the metric topic.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tls": {
+              "description": "tls specifies the Kafka client-side TLS configuration.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "ignoreTrustStoreConfig": {
+                  "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "jksPassword": {
+                  "description": "jksPassword references the secret containing the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metrics": {
+          "description": "metrics specify the security settings for the metric services.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication configuration for the metrics.",
+              "properties": {
+                "type": {
+                  "description": "type specifies the metrics authentication method. The valid option is `mtls`.",
+                  "enum": [
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prometheus": {
+              "description": "prometheus specifies the configuration overrides for the JMX-Prometheus exporter.",
+              "properties": {
+                "blacklist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "rules": {
+                  "items": {
+                    "description": "Rule defines the Prometheus Exporter rule override.",
+                    "properties": {
+                      "attrNameSnakeCase": {
+                        "type": "boolean"
+                      },
+                      "cache": {
+                        "type": "boolean"
+                      },
+                      "help": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "granular"
+                      },
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "type": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "valueFactor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": 1,
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "whitelist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "tls specifies the TLS configuration for the metrics.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "ignoreTrustStoreConfig": {
+                  "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "jksPassword": {
+                  "description": "jksPassword references the secret containing the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mountedSecrets": {
+          "description": "mountedSecrets list the secrets injected to the underlying statefulset configuration. The secret reference is mounted in the default path `/mnt/secrets/<secret-name>`. The underlying resources will follow the secret as a file configuration. More info: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod. A change to this setting will roll the cluster.",
+          "items": {
+            "description": "MountedSecrets provides a way to inject a custom secret to the underlying statefulset.",
+            "properties": {
+              "keyItems": {
+                "description": "keyItems are key and path names.",
+                "items": {
+                  "description": "Maps a string key to a path within a volume.",
+                  "properties": {
+                    "key": {
+                      "description": "The key to project.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "path": {
+                      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "path"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "secretRef": {
+                "description": "secretRef references the name of the secret.",
+                "maxLength": 30,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "secretRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mountedVolumes": {
+          "description": "mountedVolumes list the custom volumes that need to be mounted into the underlying statefulset. A change to this setting will roll the cluster.",
+          "properties": {
+            "volumeMounts": {
+              "description": "volumeMounts specify the list of volume mounts for the pods in the statefulset.",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                    "type": "boolean"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "volumes specify the list of volumes that can be mounted into the pods of statefulset.",
+              "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureDisk": {
+                    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "cachingMode": {
+                        "description": "Host Caching mode: None, Read Only, Read Write.",
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "description": "The Name of the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "description": "The URI the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureFile": {
+                    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "the name of secret that contains Azure Storage Account Name and Key",
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "description": "Share Name",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cephfs": {
+                    "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "monitors": {
+                        "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cinder": {
+                    "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeID": {
+                        "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "configMap": {
+                    "description": "ConfigMap represents a configMap that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its keys must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "csi": {
+                    "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "readOnly": {
+                        "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "downwardAPI": {
+                    "description": "DownwardAPI represents downward API about the pod that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "Items is a list of downward API volume file",
+                        "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                          "properties": {
+                            "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "emptyDir": {
+                    "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "properties": {
+                      "medium": {
+                        "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ephemeral": {
+                    "description": "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                            "properties": {
+                              "accessModes": {
+                                "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dataSource": {
+                                "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "description": "Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "description": "Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "description": "A label query over volumes to consider for binding.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fc": {
+                    "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "Optional: FC target lun number",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "description": "Optional: FC target worldwide names (WWNs)",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "wwids": {
+                        "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flexVolume": {
+                    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the driver to use for this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Optional: Extra command options if any.",
+                        "type": "object"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flocker": {
+                    "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                    "properties": {
+                      "datasetName": {
+                        "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcePersistentDisk": {
+                    "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "pdName": {
+                        "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "pdName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitRepo": {
+                    "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                    "properties": {
+                      "directory": {
+                        "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "Repository URL",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "Commit hash for the specified revision.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repository"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "glusterfs": {
+                    "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                    "properties": {
+                      "endpoints": {
+                        "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostPath": {
+                    "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                    "properties": {
+                      "path": {
+                        "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "iscsi": {
+                    "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "description": "whether support iSCSI Discovery CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "description": "whether support iSCSI Session CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "description": "Target iSCSI Qualified Name.",
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "iSCSI Target Lun number.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "portals": {
+                        "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "CHAP Secret for iSCSI target and initiator authentication",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "targetPortal": {
+                        "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "properties": {
+                      "path": {
+                        "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "properties": {
+                      "claimName": {
+                        "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "claimName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "photonPersistentDisk": {
+                    "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "description": "ID that identifies Photon Controller persistent disk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pdID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "portworxVolume": {
+                    "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "VolumeID uniquely identifies a Portworx volume",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "projected": {
+                    "description": "Items for all in one resources secrets, configmaps, and downward API",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "sources": {
+                        "description": "list of volume projections",
+                        "items": {
+                          "description": "Projection that may be projected along with other supported volume types",
+                          "properties": {
+                            "configMap": {
+                              "description": "information about the configMap data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                              "description": "information about the downwardAPI data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secret": {
+                              "description": "information about the secret data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountToken": {
+                              "description": "information about the serviceAccountToken data to project",
+                              "properties": {
+                                "audience": {
+                                  "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "quobyte": {
+                    "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "group": {
+                        "description": "Group to map volume access to Default is no group",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User to map volume access to Defaults to serivceaccount user",
+                        "type": "string"
+                      },
+                      "volume": {
+                        "description": "Volume is a string that references an already created Quobyte volume by name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbd": {
+                    "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "image": {
+                        "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "pool": {
+                        "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scaleIO": {
+                    "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "description": "The host address of the ScaleIO API Gateway.",
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "sslEnabled": {
+                        "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                        "type": "string"
+                      },
+                      "system": {
+                        "description": "The name of the storage system as configured in ScaleIO.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its keys must be defined",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageos": {
+                    "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeName": {
+                        "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "vsphereVolume": {
+                    "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "description": "Storage Policy Based Management (SPBM) profile name.",
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "description": "Path that identifies vSphere volume vmdk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumePath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "volumeMounts",
+            "volumes"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oneReplicaPerNode": {
+          "description": "oneReplicaPerNode controls whether to run 1 pod per node using the pod anti-affinity capability. Enabling this configuration in an existing cluster will roll the cluster.",
+          "type": "boolean"
+        },
+        "passwordEncoder": {
+          "description": "passwordEncoder specifies password encoder secret for Kafka.",
+          "properties": {
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer contains the directory path in the container where the required secret is mounted. Directory should have the file `password-encoder.txt`. The contents should include a new password. Old password is optional and required only for rotation. More info: https://docs.confluent.io/operator/current/co-password-encoder-secret.",
+              "type": "string"
+            },
+            "secretRef": {
+              "description": "secretRef specifies the secret name. The secret should have the key `password-encoder.txt`. The contents should include a new password. Old password is optional and required only for rotation. More info: https://docs.confluent.io/operator/current/co-password-encoder-secret.",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "podTemplate": {
+          "description": "podTemplate specifies the statefulset pod template configuration.",
+          "properties": {
+            "affinity": {
+              "description": "affinity specifies a group of affinity scheduling rules. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.",
+              "properties": {
+                "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                        "properties": {
+                          "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs stored with the resource and may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "envVars": {
+              "description": "envVars contain environment variables to be injected into containers. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs that can be used to organize and categorize (scope and select) objects. More info: http://kubernetes.io/docs/user-guide/labels.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "podSecurityContext": {
+              "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+              "properties": {
+                "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
+                    "properties": {
+                      "name": {
+                        "description": "Name of a property to set",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of a property to set",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "priorityClassName": {
+              "description": "priorityClassName specifies the priority class for the pod (if any).",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "probe": {
+              "description": "probe contains the fields for standard Kubernetes readiness/liveness probe configuration.",
+              "properties": {
+                "liveness": {
+                  "description": "liveness configures the Kubernetes probe settings. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "readiness": {
+                  "description": "readiness configures the Kubernetes probe setting. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "resources": {
+              "description": "resources describe the compute resource requirements.",
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityContext": {
+              "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "description": "ServiceAccountName is the name of the service account used to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account.",
+              "type": "string"
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "terminationGracePeriodSeconds is the grace period before the pod is deleted.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "tolerations": {
+              "description": "tolerations specify the pods to schedule onto the nodes with matching taints, using the triple `<key,value,effect>` and the matching operator `<operator>`.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "topologySpreadConstraints describe how a group of pods ought to spread across topology domains. Scheduler will schedule pods based on the constraints. All topologySpreadConstraints are ANDed.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "rackAssignment": {
+          "description": "rackAssignment specifies the rack awareness capability of the Kafka cluster.",
+          "properties": {
+            "availabilityZoneCount": {
+              "description": "availabilityZoneCount configures `broker.rack` with the formula (`pod_id % azCount`). This is mainly for backwards compatibility with Operator 1.x.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "nodeLabels": {
+              "description": "nodeLabels use the Kubernetes node API to retrieve the label values to be used in `broker.rack`. This feature requires CFK to run with the cluster-level access.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas. A change to this setting will roll the cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "services": {
+          "description": "services specify the supported Kafka services.",
+          "properties": {
+            "kafkaRest": {
+              "description": "kafkaRest specifies the embedded REST API server configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the REST API server authentication configuration.",
+                  "properties": {
+                    "basic": {
+                      "description": "basic specifies the configuration for basic authentication.",
+                      "properties": {
+                        "debug": {
+                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                          "type": "boolean"
+                        },
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "restrictedRoles": {
+                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "roles": {
+                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretRef": {
+                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication scheme for the REST API server. Valid options are `basic` and `mtls`.",
+                      "enum": [
+                        "basic",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "externalAccess": {
+                  "description": "externalAccess specifies the external access configuration.",
+                  "properties": {
+                    "loadBalancer": {
+                      "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "domain": {
+                          "description": "domain is the domain name of the component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "loadBalancerSourceRanges": {
+                          "description": "loadBalancerSourceRanges specify the source ranges.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "port": {
+                          "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "prefix": {
+                          "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify the user-provided service port(s).",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodePort": {
+                      "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "host": {
+                          "description": "host defines the host name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "nodePortOffset": {
+                          "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                          "format": "int32",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "nodePortOffset"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "route": {
+                      "description": "route specifies the configuration to create a route service in OpenShift.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "domain": {
+                          "description": "domain specifies the domain name of the Confluent component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "prefix": {
+                          "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "wildcardPolicy": {
+                          "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                          "enum": [
+                            "Subdomain",
+                            "None"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+                      "enum": [
+                        "loadBalancer",
+                        "nodePort",
+                        "route"
+                      ],
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mds": {
+              "description": "mds specifies the MDS server configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the MDS server authentication configuration.",
+                  "properties": {
+                    "type": {
+                      "description": "type defines the MDS authentication type. The valid option is `bearer`.",
+                      "enum": [
+                        "bearer"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "externalAccess": {
+                  "description": "externalAccess specifies the external access configuration.",
+                  "properties": {
+                    "loadBalancer": {
+                      "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "domain": {
+                          "description": "domain is the domain name of the component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "loadBalancerSourceRanges": {
+                          "description": "loadBalancerSourceRanges specify the source ranges.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "port": {
+                          "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "prefix": {
+                          "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify the user-provided service port(s).",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodePort": {
+                      "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "host": {
+                          "description": "host defines the host name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "nodePortOffset": {
+                          "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                          "format": "int32",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "nodePortOffset"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "route": {
+                      "description": "route specifies the configuration to create a route service in OpenShift.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "domain": {
+                          "description": "domain specifies the domain name of the Confluent component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "prefix": {
+                          "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "wildcardPolicy": {
+                          "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                          "enum": [
+                            "Subdomain",
+                            "None"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+                      "enum": [
+                        "loadBalancer",
+                        "nodePort",
+                        "route"
+                      ],
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "provider": {
+                  "description": "provider specifies the identity provider configuration.",
+                  "properties": {
+                    "ldap": {
+                      "description": "ldap defines the LDAP service configuration.",
+                      "properties": {
+                        "address": {
+                          "description": "address defines the LDAP server address.",
+                          "type": "string"
+                        },
+                        "authentication": {
+                          "description": "LdapAuthentication specifies the LDAP authentication configuration.",
+                          "properties": {
+                            "simple": {
+                              "description": "simple specifies simple authentication configuration for the LDAP.",
+                              "properties": {
+                                "directoryPathInContainer": {
+                                  "description": "directoryPathInContainer defines the directory path in the container where the credentials are mounted.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "description": "secretRef references the name of the secret that contains the credentials.",
+                                  "maxLength": 30,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": {
+                              "description": "type defines the authentication method for LDAP. Valid options are `simple` and `mtls`.",
+                              "enum": [
+                                "simple",
+                                "mtls"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "configurations": {
+                          "description": "configurations defines the LDAP configurations for Confluent RBAC.",
+                          "properties": {
+                            "groupMemberAttribute": {
+                              "description": "groupMemberAttribute specifies the LDAP group member attribute.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "groupMemberAttributePattern": {
+                              "description": "groupMemberAttributePattern specifies the regular expression pattern for the LDAP group member attribute.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "groupNameAttribute": {
+                              "description": "groupNameAttribute specifies the LDAP group name attribute.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "groupObjectClass": {
+                              "description": "groupObjectClass specifies the LDAP group object class.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "groupSearchBase": {
+                              "description": "groupSearchBase specifies the LDAP search base for the group-based search.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "groupSearchFilter": {
+                              "description": "groupSearchFilter specifies the LDAP search filter for the group-based search.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "groupSearchScope": {
+                              "description": "groupSearchScope specifies the LDAP search scope for the group-based search.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "userMemberOfAttributePattern": {
+                              "description": "userMemberOfAttributePattern specifies the regular expression pattern for the LDAP user member attribute.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "userNameAttribute": {
+                              "description": "userNameAttribute specifies the LDAP username attribute.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "userObjectClass": {
+                              "description": "userObjectClass specifies the LDAP user object class.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "userSearchBase": {
+                              "description": "userSearchBase specifies the LDAP search base for the user-based search.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "userSearchFilter": {
+                              "description": "userSearchFilter specifies the LDAP search filter for the user-based search.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "userSearchScope": {
+                              "description": "userSearchScope specifies the LDAP search scope for the user-based search.",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tls": {
+                          "description": "tls specifies the TLS configuration for the LDAP.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "ignoreTrustStoreConfig": {
+                              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "jksPassword": {
+                              "description": "jksPassword references the secret containing the JKS password.",
+                              "properties": {
+                                "secretRef": {
+                                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                                  "maxLength": 30,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "secretRef"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "address",
+                        "authentication",
+                        "configurations"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type defines the identity provider type. The valid option is `ldap`.",
+                      "enum": [
+                        "ldap"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ldap",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tokenKeyPair": {
+                  "description": "tokenKeyPair specifies the token key pair for the MDS.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret that contains the MDS token key pair.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "provider",
+                "tokenKeyPair"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "storageClass": {
+          "description": "storageClass specifies the user-provided storage class. If not configured, it will use the default storage class.",
+          "properties": {
+            "name": {
+              "description": "name is the storage class name.",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "telemetry": {
+          "description": "telemetry specifies the Confluent telemetry reporter configuration.",
+          "properties": {
+            "global": {
+              "description": "global allows disabling telemetry configuration. If CFK is deployed with telemetry, this field is only used to disable telemetry. The default value is `true` if telemetry is enabled at the global level.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tls": {
+          "description": "tls specifies the global-level TLS configuration which can be used by listeners and services.",
+          "properties": {
+            "autoGeneratedCerts": {
+              "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
+              "type": "boolean"
+            },
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "ignoreTrustStoreConfig": {
+              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+              "type": "boolean"
+            },
+            "jksPassword": {
+              "description": "jksPassword references the secret containing the JKS password.",
+              "properties": {
+                "secretRef": {
+                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "dataVolumeCapacity",
+        "image",
+        "replicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the Kafka cluster.",
+      "properties": {
+        "arbitraryData": {
+          "description": "arbitraryData is the map for any arbitrary data associated with this Confluent component.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "authorizationType": {
+          "description": "authorizationType is the authorization type for this Confluent component.",
+          "type": "string"
+        },
+        "brokerIdOffset": {
+          "description": "brokerIdOffset is the broker id offset of the Kafka cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "clusterID": {
+          "description": "clusterID is the ID of the Kafka cluster.",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "clusterName is the name of the Confluent Platform component cluster.",
+          "type": "string"
+        },
+        "clusterNamespace": {
+          "description": "clusterNamespace is the namespace where the Confluent Platform component cluster is running.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions specify the latest available observations of the current state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of currently running replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "internalSecrets": {
+          "description": "internalSecrets are internal secrets created by CFK for this Confluent component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "internalTopicNames": {
+          "description": "internalTopicNames are the topics used by the component for internal use.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "listeners": {
+          "additionalProperties": {
+            "properties": {
+              "advertisedExternalEndpoints": {
+                "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "authenticationType": {
+                "description": "authenticationType shows the authentication type configured by the listener.",
+                "type": "string"
+              },
+              "client": {
+                "type": "string"
+              },
+              "externalAccessType": {
+                "description": "externalAccessType shows the external access type used for the listener.",
+                "type": "string"
+              },
+              "externalEndpoint": {
+                "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+                "type": "string"
+              },
+              "internalEndpoint": {
+                "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+                "type": "string"
+              },
+              "tls": {
+                "description": "tls shows whether TLS is configured for the listener.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "listeners is a map for the status of Kafka Listeners.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "minISR": {
+          "description": "minISR is the minimum number of in sync replicas in the Kafka cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "description": "operatorVersion is the internal version of CFK.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "phase describes the state of the Confluent Platform component. This can either be 'PROVISIONING' or 'RUNNING' 'PROVISIONING' means the Confluent Platform component is currently getting deployed and not ready yet. 'RUNNING' means the Confluent Platform component has been successfully deployed.",
+          "type": "string"
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of currently ready replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicationFactor": {
+          "description": "replicationFactor is the replication factor of the topics in the Kafka cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "selector gets the label selector of the child pod. The Horizontal Pod Autoscaler(HPA) will scale using the label selector of the child pod.",
+          "type": "string"
+        },
+        "services": {
+          "additionalProperties": {
+            "description": "ListenerStatus describes general information about the listeners.",
+            "properties": {
+              "advertisedExternalEndpoints": {
+                "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "authenticationType": {
+                "description": "authenticationType shows the authentication type configured by the listener.",
+                "type": "string"
+              },
+              "externalAccessType": {
+                "description": "externalAccessType shows the external access type used for the listener.",
+                "type": "string"
+              },
+              "externalEndpoint": {
+                "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+                "type": "string"
+              },
+              "internalEndpoint": {
+                "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+                "type": "string"
+              },
+              "tls": {
+                "description": "tls shows whether TLS is configured for the listener.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "services is a map for the Kafka services.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "zookeeperConnect": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/kafkarestclass_v1beta1.json
+++ b/platform.confluent.io/kafkarestclass_v1beta1.json
@@ -1,0 +1,380 @@
+{
+  "description": "KafkaRestClass is the schema for the Kafka REST API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the KafkaRestClass.",
+      "properties": {
+        "kafkaClusterRef": {
+          "description": "kafkaClusterRef specifies the name of the Kafka cluster.",
+          "properties": {
+            "name": {
+              "description": "name specifies the name of the Confluent Platform component cluster.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace specifies the namespace where the Confluent Platform component cluster is running.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kafkaRest": {
+          "description": "kafkaRest specifies the Kafka REST API configuration.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the REST API authentication mechanism.",
+              "properties": {
+                "basic": {
+                  "description": "basic specifies the basic authentication settings for the REST API client.",
+                  "properties": {
+                    "debug": {
+                      "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                      "type": "boolean"
+                    },
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "restrictedRoles": {
+                      "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "roles": {
+                      "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "secretRef": {
+                      "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bearer": {
+                  "description": "bearer specifies the bearer authentication settings for the REST API client.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "type specifies the REST API authentication type. Valid options are `basic`, `bearer`, and `mtls`.",
+                  "enum": [
+                    "basic",
+                    "bearer",
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "endpoint": {
+              "description": "endpoint specifies where Confluent REST API is running.",
+              "minLength": 1,
+              "pattern": "^https?://.*",
+              "type": "string"
+            },
+            "kafkaClusterID": {
+              "description": "kafkaClusterID specifies the id of Kafka cluster. It takes precedence over using the Kafka REST API to get the cluster id.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls specifies the custom TLS structure for the application resources, e.g. connector, topic, schema, of the Confluent Platform components.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer contains the directory path in the container where `keystore.jks`, `truststore.jks`, `jksPassword.txt` keys are mounted.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "jksPassword": {
+                  "description": "jksPassword specifies the secret name that contains the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef specifies the secret name that contains the certificates. More info about certificates key/value format: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secondaryKafkaClusterRef": {
+          "description": "secondaryKafkaClusterRef specifies the name of the secondary Kafka cluster when using centralized RBAC.",
+          "properties": {
+            "name": {
+              "description": "name specifies the name of the Confluent Platform component cluster.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace specifies the namespace where the Confluent Platform component cluster is running.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secondaryKafkaRest": {
+          "description": "secondaryKafkaRest specifies the secondary Kafka REST API configuration when using centralized RBAC.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the REST API authentication mechanism.",
+              "properties": {
+                "basic": {
+                  "description": "basic specifies the basic authentication settings for the REST API client.",
+                  "properties": {
+                    "debug": {
+                      "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                      "type": "boolean"
+                    },
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "restrictedRoles": {
+                      "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "roles": {
+                      "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "secretRef": {
+                      "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bearer": {
+                  "description": "bearer specifies the bearer authentication settings for the REST API client.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "type specifies the REST API authentication type. Valid options are `basic`, `bearer`, and `mtls`.",
+                  "enum": [
+                    "basic",
+                    "bearer",
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "endpoint": {
+              "description": "endpoint specifies where Confluent REST API is running.",
+              "minLength": 1,
+              "pattern": "^https?://.*",
+              "type": "string"
+            },
+            "kafkaClusterID": {
+              "description": "kafkaClusterID specifies the id of Kafka cluster. It takes precedence over using the Kafka REST API to get the cluster id.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls specifies the custom TLS structure for the application resources, e.g. connector, topic, schema, of the Confluent Platform components.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer contains the directory path in the container where `keystore.jks`, `truststore.jks`, `jksPassword.txt` keys are mounted.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "jksPassword": {
+                  "description": "jksPassword specifies the secret name that contains the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef specifies the secret name that contains the certificates. More info about certificates key/value format: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the KafkaRestClass.",
+      "properties": {
+        "conditions": {
+          "description": "conditions are the latest available observed state of the kafkaRestClass.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "endpoint": {
+          "description": "endpoint specifies the Kafka REST API / MDS endpoint.",
+          "type": "string"
+        },
+        "kafkaClusterID": {
+          "description": "kafkaClusterID specifies the id of the Kafka cluster. If using centralized RBAC and kafkaRestClass is for the secondary Kafka cluster, it will be the cluster id of the secondary Kafka cluster.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/kafkarestproxy_v1beta1.json
+++ b/platform.confluent.io/kafkarestproxy_v1beta1.json
@@ -1,0 +1,4538 @@
+{
+  "description": "KafkaRestProxy is the schema for the Kafka REST Proxy API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the KafkaRestProxy cluster.",
+      "properties": {
+        "authentication": {
+          "description": "authentication specifies the authentication configurations for the KafkaRestProxy cluster.",
+          "properties": {
+            "basic": {
+              "description": "basic specifies the configuration for basic authentication.",
+              "properties": {
+                "debug": {
+                  "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                  "type": "boolean"
+                },
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "restrictedRoles": {
+                  "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "roles": {
+                  "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "secretRef": {
+                  "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the authentication scheme for the REST API server. Valid options are `basic` and `mtls`.",
+              "enum": [
+                "basic",
+                "mtls"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "authorization": {
+          "description": "authorization specifies the RBAC configuration for the KafkaRestProxy cluster.",
+          "properties": {
+            "kafkaRestClassRef": {
+              "description": "kafkaRestClassRef references the KafkaRestClass which specifies the Kafka REST API connection configuration.",
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of the KafkaRestClass application resource.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace specifies the namespace of the KafkaRestClass.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the client-side authorization type. The valid option is `rbac`.",
+              "enum": [
+                "rbac"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "configOverrides": {
+          "description": "configOverrides specifies the configs to override the server, JVM, Log4j properties for the KafkaRestProxy cluster. A change will roll the cluster.",
+          "properties": {
+            "jvm": {
+              "description": "jvm is a list of JVM configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "log4j": {
+              "description": "log4j is a list of Log4J configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "server": {
+              "description": "server is a list of server configuration supported by the Confluent Platform component. This will either add or update existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dependencies": {
+          "description": "dependencies specifies the dependency configurations for Kafka, Interceptor, Schema Registry, and the MDS.",
+          "properties": {
+            "interceptor": {
+              "description": "interceptor specifies the interceptor dependency configuration.",
+              "properties": {
+                "configs": {
+                  "description": "configs describe the configurations for the Confluent Platform interceptor. The config override feature can be used to pass the configuration settings.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "consumer": {
+                  "description": "consumer specifies the consumer configuration for the interceptor. If not configured, it uses the Kafka dependency configuration.",
+                  "properties": {
+                    "authentication": {
+                      "description": "authentication defines the authentication for the Kafka cluster.",
+                      "properties": {
+                        "jaasConfig": {
+                          "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "jaasConfigPassThrough": {
+                          "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauthbearer": {
+                          "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": {
+                          "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                          "enum": [
+                            "plain",
+                            "oauthbearer",
+                            "digest",
+                            "mtls"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "bootstrapEndpoint": {
+                      "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                      "minLength": 1,
+                      "pattern": ".+:[0-9]+",
+                      "type": "string"
+                    },
+                    "discovery": {
+                      "description": "discovery specifies the capability to discover the Kafka cluster.",
+                      "properties": {
+                        "name": {
+                          "description": "name is the name of the Confluent Platform component cluster.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tls": {
+                      "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "ignoreTrustStoreConfig": {
+                          "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "jksPassword": {
+                          "description": "jksPassword references the secret containing the JKS password.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "enabled": {
+                  "description": "enabled indicates whether the Confluent Platform interceptor is enabled or disabled.",
+                  "type": "boolean"
+                },
+                "producer": {
+                  "description": "producer specifies the producer configuration for the interceptor. If not configured, it uses the Kafka dependency configuration.",
+                  "properties": {
+                    "authentication": {
+                      "description": "authentication defines the authentication for the Kafka cluster.",
+                      "properties": {
+                        "jaasConfig": {
+                          "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "jaasConfigPassThrough": {
+                          "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauthbearer": {
+                          "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": {
+                          "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                          "enum": [
+                            "plain",
+                            "oauthbearer",
+                            "digest",
+                            "mtls"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "bootstrapEndpoint": {
+                      "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                      "minLength": 1,
+                      "pattern": ".+:[0-9]+",
+                      "type": "string"
+                    },
+                    "discovery": {
+                      "description": "discovery specifies the capability to discover the Kafka cluster.",
+                      "properties": {
+                        "name": {
+                          "description": "name is the name of the Confluent Platform component cluster.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tls": {
+                      "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "ignoreTrustStoreConfig": {
+                          "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "jksPassword": {
+                          "description": "jksPassword references the secret containing the JKS password.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "publishMs": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kafka": {
+              "description": "kafka specifies the Kafka dependency configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication defines the authentication for the Kafka cluster.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "digest",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bootstrapEndpoint": {
+                  "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "discovery": {
+                  "description": "discovery specifies the capability to discover the Kafka cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name is the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mds": {
+              "description": "mds specifies the MDS dependencies configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the client side authentication configuration for the MDS.",
+                  "properties": {
+                    "bearer": {
+                      "description": "bearer specifies the bearer authentication settings.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication method for the MDS. The valid option is `bearer`.",
+                      "enum": [
+                        "bearer"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bearer",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "endpoint": {
+                  "description": "endpoint specifies the MDS endpoint.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tokenKeyPair": {
+                  "description": "tokenKeyPair specifies the token keypair to configure the MDS.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret that contains the MDS token key pair.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "authentication",
+                "endpoint",
+                "tokenKeyPair"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "schemaRegistry": {
+              "description": "schemaRegistry specifies the Schema Registry dependency configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the authentication for the Schema Registry cluster.",
+                  "properties": {
+                    "basic": {
+                      "description": "basic specifies the configuration for basic authentication.",
+                      "properties": {
+                        "debug": {
+                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                          "type": "boolean"
+                        },
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "restrictedRoles": {
+                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "roles": {
+                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretRef": {
+                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                      "enum": [
+                        "basic",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Schema Registry cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "description": "url specifies the URL endpoint of the Schema Registry cluster.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalAccess": {
+          "description": "externalAccess specifies the external access configuration.",
+          "properties": {
+            "loadBalancer": {
+              "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain is the domain name of the component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "loadBalancerSourceRanges": {
+                  "description": "loadBalancerSourceRanges specify the source ranges.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "port": {
+                  "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "prefix": {
+                  "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify the user-provided service port(s).",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodePort": {
+              "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "host": {
+                  "description": "host defines the host name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "nodePortOffset": {
+                  "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "host",
+                "nodePortOffset"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "route": {
+              "description": "route specifies the configuration to create a route service in OpenShift.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain specifies the domain name of the Confluent component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "prefix": {
+                  "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "wildcardPolicy": {
+                  "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                  "enum": [
+                    "Subdomain",
+                    "None"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+              "enum": [
+                "loadBalancer",
+                "nodePort",
+                "route"
+              ],
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "headlessService": {
+          "description": "headlessService specifies the configuration of the Kubernetes headless service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs. It specifies the annotations to be added to the CFK-created headless service. These annotations are merged with the injectAnnotations and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs. It specifies the labels to be added to the CFK-created headless service. These labels are merged with the injectLabels and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "publishNotReadyAddresses": {
+              "description": "publishNotReadyAddresses specifies the publishNotReadyAddresses field. For Kafka, this value must be true. The default value is true.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "image specifies the application and the init docker image configurations. A change to this setting will roll the cluster.",
+          "properties": {
+            "application": {
+              "description": "application is the Docker image name of the application. Specify `<Docker-registry FQDN>/<docker-repository-name>/<component-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "init": {
+              "description": "init is the init-container name. Specify `<Docker-registry FQDN>/<docker-repository-name>/<init-container-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "description": "pullPolicy is the policy for pulling images. Valid options are `Always`, `Never`, and `IfNotPresent`. The default value is `IfNotPresent`.",
+              "enum": [
+                "Always",
+                "Never",
+                "IfNotPresent"
+              ],
+              "type": "string"
+            },
+            "pullSecretRef": {
+              "description": "pullSecretRef references the secrets in the same namespace to be used for pulling images. Image pull secrets are distinct from secrets because secrets can be mounted in the pod, but image pull secrets are only accessed by `kubelet`. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "application",
+            "init"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "injectAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectAnnotations are the annotations injected to the internal resources that CFK created. The internal annotations are preserved and cannot be overridden. For pod annotations, use `podTemplate.annotations`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "injectLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectLabels are the labels injected to the internal resources that CFK created. The internal labels are preserved and cannot be overridden. For pod labels, use `podTemplate.labels`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "k8sClusterDomain": {
+          "description": "k8sClusterDomain specifies the configuration of the Kubernetes cluster domain. The default is the `cluster.local` domain.",
+          "type": "string"
+        },
+        "license": {
+          "description": "license specifies the license configuration for the Confluent Platform component.",
+          "properties": {
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where the license key is mounted. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "minLength": 1,
+              "type": "string"
+            },
+            "globalLicense": {
+              "description": "globalLicense specifies whether the Confluent Platform component shares the common global license.",
+              "type": "boolean"
+            },
+            "secretRef": {
+              "description": "secretRef references the secret that provides the license for the Confluent Platform component. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metrics": {
+          "description": "metrics specify the security settings for the metric services.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication configuration for the metrics.",
+              "properties": {
+                "type": {
+                  "description": "type specifies the metrics authentication method. The valid option is `mtls`.",
+                  "enum": [
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prometheus": {
+              "description": "prometheus specifies the configuration overrides for the JMX-Prometheus exporter.",
+              "properties": {
+                "blacklist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "rules": {
+                  "items": {
+                    "description": "Rule defines the Prometheus Exporter rule override.",
+                    "properties": {
+                      "attrNameSnakeCase": {
+                        "type": "boolean"
+                      },
+                      "cache": {
+                        "type": "boolean"
+                      },
+                      "help": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "granular"
+                      },
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "type": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "valueFactor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": 1,
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "whitelist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "tls specifies the TLS configuration for the metrics.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "ignoreTrustStoreConfig": {
+                  "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "jksPassword": {
+                  "description": "jksPassword references the secret containing the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mountedSecrets": {
+          "description": "mountedSecrets list the secrets injected to the underlying statefulset configuration. The secret reference is mounted in the default path `/mnt/secrets/<secret-name>`. The underlying resources will follow the secret as a file configuration. More info: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod. A change to this setting will roll the cluster.",
+          "items": {
+            "description": "MountedSecrets provides a way to inject a custom secret to the underlying statefulset.",
+            "properties": {
+              "keyItems": {
+                "description": "keyItems are key and path names.",
+                "items": {
+                  "description": "Maps a string key to a path within a volume.",
+                  "properties": {
+                    "key": {
+                      "description": "The key to project.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "path": {
+                      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "path"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "secretRef": {
+                "description": "secretRef references the name of the secret.",
+                "maxLength": 30,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "secretRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mountedVolumes": {
+          "description": "mountedVolumes list the custom volumes that need to be mounted into the underlying statefulset. A change to this setting will roll the cluster.",
+          "properties": {
+            "volumeMounts": {
+              "description": "volumeMounts specify the list of volume mounts for the pods in the statefulset.",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                    "type": "boolean"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "volumes specify the list of volumes that can be mounted into the pods of statefulset.",
+              "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureDisk": {
+                    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "cachingMode": {
+                        "description": "Host Caching mode: None, Read Only, Read Write.",
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "description": "The Name of the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "description": "The URI the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureFile": {
+                    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "the name of secret that contains Azure Storage Account Name and Key",
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "description": "Share Name",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cephfs": {
+                    "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "monitors": {
+                        "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cinder": {
+                    "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeID": {
+                        "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "configMap": {
+                    "description": "ConfigMap represents a configMap that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its keys must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "csi": {
+                    "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "readOnly": {
+                        "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "downwardAPI": {
+                    "description": "DownwardAPI represents downward API about the pod that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "Items is a list of downward API volume file",
+                        "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                          "properties": {
+                            "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "emptyDir": {
+                    "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "properties": {
+                      "medium": {
+                        "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ephemeral": {
+                    "description": "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                            "properties": {
+                              "accessModes": {
+                                "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dataSource": {
+                                "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "description": "Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "description": "Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "description": "A label query over volumes to consider for binding.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fc": {
+                    "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "Optional: FC target lun number",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "description": "Optional: FC target worldwide names (WWNs)",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "wwids": {
+                        "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flexVolume": {
+                    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the driver to use for this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Optional: Extra command options if any.",
+                        "type": "object"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flocker": {
+                    "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                    "properties": {
+                      "datasetName": {
+                        "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcePersistentDisk": {
+                    "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "pdName": {
+                        "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "pdName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitRepo": {
+                    "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                    "properties": {
+                      "directory": {
+                        "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "Repository URL",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "Commit hash for the specified revision.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repository"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "glusterfs": {
+                    "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                    "properties": {
+                      "endpoints": {
+                        "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostPath": {
+                    "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                    "properties": {
+                      "path": {
+                        "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "iscsi": {
+                    "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "description": "whether support iSCSI Discovery CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "description": "whether support iSCSI Session CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "description": "Target iSCSI Qualified Name.",
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "iSCSI Target Lun number.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "portals": {
+                        "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "CHAP Secret for iSCSI target and initiator authentication",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "targetPortal": {
+                        "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "properties": {
+                      "path": {
+                        "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "properties": {
+                      "claimName": {
+                        "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "claimName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "photonPersistentDisk": {
+                    "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "description": "ID that identifies Photon Controller persistent disk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pdID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "portworxVolume": {
+                    "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "VolumeID uniquely identifies a Portworx volume",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "projected": {
+                    "description": "Items for all in one resources secrets, configmaps, and downward API",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "sources": {
+                        "description": "list of volume projections",
+                        "items": {
+                          "description": "Projection that may be projected along with other supported volume types",
+                          "properties": {
+                            "configMap": {
+                              "description": "information about the configMap data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                              "description": "information about the downwardAPI data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secret": {
+                              "description": "information about the secret data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountToken": {
+                              "description": "information about the serviceAccountToken data to project",
+                              "properties": {
+                                "audience": {
+                                  "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "quobyte": {
+                    "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "group": {
+                        "description": "Group to map volume access to Default is no group",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User to map volume access to Defaults to serivceaccount user",
+                        "type": "string"
+                      },
+                      "volume": {
+                        "description": "Volume is a string that references an already created Quobyte volume by name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbd": {
+                    "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "image": {
+                        "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "pool": {
+                        "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scaleIO": {
+                    "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "description": "The host address of the ScaleIO API Gateway.",
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "sslEnabled": {
+                        "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                        "type": "string"
+                      },
+                      "system": {
+                        "description": "The name of the storage system as configured in ScaleIO.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its keys must be defined",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageos": {
+                    "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeName": {
+                        "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "vsphereVolume": {
+                    "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "description": "Storage Policy Based Management (SPBM) profile name.",
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "description": "Path that identifies vSphere volume vmdk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumePath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "volumeMounts",
+            "volumes"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oneReplicaPerNode": {
+          "description": "oneReplicaPerNode controls whether to run 1 pod per node using the pod anti-affinity capability. Enabling this configuration in an existing cluster will roll the cluster.",
+          "type": "boolean"
+        },
+        "podTemplate": {
+          "description": "podTemplate specifies the statefulset pod template configuration.",
+          "properties": {
+            "affinity": {
+              "description": "affinity specifies a group of affinity scheduling rules. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.",
+              "properties": {
+                "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                        "properties": {
+                          "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs stored with the resource and may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "envVars": {
+              "description": "envVars contain environment variables to be injected into containers. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs that can be used to organize and categorize (scope and select) objects. More info: http://kubernetes.io/docs/user-guide/labels.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "podSecurityContext": {
+              "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+              "properties": {
+                "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
+                    "properties": {
+                      "name": {
+                        "description": "Name of a property to set",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of a property to set",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "priorityClassName": {
+              "description": "priorityClassName specifies the priority class for the pod (if any).",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "probe": {
+              "description": "probe contains the fields for standard Kubernetes readiness/liveness probe configuration.",
+              "properties": {
+                "liveness": {
+                  "description": "liveness configures the Kubernetes probe settings. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "readiness": {
+                  "description": "readiness configures the Kubernetes probe setting. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "resources": {
+              "description": "resources describe the compute resource requirements.",
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityContext": {
+              "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "description": "ServiceAccountName is the name of the service account used to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account.",
+              "type": "string"
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "terminationGracePeriodSeconds is the grace period before the pod is deleted.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "tolerations": {
+              "description": "tolerations specify the pods to schedule onto the nodes with matching taints, using the triple `<key,value,effect>` and the matching operator `<operator>`.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "topologySpreadConstraints describe how a group of pods ought to spread across topology domains. Scheduler will schedule pods based on the constraints. All topologySpreadConstraints are ANDed.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas. A change to this setting will roll the cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "telemetry": {
+          "description": "telemetry specifies the Confluent telemetry reporter configuration.",
+          "properties": {
+            "global": {
+              "description": "global allows disabling telemetry configuration. If CFK is deployed with telemetry, this field is only used to disable telemetry. The default value is `true` if telemetry is enabled at the global level.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tls": {
+          "description": "tls specifies the TLS configurations for the KafkaRestProxy cluster.",
+          "properties": {
+            "autoGeneratedCerts": {
+              "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
+              "type": "boolean"
+            },
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "ignoreTrustStoreConfig": {
+              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+              "type": "boolean"
+            },
+            "jksPassword": {
+              "description": "jksPassword references the secret containing the JKS password.",
+              "properties": {
+                "secretRef": {
+                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "image",
+        "replicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the KafkaRestProxy cluster.",
+      "properties": {
+        "arbitraryData": {
+          "description": "arbitraryData is the map for any arbitrary data associated with this Confluent component.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "authorizationType": {
+          "description": "authorizationType is the authorization type for this Confluent component.",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "clusterName is the name of the Confluent Platform component cluster.",
+          "type": "string"
+        },
+        "clusterNamespace": {
+          "description": "clusterNamespace is the namespace where the Confluent Platform component cluster is running.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions specify the latest available observations of the current state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of currently running replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "internalSecrets": {
+          "description": "internalSecrets are internal secrets created by CFK for this Confluent component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "internalTopicNames": {
+          "description": "internalTopicNames are the topics used by the component for internal use.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kafka": {
+          "description": "kafka is the Kafka client side status for the KafkaRestProxy cluster.",
+          "properties": {
+            "authenticationType": {
+              "description": "authenticationType describes the authentication method for the Kafka cluster.",
+              "type": "string"
+            },
+            "bootstrapEndpoint": {
+              "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls indicates whether TLS is enabled for the Kafka dependency.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metricPrefix": {
+          "description": "metricPrefix is the prefix for the JMX metric of the KafkaRestProxy.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "description": "operatorVersion is the internal version of CFK.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "phase describes the state of the Confluent Platform component. This can either be 'PROVISIONING' or 'RUNNING' 'PROVISIONING' means the Confluent Platform component is currently getting deployed and not ready yet. 'RUNNING' means the Confluent Platform component has been successfully deployed.",
+          "type": "string"
+        },
+        "rbac": {
+          "description": "rbac contains the RBAC-related status when RBAC is enabled.",
+          "properties": {
+            "clusterID": {
+              "description": "clusterID specifies the id of the cluster.",
+              "type": "string"
+            },
+            "internalRolebindings": {
+              "description": "internalRolebindings specifies the internal rolebindings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of currently ready replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "restConfig": {
+          "description": "restConfig is the REST API configuration of the KafkaRestProxy.",
+          "properties": {
+            "advertisedExternalEndpoints": {
+              "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "authenticationType": {
+              "description": "authenticationType shows the authentication type configured by the listener.",
+              "type": "string"
+            },
+            "externalAccessType": {
+              "description": "externalAccessType shows the external access type used for the listener.",
+              "type": "string"
+            },
+            "externalEndpoint": {
+              "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "internalEndpoint": {
+              "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls shows whether TLS is configured for the listener.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "selector gets the label selector of the child pod. The Horizontal Pod Autoscaler(HPA) will scale using the label selector of the child pod.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/kafkatopic_v1beta1.json
+++ b/platform.confluent.io/kafkatopic_v1beta1.json
@@ -1,0 +1,301 @@
+{
+  "description": "KafkaTopic is the schema for the Kafka Topic API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the KafkaTopic.",
+      "properties": {
+        "configs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "configs is a map of string key and value pairs that are used to pass the configuration settings for the topic. More info: https://docs.confluent.io/current/installation/configuration/topic-configs.html.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "kafkaClusterRef": {
+          "description": "kafkaClusterRef specifies the name of the Kafka cluster.",
+          "properties": {
+            "name": {
+              "description": "name specifies the name of the Confluent Platform component cluster.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace specifies the namespace where the Confluent Platform component cluster is running.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kafkaRest": {
+          "description": "kafkaRest specifies the Kafka REST API configuration.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the REST API authentication mechanism.",
+              "properties": {
+                "basic": {
+                  "description": "basic specifies the basic authentication settings for the REST API client.",
+                  "properties": {
+                    "debug": {
+                      "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                      "type": "boolean"
+                    },
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "restrictedRoles": {
+                      "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "roles": {
+                      "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "secretRef": {
+                      "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bearer": {
+                  "description": "bearer specifies the bearer authentication settings for the REST API client.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "type specifies the REST API authentication type. Valid options are `basic`, `bearer`, and `mtls`.",
+                  "enum": [
+                    "basic",
+                    "bearer",
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "endpoint": {
+              "description": "endpoint specifies where Confluent REST API is running.",
+              "minLength": 1,
+              "pattern": "^https?://.*",
+              "type": "string"
+            },
+            "kafkaClusterID": {
+              "description": "kafkaClusterID specifies the id of Kafka cluster. It takes precedence over using the Kafka REST API to get the cluster id.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls specifies the custom TLS structure for the application resources, e.g. connector, topic, schema, of the Confluent Platform components.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer contains the directory path in the container where `keystore.jks`, `truststore.jks`, `jksPassword.txt` keys are mounted.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "jksPassword": {
+                  "description": "jksPassword specifies the secret name that contains the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef specifies the secret name that contains the certificates. More info about certificates key/value format: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kafkaRestClassRef": {
+          "description": "kafkaRestClassRef references the KafkaRestClass which defines Kafka REST API connection information.",
+          "properties": {
+            "name": {
+              "description": "name specifies the name of the KafkaRestClass application resource.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace specifies the namespace of the KafkaRestClass.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "name": {
+          "description": "name specifies the topic name. If not configured, the KafkaTopic CR name is used as the topic name.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9\\._\\-]*$",
+          "type": "string"
+        },
+        "partitionCount": {
+          "description": "partitionCount specifies the number of partitions for the topic. If not configured, it will be defaulted to the partition count that Kafka REST V3 API supports.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas specifies the replication factor for the topic. If not configured, it will be defaulted to the replication factor that Kafka REST V3 API supports.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the KafkaTopic.",
+      "properties": {
+        "appState": {
+          "default": "Unknown",
+          "description": "appState is the current state of the topic application.",
+          "enum": [
+            "Unknown",
+            "Created",
+            "Failed",
+            "Deleted"
+          ],
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions are the latest available observed states of the topic.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "kafkaCluster": {
+          "type": "string"
+        },
+        "kafkaClusterID": {
+          "description": "kafkaClusterID is the id of the Kafka cluster.",
+          "type": "string"
+        },
+        "kafkaRestEndpoint": {
+          "description": "kafkaRestEndpoint is the endpoint of the Kafka REST API.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "partitionCount": {
+          "description": "partitionCount is the partition count of the topic.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the replication factor of the topic.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "state": {
+          "description": "state is the state of the topic.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/platform.confluent.io/ksqldb_v1beta1.json
+++ b/platform.confluent.io/ksqldb_v1beta1.json
@@ -1,0 +1,4692 @@
+{
+  "description": "KsqlDB is the schema for the ksqlDB API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the ksqlDB cluster.",
+      "properties": {
+        "authentication": {
+          "description": "authentication specifies whether authentication is needed when accessing the ksqlDB cluster.",
+          "properties": {
+            "basic": {
+              "description": "basic specifies the configuration for basic authentication.",
+              "properties": {
+                "debug": {
+                  "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                  "type": "boolean"
+                },
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "restrictedRoles": {
+                  "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "roles": {
+                  "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "secretRef": {
+                  "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the authentication scheme for the REST API server. Valid options are `basic` and `mtls`.",
+              "enum": [
+                "basic",
+                "mtls"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "authorization": {
+          "description": "authorization specifies the RBAC configuration for the ksqlDB cluster.",
+          "properties": {
+            "kafkaRestClassRef": {
+              "description": "kafkaRestClassRef references the KafkaRestClass which specifies the Kafka REST API connection configuration.",
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of the KafkaRestClass application resource.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace specifies the namespace of the KafkaRestClass.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the client-side authorization type. The valid option is `rbac`.",
+              "enum": [
+                "rbac"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "configOverrides": {
+          "description": "configOverrides specifies the configs to override the server, JVM, Log4j properties for the ksqlDB cluster. A change will roll the cluster.",
+          "properties": {
+            "jvm": {
+              "description": "jvm is a list of JVM configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "log4j": {
+              "description": "log4j is a list of Log4J configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "server": {
+              "description": "server is a list of server configuration supported by the Confluent Platform component. This will either add or update existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dataVolumeCapacity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "dataVolumeCapacity specifies the data volume for the ksqlDB cluster.",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
+        "dependencies": {
+          "description": "dependencies specifies the dependency configurations for Kafka, Interceptor, Schema Registry, the MDS, and Connect.",
+          "properties": {
+            "connect": {
+              "description": "connect specifies the Connect dependency configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the authentication configuration for the Connect cluster.",
+                  "properties": {
+                    "basic": {
+                      "description": "basic specifies the configuration for basic authentication.",
+                      "properties": {
+                        "debug": {
+                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                          "type": "boolean"
+                        },
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "restrictedRoles": {
+                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "roles": {
+                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretRef": {
+                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                      "enum": [
+                        "basic",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the client-side TLS setting for the Connect cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "description": "url specifies the URL endpoint of the Connect cluster.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "interceptor": {
+              "description": "interceptor specifies the interceptor dependency configuration.",
+              "properties": {
+                "configs": {
+                  "description": "configs describe the configurations for the Confluent Platform interceptor. The config override feature can be used to pass the configuration settings.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "consumer": {
+                  "description": "consumer specifies the consumer configuration for the interceptor. If not configured, it uses the Kafka dependency configuration.",
+                  "properties": {
+                    "authentication": {
+                      "description": "authentication defines the authentication for the Kafka cluster.",
+                      "properties": {
+                        "jaasConfig": {
+                          "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "jaasConfigPassThrough": {
+                          "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauthbearer": {
+                          "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": {
+                          "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                          "enum": [
+                            "plain",
+                            "oauthbearer",
+                            "digest",
+                            "mtls"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "bootstrapEndpoint": {
+                      "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                      "minLength": 1,
+                      "pattern": ".+:[0-9]+",
+                      "type": "string"
+                    },
+                    "discovery": {
+                      "description": "discovery specifies the capability to discover the Kafka cluster.",
+                      "properties": {
+                        "name": {
+                          "description": "name is the name of the Confluent Platform component cluster.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tls": {
+                      "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "ignoreTrustStoreConfig": {
+                          "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "jksPassword": {
+                          "description": "jksPassword references the secret containing the JKS password.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "enabled": {
+                  "description": "enabled indicates whether the Confluent Platform interceptor is enabled or disabled.",
+                  "type": "boolean"
+                },
+                "producer": {
+                  "description": "producer specifies the producer configuration for the interceptor. If not configured, it uses the Kafka dependency configuration.",
+                  "properties": {
+                    "authentication": {
+                      "description": "authentication defines the authentication for the Kafka cluster.",
+                      "properties": {
+                        "jaasConfig": {
+                          "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "jaasConfigPassThrough": {
+                          "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauthbearer": {
+                          "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": {
+                          "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                          "enum": [
+                            "plain",
+                            "oauthbearer",
+                            "digest",
+                            "mtls"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "bootstrapEndpoint": {
+                      "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                      "minLength": 1,
+                      "pattern": ".+:[0-9]+",
+                      "type": "string"
+                    },
+                    "discovery": {
+                      "description": "discovery specifies the capability to discover the Kafka cluster.",
+                      "properties": {
+                        "name": {
+                          "description": "name is the name of the Confluent Platform component cluster.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tls": {
+                      "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "ignoreTrustStoreConfig": {
+                          "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "jksPassword": {
+                          "description": "jksPassword references the secret containing the JKS password.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "publishMs": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kafka": {
+              "description": "kafka specifies the Kafka dependency configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication defines the authentication for the Kafka cluster.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "digest",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bootstrapEndpoint": {
+                  "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "discovery": {
+                  "description": "discovery specifies the capability to discover the Kafka cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name is the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mds": {
+              "description": "mds specifies the MDS dependencies configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the client side authentication configuration for the MDS.",
+                  "properties": {
+                    "bearer": {
+                      "description": "bearer specifies the bearer authentication settings.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication method for the MDS. The valid option is `bearer`.",
+                      "enum": [
+                        "bearer"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bearer",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "endpoint": {
+                  "description": "endpoint specifies the MDS endpoint.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tokenKeyPair": {
+                  "description": "tokenKeyPair specifies the token keypair to configure the MDS.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret that contains the MDS token key pair.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "authentication",
+                "endpoint",
+                "tokenKeyPair"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "schemaRegistry": {
+              "description": "schemaRegistry specifies the Schema Registry dependency configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the authentication for the Schema Registry cluster.",
+                  "properties": {
+                    "basic": {
+                      "description": "basic specifies the configuration for basic authentication.",
+                      "properties": {
+                        "debug": {
+                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                          "type": "boolean"
+                        },
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "restrictedRoles": {
+                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "roles": {
+                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretRef": {
+                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                      "enum": [
+                        "basic",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Schema Registry cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "url": {
+                  "description": "url specifies the URL endpoint of the Schema Registry cluster.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalAccess": {
+          "description": "externalAccess specifies the configurations for the endpoints and services to make the ksqlDB accessible from outside the cluster.",
+          "properties": {
+            "loadBalancer": {
+              "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain is the domain name of the component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "loadBalancerSourceRanges": {
+                  "description": "loadBalancerSourceRanges specify the source ranges.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "port": {
+                  "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "prefix": {
+                  "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify the user-provided service port(s).",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodePort": {
+              "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "host": {
+                  "description": "host defines the host name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "nodePortOffset": {
+                  "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "host",
+                "nodePortOffset"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "route": {
+              "description": "route specifies the configuration to create a route service in OpenShift.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain specifies the domain name of the Confluent component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "prefix": {
+                  "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "wildcardPolicy": {
+                  "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                  "enum": [
+                    "Subdomain",
+                    "None"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+              "enum": [
+                "loadBalancer",
+                "nodePort",
+                "route"
+              ],
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "headlessService": {
+          "description": "headlessService specifies the configuration of the Kubernetes headless service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs. It specifies the annotations to be added to the CFK-created headless service. These annotations are merged with the injectAnnotations and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs. It specifies the labels to be added to the CFK-created headless service. These labels are merged with the injectLabels and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "publishNotReadyAddresses": {
+              "description": "publishNotReadyAddresses specifies the publishNotReadyAddresses field. For Kafka, this value must be true. The default value is true.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "image specifies the application and the init docker image configurations. A change to this setting will roll the cluster.",
+          "properties": {
+            "application": {
+              "description": "application is the Docker image name of the application. Specify `<Docker-registry FQDN>/<docker-repository-name>/<component-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "init": {
+              "description": "init is the init-container name. Specify `<Docker-registry FQDN>/<docker-repository-name>/<init-container-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "description": "pullPolicy is the policy for pulling images. Valid options are `Always`, `Never`, and `IfNotPresent`. The default value is `IfNotPresent`.",
+              "enum": [
+                "Always",
+                "Never",
+                "IfNotPresent"
+              ],
+              "type": "string"
+            },
+            "pullSecretRef": {
+              "description": "pullSecretRef references the secrets in the same namespace to be used for pulling images. Image pull secrets are distinct from secrets because secrets can be mounted in the pod, but image pull secrets are only accessed by `kubelet`. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "application",
+            "init"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "injectAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectAnnotations are the annotations injected to the internal resources that CFK created. The internal annotations are preserved and cannot be overridden. For pod annotations, use `podTemplate.annotations`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "injectLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectLabels are the labels injected to the internal resources that CFK created. The internal labels are preserved and cannot be overridden. For pod labels, use `podTemplate.labels`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "internalTopicReplicationFactor": {
+          "description": "internalTopicReplicationFactor specifies the replication factor for internal topics.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "k8sClusterDomain": {
+          "description": "k8sClusterDomain specifies the configuration of the Kubernetes cluster domain. The default is the `cluster.local` domain.",
+          "type": "string"
+        },
+        "license": {
+          "description": "license specifies the license configuration for the Confluent Platform component.",
+          "properties": {
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where the license key is mounted. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "minLength": 1,
+              "type": "string"
+            },
+            "globalLicense": {
+              "description": "globalLicense specifies whether the Confluent Platform component shares the common global license.",
+              "type": "boolean"
+            },
+            "secretRef": {
+              "description": "secretRef references the secret that provides the license for the Confluent Platform component. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metrics": {
+          "description": "metrics specify the security settings for the metric services.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication configuration for the metrics.",
+              "properties": {
+                "type": {
+                  "description": "type specifies the metrics authentication method. The valid option is `mtls`.",
+                  "enum": [
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prometheus": {
+              "description": "prometheus specifies the configuration overrides for the JMX-Prometheus exporter.",
+              "properties": {
+                "blacklist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "rules": {
+                  "items": {
+                    "description": "Rule defines the Prometheus Exporter rule override.",
+                    "properties": {
+                      "attrNameSnakeCase": {
+                        "type": "boolean"
+                      },
+                      "cache": {
+                        "type": "boolean"
+                      },
+                      "help": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "granular"
+                      },
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "type": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "valueFactor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": 1,
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "whitelist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "tls specifies the TLS configuration for the metrics.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "ignoreTrustStoreConfig": {
+                  "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "jksPassword": {
+                  "description": "jksPassword references the secret containing the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mountedSecrets": {
+          "description": "mountedSecrets list the secrets injected to the underlying statefulset configuration. The secret reference is mounted in the default path `/mnt/secrets/<secret-name>`. The underlying resources will follow the secret as a file configuration. More info: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod. A change to this setting will roll the cluster.",
+          "items": {
+            "description": "MountedSecrets provides a way to inject a custom secret to the underlying statefulset.",
+            "properties": {
+              "keyItems": {
+                "description": "keyItems are key and path names.",
+                "items": {
+                  "description": "Maps a string key to a path within a volume.",
+                  "properties": {
+                    "key": {
+                      "description": "The key to project.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "path": {
+                      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "path"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "secretRef": {
+                "description": "secretRef references the name of the secret.",
+                "maxLength": 30,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "secretRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mountedVolumes": {
+          "description": "mountedVolumes list the custom volumes that need to be mounted into the underlying statefulset. A change to this setting will roll the cluster.",
+          "properties": {
+            "volumeMounts": {
+              "description": "volumeMounts specify the list of volume mounts for the pods in the statefulset.",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                    "type": "boolean"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "volumes specify the list of volumes that can be mounted into the pods of statefulset.",
+              "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureDisk": {
+                    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "cachingMode": {
+                        "description": "Host Caching mode: None, Read Only, Read Write.",
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "description": "The Name of the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "description": "The URI the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureFile": {
+                    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "the name of secret that contains Azure Storage Account Name and Key",
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "description": "Share Name",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cephfs": {
+                    "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "monitors": {
+                        "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cinder": {
+                    "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeID": {
+                        "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "configMap": {
+                    "description": "ConfigMap represents a configMap that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its keys must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "csi": {
+                    "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "readOnly": {
+                        "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "downwardAPI": {
+                    "description": "DownwardAPI represents downward API about the pod that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "Items is a list of downward API volume file",
+                        "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                          "properties": {
+                            "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "emptyDir": {
+                    "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "properties": {
+                      "medium": {
+                        "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ephemeral": {
+                    "description": "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                            "properties": {
+                              "accessModes": {
+                                "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dataSource": {
+                                "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "description": "Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "description": "Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "description": "A label query over volumes to consider for binding.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fc": {
+                    "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "Optional: FC target lun number",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "description": "Optional: FC target worldwide names (WWNs)",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "wwids": {
+                        "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flexVolume": {
+                    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the driver to use for this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Optional: Extra command options if any.",
+                        "type": "object"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flocker": {
+                    "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                    "properties": {
+                      "datasetName": {
+                        "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcePersistentDisk": {
+                    "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "pdName": {
+                        "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "pdName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitRepo": {
+                    "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                    "properties": {
+                      "directory": {
+                        "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "Repository URL",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "Commit hash for the specified revision.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repository"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "glusterfs": {
+                    "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                    "properties": {
+                      "endpoints": {
+                        "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostPath": {
+                    "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                    "properties": {
+                      "path": {
+                        "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "iscsi": {
+                    "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "description": "whether support iSCSI Discovery CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "description": "whether support iSCSI Session CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "description": "Target iSCSI Qualified Name.",
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "iSCSI Target Lun number.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "portals": {
+                        "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "CHAP Secret for iSCSI target and initiator authentication",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "targetPortal": {
+                        "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "properties": {
+                      "path": {
+                        "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "properties": {
+                      "claimName": {
+                        "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "claimName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "photonPersistentDisk": {
+                    "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "description": "ID that identifies Photon Controller persistent disk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pdID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "portworxVolume": {
+                    "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "VolumeID uniquely identifies a Portworx volume",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "projected": {
+                    "description": "Items for all in one resources secrets, configmaps, and downward API",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "sources": {
+                        "description": "list of volume projections",
+                        "items": {
+                          "description": "Projection that may be projected along with other supported volume types",
+                          "properties": {
+                            "configMap": {
+                              "description": "information about the configMap data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                              "description": "information about the downwardAPI data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secret": {
+                              "description": "information about the secret data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountToken": {
+                              "description": "information about the serviceAccountToken data to project",
+                              "properties": {
+                                "audience": {
+                                  "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "quobyte": {
+                    "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "group": {
+                        "description": "Group to map volume access to Default is no group",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User to map volume access to Defaults to serivceaccount user",
+                        "type": "string"
+                      },
+                      "volume": {
+                        "description": "Volume is a string that references an already created Quobyte volume by name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbd": {
+                    "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "image": {
+                        "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "pool": {
+                        "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scaleIO": {
+                    "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "description": "The host address of the ScaleIO API Gateway.",
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "sslEnabled": {
+                        "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                        "type": "string"
+                      },
+                      "system": {
+                        "description": "The name of the storage system as configured in ScaleIO.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its keys must be defined",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageos": {
+                    "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeName": {
+                        "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "vsphereVolume": {
+                    "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "description": "Storage Policy Based Management (SPBM) profile name.",
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "description": "Path that identifies vSphere volume vmdk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumePath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "volumeMounts",
+            "volumes"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oneReplicaPerNode": {
+          "description": "oneReplicaPerNode controls whether to run 1 pod per node using the pod anti-affinity capability. Enabling this configuration in an existing cluster will roll the cluster.",
+          "type": "boolean"
+        },
+        "podTemplate": {
+          "description": "podTemplate specifies the statefulset pod template configuration.",
+          "properties": {
+            "affinity": {
+              "description": "affinity specifies a group of affinity scheduling rules. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.",
+              "properties": {
+                "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                        "properties": {
+                          "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs stored with the resource and may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "envVars": {
+              "description": "envVars contain environment variables to be injected into containers. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs that can be used to organize and categorize (scope and select) objects. More info: http://kubernetes.io/docs/user-guide/labels.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "podSecurityContext": {
+              "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+              "properties": {
+                "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
+                    "properties": {
+                      "name": {
+                        "description": "Name of a property to set",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of a property to set",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "priorityClassName": {
+              "description": "priorityClassName specifies the priority class for the pod (if any).",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "probe": {
+              "description": "probe contains the fields for standard Kubernetes readiness/liveness probe configuration.",
+              "properties": {
+                "liveness": {
+                  "description": "liveness configures the Kubernetes probe settings. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "readiness": {
+                  "description": "readiness configures the Kubernetes probe setting. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "resources": {
+              "description": "resources describe the compute resource requirements.",
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityContext": {
+              "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "description": "ServiceAccountName is the name of the service account used to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account.",
+              "type": "string"
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "terminationGracePeriodSeconds is the grace period before the pod is deleted.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "tolerations": {
+              "description": "tolerations specify the pods to schedule onto the nodes with matching taints, using the triple `<key,value,effect>` and the matching operator `<operator>`.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "topologySpreadConstraints describe how a group of pods ought to spread across topology domains. Scheduler will schedule pods based on the constraints. All topologySpreadConstraints are ANDed.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas. A change to this setting will roll the cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "storageClass": {
+          "description": "storageClass specifies the storage class used for creating the PVC for the ksqlDB cluster.",
+          "properties": {
+            "name": {
+              "description": "name is the storage class name.",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "telemetry": {
+          "description": "telemetry specifies the Confluent telemetry reporter configuration.",
+          "properties": {
+            "global": {
+              "description": "global allows disabling telemetry configuration. If CFK is deployed with telemetry, this field is only used to disable telemetry. The default value is `true` if telemetry is enabled at the global level.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tls": {
+          "description": "tls specifies the TLS configurations for the ksqlDB cluster.",
+          "properties": {
+            "autoGeneratedCerts": {
+              "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
+              "type": "boolean"
+            },
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "ignoreTrustStoreConfig": {
+              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+              "type": "boolean"
+            },
+            "jksPassword": {
+              "description": "jksPassword references the secret containing the JKS password.",
+              "properties": {
+                "secretRef": {
+                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "dataVolumeCapacity",
+        "image",
+        "replicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of ksqlDB Server.",
+      "properties": {
+        "arbitraryData": {
+          "description": "arbitraryData is the map for any arbitrary data associated with this Confluent component.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "authorizationType": {
+          "description": "authorizationType is the authorization type for this Confluent component.",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "clusterName is the name of the Confluent Platform component cluster.",
+          "type": "string"
+        },
+        "clusterNamespace": {
+          "description": "clusterNamespace is the namespace where the Confluent Platform component cluster is running.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions specify the latest available observations of the current state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of currently running replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "internalSecrets": {
+          "description": "internalSecrets are internal secrets created by CFK for this Confluent component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "internalTopicNames": {
+          "description": "internalTopicNames are the topics used by the component for internal use.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kafka": {
+          "description": "kafka is the Kafka client side status for the ksqlDB cluster.",
+          "properties": {
+            "authenticationType": {
+              "description": "authenticationType describes the authentication method for the Kafka cluster.",
+              "type": "string"
+            },
+            "bootstrapEndpoint": {
+              "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls indicates whether TLS is enabled for the Kafka dependency.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "description": "operatorVersion is the internal version of CFK.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "phase describes the state of the Confluent Platform component. This can either be 'PROVISIONING' or 'RUNNING' 'PROVISIONING' means the Confluent Platform component is currently getting deployed and not ready yet. 'RUNNING' means the Confluent Platform component has been successfully deployed.",
+          "type": "string"
+        },
+        "rbac": {
+          "description": "rbac contains the RBAC-related status when RBAC is enabled.",
+          "properties": {
+            "clusterID": {
+              "description": "clusterID specifies the id of the cluster.",
+              "type": "string"
+            },
+            "internalRolebindings": {
+              "description": "internalRolebindings specifies the internal rolebindings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of currently ready replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "restConfig": {
+          "description": "restConfig is the REST API configuration of the ksqlDB cluster.",
+          "properties": {
+            "advertisedExternalEndpoints": {
+              "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "authenticationType": {
+              "description": "authenticationType shows the authentication type configured by the listener.",
+              "type": "string"
+            },
+            "externalAccessType": {
+              "description": "externalAccessType shows the external access type used for the listener.",
+              "type": "string"
+            },
+            "externalEndpoint": {
+              "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "internalEndpoint": {
+              "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls shows whether TLS is configured for the listener.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "selector gets the label selector of the child pod. The Horizontal Pod Autoscaler(HPA) will scale using the label selector of the child pod.",
+          "type": "string"
+        },
+        "serviceID": {
+          "description": "serviceID is the id of the ksqlDB service.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/schema_v1beta1.json
+++ b/platform.confluent.io/schema_v1beta1.json
@@ -1,0 +1,499 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the Schema.",
+      "properties": {
+        "compatibilityLevel": {
+          "description": "compatibilityLevel specifies the compatibility level requirement for the schema under the specified subject. Valid options are `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE` and `NONE`. more info: https://docs.confluent.io/platform/current/schema-registry/avro.html#schema-evolution-and-compatibility",
+          "enum": [
+            "BACKWARD",
+            "BACKWARD_TRANSITIVE",
+            "FORWARD",
+            "FORWARD_TRANSITIVE",
+            "FULL",
+            "FULL_TRANSITIVE",
+            "NONE"
+          ],
+          "type": "string"
+        },
+        "data": {
+          "description": "data defines the data required to create the schema.",
+          "properties": {
+            "configRef": {
+              "description": "configRef is the name of the Kubernetes ConfigMap resource containing the schema.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "format": {
+              "description": "format is the format type of the encoded schema. Valid options are `avro`, `json`, and `protobuf`.",
+              "enum": [
+                "avro",
+                "json",
+                "protobuf"
+              ],
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "configRef",
+            "format"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "name": {
+          "description": "name specifies the subject name of schema. If not configured, the Schema CR name is used as the subject name.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[^\\\\]*$",
+          "type": "string"
+        },
+        "schemaReferences": {
+          "description": "schemaReferences defines the schema references in the schema data.",
+          "items": {
+            "description": "SchemaReference is the schema to be used as a reference for the new schema.",
+            "properties": {
+              "avro": {
+                "description": "avro is the data for the referenced Avro schema.",
+                "properties": {
+                  "avro": {
+                    "description": "name is the fully qualified name of the referenced Avro schema.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "avro"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "format": {
+                "description": "format is the format type of the referenced schema. Valid options are `avro`, `json`, and `protobuf`.",
+                "enum": [
+                  "avro",
+                  "json",
+                  "protobuf"
+                ],
+                "minLength": 1,
+                "type": "string"
+              },
+              "json": {
+                "description": "json is the data for the referenced JSON schema.",
+                "properties": {
+                  "url": {
+                    "description": "url is the referenced JSON schema url.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "protobuf": {
+                "description": "protobuf is the data for the referenced Protobuf schema.",
+                "properties": {
+                  "file": {
+                    "description": "file is the file name of the referenced Protobuf schema.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "subject": {
+                "description": "subject is the subject name for the referenced schema through the configRef.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "version": {
+                "description": "version is the version type of the referenced schema.",
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "format",
+              "subject",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "schemaRegistryClusterRef": {
+          "description": "schemaRegistryClusterRef references the CFK-managed Schema Registry cluster.",
+          "properties": {
+            "name": {
+              "description": "name specifies the name of the Confluent Platform component cluster.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace specifies the namespace where the Confluent Platform component cluster is running.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "schemaRegistryRest": {
+          "description": "schemaRegistryRest specifies the Schema Registry REST API configuration.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the REST API authentication mechanism.",
+              "properties": {
+                "basic": {
+                  "description": "basic specifies the basic authentication settings for the REST API client.",
+                  "properties": {
+                    "debug": {
+                      "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                      "type": "boolean"
+                    },
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "restrictedRoles": {
+                      "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "roles": {
+                      "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "secretRef": {
+                      "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bearer": {
+                  "description": "bearer specifies the bearer authentication settings for the REST API client.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "type specifies the REST API authentication type. Valid options are `basic`, `bearer`, and `mtls`.",
+                  "enum": [
+                    "basic",
+                    "bearer",
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "endpoint": {
+              "description": "endpoint specifies where Confluent REST API is running.",
+              "minLength": 1,
+              "pattern": "^https?://.*",
+              "type": "string"
+            },
+            "kafkaClusterID": {
+              "description": "kafkaClusterID specifies the id of Kafka cluster. It takes precedence over using the Kafka REST API to get the cluster id.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls specifies the custom TLS structure for the application resources, e.g. connector, topic, schema, of the Confluent Platform components.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer contains the directory path in the container where `keystore.jks`, `truststore.jks`, `jksPassword.txt` keys are mounted.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "jksPassword": {
+                  "description": "jksPassword specifies the secret name that contains the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef specifies the secret name that contains the certificates. More info about certificates key/value format: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 63,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the Schema.",
+      "properties": {
+        "appState": {
+          "default": "Unknown",
+          "description": "appState is the current state of the Schema application.",
+          "enum": [
+            "Unknown",
+            "Created",
+            "Failed",
+            "Deleted"
+          ],
+          "type": "string"
+        },
+        "compatibilityLevel": {
+          "description": "compatibilityLevel specifies the compatibility level of the schema under the subject.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions are the latest available observed state of the schema.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "deletedVersions": {
+          "description": "deletedVersions are the successfully hard deleted versions for the subject.",
+          "items": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "format": {
+          "description": "format is the format of the latest schema for the subject.",
+          "type": "string"
+        },
+        "id": {
+          "description": "id is the id of the latest schema for the subject.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "schemaReferences": {
+          "description": "schemaReferences are the schema references for the subject.",
+          "items": {
+            "description": "SchemaReference is the schema to be used as a reference for the new schema.",
+            "properties": {
+              "avro": {
+                "description": "avro is the data for the referenced Avro schema.",
+                "properties": {
+                  "avro": {
+                    "description": "name is the fully qualified name of the referenced Avro schema.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "avro"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "format": {
+                "description": "format is the format type of the referenced schema. Valid options are `avro`, `json`, and `protobuf`.",
+                "enum": [
+                  "avro",
+                  "json",
+                  "protobuf"
+                ],
+                "minLength": 1,
+                "type": "string"
+              },
+              "json": {
+                "description": "json is the data for the referenced JSON schema.",
+                "properties": {
+                  "url": {
+                    "description": "url is the referenced JSON schema url.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "protobuf": {
+                "description": "protobuf is the data for the referenced Protobuf schema.",
+                "properties": {
+                  "file": {
+                    "description": "file is the file name of the referenced Protobuf schema.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "subject": {
+                "description": "subject is the subject name for the referenced schema through the configRef.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "version": {
+                "description": "version is the version type of the referenced schema.",
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "format",
+              "subject",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "schemaRegistryAuthenticationType": {
+          "description": "schemaRegistryAuthenticationType is the authentication method used.",
+          "type": "string"
+        },
+        "schemaRegistryEndpoint": {
+          "description": "schemaRegistryEndpoint is the Schema Registry REST endpoint.",
+          "type": "string"
+        },
+        "schemaRegistryTLS": {
+          "description": "schemaRegistryTLS shows whether the Schema Registry is using TLS.",
+          "type": "boolean"
+        },
+        "softDeletedVersions": {
+          "description": "softDeletedVersions are the successfully soft deleted versions for the subject.",
+          "items": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "state": {
+          "description": "state is the state of the Schema CR.",
+          "type": "string"
+        },
+        "subject": {
+          "description": "subject is the subject of the schema.",
+          "type": "string"
+        },
+        "version": {
+          "description": "version is the version of the latest schema for the subject.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/schemaexporter_v1beta1.json
+++ b/platform.confluent.io/schemaexporter_v1beta1.json
@@ -1,0 +1,486 @@
+{
+  "description": "SchemaExporter is the schema for the SchemaExporter API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the schema exporter.",
+      "properties": {
+        "configs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "configs is a map of string key and value pairs. It specifies additional configurations for the schema exporter. More info: https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html#create-a-configuration-file-for-the-exporter",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "contextName": {
+          "description": "contextName specifies the custom context name in the destination Schema Registry cluster where the schemas will be exported. If this is defined, contextType will be ignored. If this is not defined, schemas will be exported to context in destination based on contextType.",
+          "type": "string"
+        },
+        "contextType": {
+          "description": "contextType specifies the type of context created in the destination Schema Registry cluster of the schema exporter. Valid options are `AUTO` and `NONE`. The default value is `AUTO`.",
+          "enum": [
+            "AUTO",
+            "NONE"
+          ],
+          "type": "string"
+        },
+        "destinationCluster": {
+          "description": "destinationCluster specifies the destination Schema Registry cluster. If this is not defined, sourceCluster is chosen as the destination and the schema exporter will be exporting schemas across contexts within the sourceCluster. Schema exporter should be enabled in Schema Registry cluster CR with `spec.enableSchemaExporter`.",
+          "properties": {
+            "schemaRegistryClusterRef": {
+              "description": "schemaRegistryClusterRef references the CFK-managed Schema Registry cluster.",
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of the Confluent Platform component cluster.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace specifies the namespace where the Confluent Platform component cluster is running.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "schemaRegistryRest": {
+              "description": "schemaRegistryRest specifies the Schema Registry REST API configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the REST API authentication mechanism.",
+                  "properties": {
+                    "basic": {
+                      "description": "basic specifies the basic authentication settings for the REST API client.",
+                      "properties": {
+                        "debug": {
+                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                          "type": "boolean"
+                        },
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "restrictedRoles": {
+                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "roles": {
+                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretRef": {
+                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "bearer": {
+                      "description": "bearer specifies the bearer authentication settings for the REST API client.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the REST API authentication type. Valid options are `basic`, `bearer`, and `mtls`.",
+                      "enum": [
+                        "basic",
+                        "bearer",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "endpoint": {
+                  "description": "endpoint specifies where Confluent REST API is running.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                },
+                "kafkaClusterID": {
+                  "description": "kafkaClusterID specifies the id of Kafka cluster. It takes precedence over using the Kafka REST API to get the cluster id.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "tls specifies the custom TLS structure for the application resources, e.g. connector, topic, schema, of the Confluent Platform components.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer contains the directory path in the container where `keystore.jks`, `truststore.jks`, `jksPassword.txt` keys are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword specifies the secret name that contains the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the secret name that contains the certificates. More info about certificates key/value format: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sourceCluster": {
+          "description": "sourceCluster specifies the source Schema Registry cluster. Schema exporter will be set up in the source cluster. If this is not defined, controller will try to auto discover Schema Registry in the namespace of the schema exporter. If it cannot discover a Schema Registry cluster or more than one Schema Registry clusters are found, controller will return error. Schema exporter should be enabled in Schema Registry cluster CR with `spec.enableSchemaExporter`.",
+          "properties": {
+            "schemaRegistryClusterRef": {
+              "description": "schemaRegistryClusterRef references the CFK-managed Schema Registry cluster.",
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of the Confluent Platform component cluster.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace specifies the namespace where the Confluent Platform component cluster is running.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "schemaRegistryRest": {
+              "description": "schemaRegistryRest specifies the Schema Registry REST API configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the REST API authentication mechanism.",
+                  "properties": {
+                    "basic": {
+                      "description": "basic specifies the basic authentication settings for the REST API client.",
+                      "properties": {
+                        "debug": {
+                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                          "type": "boolean"
+                        },
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "restrictedRoles": {
+                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1,
+                          "type": "array"
+                        },
+                        "roles": {
+                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secretRef": {
+                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "bearer": {
+                      "description": "bearer specifies the bearer authentication settings for the REST API client.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the REST API authentication type. Valid options are `basic`, `bearer`, and `mtls`.",
+                      "enum": [
+                        "basic",
+                        "bearer",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "endpoint": {
+                  "description": "endpoint specifies where Confluent REST API is running.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                },
+                "kafkaClusterID": {
+                  "description": "kafkaClusterID specifies the id of Kafka cluster. It takes precedence over using the Kafka REST API to get the cluster id.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "tls specifies the custom TLS structure for the application resources, e.g. connector, topic, schema, of the Confluent Platform components.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer contains the directory path in the container where `keystore.jks`, `truststore.jks`, `jksPassword.txt` keys are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword specifies the secret name that contains the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the secret name that contains the certificates. More info about certificates key/value format: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "subjectRenameFormat": {
+          "description": "subjectRenameFormat specifies the rename format for the subjects exported to the destination. For example, if the value is `my-${subject}`, subjects at destination will become `my-firstSubject` where `firstSubject` is the original subject name.",
+          "type": "string"
+        },
+        "subjects": {
+          "description": "subjects specifies the list of subjects to be exported by schema exporter. The default value is `[\"*\"]`. This indicates all subjects in the default context.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the schema exporter.",
+      "properties": {
+        "appState": {
+          "default": "Unknown",
+          "description": "appState is the current state of the schema exporter application.",
+          "enum": [
+            "Unknown",
+            "Created",
+            "Failed",
+            "Deleted"
+          ],
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions are the latest available observations of the schema exporter's state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "contextName": {
+          "description": "contextName shows the name of the context in the destination Schema Registry cluster where the schemas will be exported.",
+          "type": "string"
+        },
+        "contextType": {
+          "description": "contextType is the contextType of the schema exporter.",
+          "type": "string"
+        },
+        "destinationSchemaRegistry": {
+          "description": "destinationSchemaRegistry shows the destination Schema Registry endpoint, authentication type and if it is using TLS.",
+          "properties": {
+            "authenticationType": {
+              "description": "authenticationType is the authentication method used for Schema Registry.",
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "endpoint is the Schema Registry REST endpoint.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls shows whether the Schema Registry is using TLS.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "exporterStatus": {
+          "description": "exporterStatus is the status of the schema exporter.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "sourceSchemaRegistry": {
+          "description": "sourceSchemaRegistry shows the source Schema Registry endpoint, authentication type and if it is using TLS.",
+          "properties": {
+            "authenticationType": {
+              "description": "authenticationType is the authentication method used for Schema Registry.",
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "endpoint is the Schema Registry REST endpoint.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls shows whether the Schema Registry is using TLS.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "state": {
+          "description": "state is the current state of the schema exporter.",
+          "type": "string"
+        },
+        "subjects": {
+          "description": "subjects is the list of subjects exported by the schema exporter.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/platform.confluent.io/schemaregistry_v1beta1.json
+++ b/platform.confluent.io/schemaregistry_v1beta1.json
@@ -1,0 +1,4107 @@
+{
+  "description": "SchemaRegistry is the schema for the Schema Registry API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the Schema Registry cluster.",
+      "properties": {
+        "authentication": {
+          "description": "authentication specifies the authentication configurations for the REST API endpoint.",
+          "properties": {
+            "basic": {
+              "description": "basic specifies the configuration for basic authentication.",
+              "properties": {
+                "debug": {
+                  "description": "debug enables the basic authentication debug logs for JaaS configuration.",
+                  "type": "boolean"
+                },
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "restrictedRoles": {
+                  "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "roles": {
+                  "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "secretRef": {
+                  "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the authentication scheme for the REST API server. Valid options are `basic` and `mtls`.",
+              "enum": [
+                "basic",
+                "mtls"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "authorization": {
+          "description": "authorization specifies the authorization configurations.",
+          "properties": {
+            "kafkaRestClassRef": {
+              "description": "kafkaRestClassRef references the KafkaRestClass which specifies the Kafka REST API connection configuration.",
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of the KafkaRestClass application resource.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace specifies the namespace of the KafkaRestClass.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the client-side authorization type. The valid option is `rbac`.",
+              "enum": [
+                "rbac"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "configOverrides": {
+          "description": "configOverrides specifies the configs to override the server, JVM, Log4j properties for the Schema Registry cluster. A change will roll the cluster.",
+          "properties": {
+            "jvm": {
+              "description": "jvm is a list of JVM configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "log4j": {
+              "description": "log4j is a list of Log4J configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "server": {
+              "description": "server is a list of server configuration supported by the Confluent Platform component. This will either add or update existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dependencies": {
+          "description": "dependencies specify the dependency configurations for the Schema Registry.",
+          "properties": {
+            "kafka": {
+              "description": "kafka specifies the Kafka dependency configuration.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication defines the authentication for the Kafka cluster.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "oauthbearer": {
+                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
+                      "enum": [
+                        "plain",
+                        "oauthbearer",
+                        "digest",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bootstrapEndpoint": {
+                  "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+                  "minLength": 1,
+                  "pattern": ".+:[0-9]+",
+                  "type": "string"
+                },
+                "discovery": {
+                  "description": "discovery specifies the capability to discover the Kafka cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name is the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls defines the client-side TLS setting for the Kafka cluster.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mds": {
+              "description": "mds specifies the MDS dependencies configurations.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the client side authentication configuration for the MDS.",
+                  "properties": {
+                    "bearer": {
+                      "description": "bearer specifies the bearer authentication settings.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the authentication method for the MDS. The valid option is `bearer`.",
+                      "enum": [
+                        "bearer"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bearer",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "endpoint": {
+                  "description": "endpoint specifies the MDS endpoint.",
+                  "minLength": 1,
+                  "pattern": "^https?://.*",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tokenKeyPair": {
+                  "description": "tokenKeyPair specifies the token keypair to configure the MDS.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret that contains the MDS token key pair.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "authentication",
+                "endpoint",
+                "tokenKeyPair"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "enableSchemaExporter": {
+          "description": "enableSchemaExporter enables schema exporter in the Schema Registry.",
+          "type": "boolean"
+        },
+        "externalAccess": {
+          "description": "externalAccess specifies the external access configuration.",
+          "properties": {
+            "loadBalancer": {
+              "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain is the domain name of the component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "loadBalancerSourceRanges": {
+                  "description": "loadBalancerSourceRanges specify the source ranges.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "port": {
+                  "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "prefix": {
+                  "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify the user-provided service port(s).",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodePort": {
+              "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "host": {
+                  "description": "host defines the host name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "nodePortOffset": {
+                  "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "host",
+                "nodePortOffset"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "route": {
+              "description": "route specifies the configuration to create a route service in OpenShift.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain specifies the domain name of the Confluent component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "prefix": {
+                  "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "wildcardPolicy": {
+                  "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                  "enum": [
+                    "Subdomain",
+                    "None"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+              "enum": [
+                "loadBalancer",
+                "nodePort",
+                "route"
+              ],
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "headlessService": {
+          "description": "headlessService specifies the configuration of the Kubernetes headless service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs. It specifies the annotations to be added to the CFK-created headless service. These annotations are merged with the injectAnnotations and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs. It specifies the labels to be added to the CFK-created headless service. These labels are merged with the injectLabels and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "publishNotReadyAddresses": {
+              "description": "publishNotReadyAddresses specifies the publishNotReadyAddresses field. For Kafka, this value must be true. The default value is true.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "image specifies the application and the init docker image configurations. A change to this setting will roll the cluster.",
+          "properties": {
+            "application": {
+              "description": "application is the Docker image name of the application. Specify `<Docker-registry FQDN>/<docker-repository-name>/<component-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "init": {
+              "description": "init is the init-container name. Specify `<Docker-registry FQDN>/<docker-repository-name>/<init-container-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "description": "pullPolicy is the policy for pulling images. Valid options are `Always`, `Never`, and `IfNotPresent`. The default value is `IfNotPresent`.",
+              "enum": [
+                "Always",
+                "Never",
+                "IfNotPresent"
+              ],
+              "type": "string"
+            },
+            "pullSecretRef": {
+              "description": "pullSecretRef references the secrets in the same namespace to be used for pulling images. Image pull secrets are distinct from secrets because secrets can be mounted in the pod, but image pull secrets are only accessed by `kubelet`. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "application",
+            "init"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "injectAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectAnnotations are the annotations injected to the internal resources that CFK created. The internal annotations are preserved and cannot be overridden. For pod annotations, use `podTemplate.annotations`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "injectLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectLabels are the labels injected to the internal resources that CFK created. The internal labels are preserved and cannot be overridden. For pod labels, use `podTemplate.labels`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "internalTopicReplicatorFactor": {
+          "description": "internalTopicReplicatorFactor specifies the replication factor for internal topics.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "k8sClusterDomain": {
+          "description": "k8sClusterDomain specifies the configuration of the Kubernetes cluster domain. The default is the `cluster.local` domain.",
+          "type": "string"
+        },
+        "license": {
+          "description": "license specifies the license configuration for the Confluent Platform component.",
+          "properties": {
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where the license key is mounted. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "minLength": 1,
+              "type": "string"
+            },
+            "globalLicense": {
+              "description": "globalLicense specifies whether the Confluent Platform component shares the common global license.",
+              "type": "boolean"
+            },
+            "secretRef": {
+              "description": "secretRef references the secret that provides the license for the Confluent Platform component. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metrics": {
+          "description": "metrics specify the security settings for the metric services.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication configuration for the metrics.",
+              "properties": {
+                "type": {
+                  "description": "type specifies the metrics authentication method. The valid option is `mtls`.",
+                  "enum": [
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prometheus": {
+              "description": "prometheus specifies the configuration overrides for the JMX-Prometheus exporter.",
+              "properties": {
+                "blacklist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "rules": {
+                  "items": {
+                    "description": "Rule defines the Prometheus Exporter rule override.",
+                    "properties": {
+                      "attrNameSnakeCase": {
+                        "type": "boolean"
+                      },
+                      "cache": {
+                        "type": "boolean"
+                      },
+                      "help": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "granular"
+                      },
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "type": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "valueFactor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": 1,
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "whitelist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "tls specifies the TLS configuration for the metrics.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "ignoreTrustStoreConfig": {
+                  "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "jksPassword": {
+                  "description": "jksPassword references the secret containing the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mountedSecrets": {
+          "description": "mountedSecrets list the secrets injected to the underlying statefulset configuration. The secret reference is mounted in the default path `/mnt/secrets/<secret-name>`. The underlying resources will follow the secret as a file configuration. More info: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod. A change to this setting will roll the cluster.",
+          "items": {
+            "description": "MountedSecrets provides a way to inject a custom secret to the underlying statefulset.",
+            "properties": {
+              "keyItems": {
+                "description": "keyItems are key and path names.",
+                "items": {
+                  "description": "Maps a string key to a path within a volume.",
+                  "properties": {
+                    "key": {
+                      "description": "The key to project.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "path": {
+                      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "path"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "secretRef": {
+                "description": "secretRef references the name of the secret.",
+                "maxLength": 30,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "secretRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mountedVolumes": {
+          "description": "mountedVolumes list the custom volumes that need to be mounted into the underlying statefulset. A change to this setting will roll the cluster.",
+          "properties": {
+            "volumeMounts": {
+              "description": "volumeMounts specify the list of volume mounts for the pods in the statefulset.",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                    "type": "boolean"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "volumes specify the list of volumes that can be mounted into the pods of statefulset.",
+              "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureDisk": {
+                    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "cachingMode": {
+                        "description": "Host Caching mode: None, Read Only, Read Write.",
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "description": "The Name of the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "description": "The URI the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureFile": {
+                    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "the name of secret that contains Azure Storage Account Name and Key",
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "description": "Share Name",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cephfs": {
+                    "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "monitors": {
+                        "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cinder": {
+                    "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeID": {
+                        "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "configMap": {
+                    "description": "ConfigMap represents a configMap that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its keys must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "csi": {
+                    "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "readOnly": {
+                        "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "downwardAPI": {
+                    "description": "DownwardAPI represents downward API about the pod that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "Items is a list of downward API volume file",
+                        "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                          "properties": {
+                            "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "emptyDir": {
+                    "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "properties": {
+                      "medium": {
+                        "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ephemeral": {
+                    "description": "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                            "properties": {
+                              "accessModes": {
+                                "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dataSource": {
+                                "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "description": "Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "description": "Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "description": "A label query over volumes to consider for binding.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fc": {
+                    "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "Optional: FC target lun number",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "description": "Optional: FC target worldwide names (WWNs)",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "wwids": {
+                        "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flexVolume": {
+                    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the driver to use for this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Optional: Extra command options if any.",
+                        "type": "object"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flocker": {
+                    "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                    "properties": {
+                      "datasetName": {
+                        "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcePersistentDisk": {
+                    "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "pdName": {
+                        "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "pdName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitRepo": {
+                    "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                    "properties": {
+                      "directory": {
+                        "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "Repository URL",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "Commit hash for the specified revision.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repository"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "glusterfs": {
+                    "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                    "properties": {
+                      "endpoints": {
+                        "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostPath": {
+                    "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                    "properties": {
+                      "path": {
+                        "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "iscsi": {
+                    "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "description": "whether support iSCSI Discovery CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "description": "whether support iSCSI Session CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "description": "Target iSCSI Qualified Name.",
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "iSCSI Target Lun number.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "portals": {
+                        "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "CHAP Secret for iSCSI target and initiator authentication",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "targetPortal": {
+                        "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "properties": {
+                      "path": {
+                        "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "properties": {
+                      "claimName": {
+                        "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "claimName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "photonPersistentDisk": {
+                    "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "description": "ID that identifies Photon Controller persistent disk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pdID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "portworxVolume": {
+                    "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "VolumeID uniquely identifies a Portworx volume",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "projected": {
+                    "description": "Items for all in one resources secrets, configmaps, and downward API",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "sources": {
+                        "description": "list of volume projections",
+                        "items": {
+                          "description": "Projection that may be projected along with other supported volume types",
+                          "properties": {
+                            "configMap": {
+                              "description": "information about the configMap data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                              "description": "information about the downwardAPI data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secret": {
+                              "description": "information about the secret data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountToken": {
+                              "description": "information about the serviceAccountToken data to project",
+                              "properties": {
+                                "audience": {
+                                  "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "quobyte": {
+                    "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "group": {
+                        "description": "Group to map volume access to Default is no group",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User to map volume access to Defaults to serivceaccount user",
+                        "type": "string"
+                      },
+                      "volume": {
+                        "description": "Volume is a string that references an already created Quobyte volume by name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbd": {
+                    "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "image": {
+                        "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "pool": {
+                        "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scaleIO": {
+                    "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "description": "The host address of the ScaleIO API Gateway.",
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "sslEnabled": {
+                        "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                        "type": "string"
+                      },
+                      "system": {
+                        "description": "The name of the storage system as configured in ScaleIO.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its keys must be defined",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageos": {
+                    "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeName": {
+                        "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "vsphereVolume": {
+                    "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "description": "Storage Policy Based Management (SPBM) profile name.",
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "description": "Path that identifies vSphere volume vmdk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumePath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "volumeMounts",
+            "volumes"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oneReplicaPerNode": {
+          "description": "oneReplicaPerNode controls whether to run 1 pod per node using the pod anti-affinity capability. Enabling this configuration in an existing cluster will roll the cluster.",
+          "type": "boolean"
+        },
+        "passwordEncoder": {
+          "description": "passwordEncoder specifies password encoder secret for Schema Registry.",
+          "properties": {
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer contains the directory path in the container where the required secret is mounted. Directory should have the file `password-encoder.txt`. The contents should include a new password. Old password is optional and required only for rotation. More info: https://docs.confluent.io/operator/current/co-password-encoder-secret.",
+              "type": "string"
+            },
+            "secretRef": {
+              "description": "secretRef specifies the secret name. The secret should have the key `password-encoder.txt`. The contents should include a new password. Old password is optional and required only for rotation. More info: https://docs.confluent.io/operator/current/co-password-encoder-secret.",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "podTemplate": {
+          "description": "podTemplate specifies the statefulset pod template configuration.",
+          "properties": {
+            "affinity": {
+              "description": "affinity specifies a group of affinity scheduling rules. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.",
+              "properties": {
+                "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                        "properties": {
+                          "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs stored with the resource and may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "envVars": {
+              "description": "envVars contain environment variables to be injected into containers. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs that can be used to organize and categorize (scope and select) objects. More info: http://kubernetes.io/docs/user-guide/labels.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "podSecurityContext": {
+              "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+              "properties": {
+                "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
+                    "properties": {
+                      "name": {
+                        "description": "Name of a property to set",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of a property to set",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "priorityClassName": {
+              "description": "priorityClassName specifies the priority class for the pod (if any).",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "probe": {
+              "description": "probe contains the fields for standard Kubernetes readiness/liveness probe configuration.",
+              "properties": {
+                "liveness": {
+                  "description": "liveness configures the Kubernetes probe settings. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "readiness": {
+                  "description": "readiness configures the Kubernetes probe setting. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "resources": {
+              "description": "resources describe the compute resource requirements.",
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityContext": {
+              "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "description": "ServiceAccountName is the name of the service account used to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account.",
+              "type": "string"
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "terminationGracePeriodSeconds is the grace period before the pod is deleted.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "tolerations": {
+              "description": "tolerations specify the pods to schedule onto the nodes with matching taints, using the triple `<key,value,effect>` and the matching operator `<operator>`.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "topologySpreadConstraints describe how a group of pods ought to spread across topology domains. Scheduler will schedule pods based on the constraints. All topologySpreadConstraints are ANDed.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas. A change to this setting will roll the cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "telemetry": {
+          "description": "telemetry specifies the Confluent telemetry reporter configuration.",
+          "properties": {
+            "global": {
+              "description": "global allows disabling telemetry configuration. If CFK is deployed with telemetry, this field is only used to disable telemetry. The default value is `true` if telemetry is enabled at the global level.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tls": {
+          "description": "tls specifies the TLS configurations for the REST API endpoint.",
+          "properties": {
+            "autoGeneratedCerts": {
+              "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
+              "type": "boolean"
+            },
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "ignoreTrustStoreConfig": {
+              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+              "type": "boolean"
+            },
+            "jksPassword": {
+              "description": "jksPassword references the secret containing the JKS password.",
+              "properties": {
+                "secretRef": {
+                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "image",
+        "replicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the Schema Registry cluster.",
+      "properties": {
+        "arbitraryData": {
+          "description": "arbitraryData is the map for any arbitrary data associated with this Confluent component.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "authorizationType": {
+          "description": "authorizationType is the authorization type for this Confluent component.",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "clusterName is the name of the Confluent Platform component cluster.",
+          "type": "string"
+        },
+        "clusterNamespace": {
+          "description": "clusterNamespace is the namespace where the Confluent Platform component cluster is running.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions specify the latest available observations of the current state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of currently running replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "groupId": {
+          "description": "groupId is the group id of the Schema Registry cluster.",
+          "type": "string"
+        },
+        "internalSecrets": {
+          "description": "internalSecrets are internal secrets created by CFK for this Confluent component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "internalTopicNames": {
+          "description": "internalTopicNames are the topics used by the component for internal use.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kafka": {
+          "description": "kafka is the Kafka client side status for the Schema Registry cluster.",
+          "properties": {
+            "authenticationType": {
+              "description": "authenticationType describes the authentication method for the Kafka cluster.",
+              "type": "string"
+            },
+            "bootstrapEndpoint": {
+              "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls indicates whether TLS is enabled for the Kafka dependency.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metricPrefix": {
+          "description": "metricPrefix is the prefix for the JMX metric of the Schema Registry cluster.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "description": "operatorVersion is the internal version of CFK.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "phase describes the state of the Confluent Platform component. This can either be 'PROVISIONING' or 'RUNNING' 'PROVISIONING' means the Confluent Platform component is currently getting deployed and not ready yet. 'RUNNING' means the Confluent Platform component has been successfully deployed.",
+          "type": "string"
+        },
+        "rbac": {
+          "description": "rbac contains the RBAC-related status when RBAC is enabled.",
+          "properties": {
+            "clusterID": {
+              "description": "clusterID specifies the id of the cluster.",
+              "type": "string"
+            },
+            "internalRolebindings": {
+              "description": "internalRolebindings specifies the internal rolebindings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of currently ready replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "restConfig": {
+          "description": "restConfig is the REST API configuration of the Schema Registry cluster.",
+          "properties": {
+            "advertisedExternalEndpoints": {
+              "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "authenticationType": {
+              "description": "authenticationType shows the authentication type configured by the listener.",
+              "type": "string"
+            },
+            "externalAccessType": {
+              "description": "externalAccessType shows the external access type used for the listener.",
+              "type": "string"
+            },
+            "externalEndpoint": {
+              "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "internalEndpoint": {
+              "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls shows whether TLS is configured for the listener.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "selector gets the label selector of the child pod. The Horizontal Pod Autoscaler(HPA) will scale using the label selector of the child pod.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/platform.confluent.io/zookeeper_v1beta1.json
+++ b/platform.confluent.io/zookeeper_v1beta1.json
@@ -1,0 +1,3383 @@
+{
+  "description": "Zookeeper is the schema for the Zookeeper API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of the Zookeeper cluster.",
+      "properties": {
+        "authentication": {
+          "description": "authentication specifies the authentication configuration.",
+          "properties": {
+            "jaasConfig": {
+              "description": "jaasConfig specifies the JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+              "properties": {
+                "secretRef": {
+                  "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jaasConfigPassThrough": {
+              "description": "jaasConfigPassThrough specifies another way to provide JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "principalMappingRules": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "description": "type specifies the Kafka or Zookeeper authentication type. Valid options are `plain`, `digest`, `mtls`, and `ldap`.",
+              "enum": [
+                "plain",
+                "digest",
+                "mtls",
+                "ldap"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "configOverrides": {
+          "description": "configOverrides specifies configs to override the server/JVM/log4j/peer properties for the Zookeeper cluster. A change to this property will roll the cluster.",
+          "properties": {
+            "jvm": {
+              "description": "jvm is a list of JVM configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "log4j": {
+              "description": "log4j is a list of Log4J configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "peers": {
+              "description": "peers specify a list of dynamic peer configurations for the Zookeeper cluster. This is only required when deploying stretch Zookeeper for MRC deployments and should include all the Zookeeper peers in other DCs that form the ensemble. This will either add or update the existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "server": {
+              "description": "server is a list of server configuration supported by the Confluent Platform component. This will either add or update existing configuration.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dataVolumeCapacity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "dataVolumeCapacity specifies the data volume size.",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
+        "headlessService": {
+          "description": "headlessService specifies the configuration of the Kubernetes headless service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs. It specifies the annotations to be added to the CFK-created headless service. These annotations are merged with the injectAnnotations and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs. It specifies the labels to be added to the CFK-created headless service. These labels are merged with the injectLabels and take precedence.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "publishNotReadyAddresses": {
+              "description": "publishNotReadyAddresses specifies the publishNotReadyAddresses field. For Kafka, this value must be true. The default value is true.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "description": "image specifies the application and the init docker image configurations. A change to this setting will roll the cluster.",
+          "properties": {
+            "application": {
+              "description": "application is the Docker image name of the application. Specify `<Docker-registry FQDN>/<docker-repository-name>/<component-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "init": {
+              "description": "init is the init-container name. Specify `<Docker-registry FQDN>/<docker-repository-name>/<init-container-image-name>:<tag>`.",
+              "pattern": ".+:.+",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "description": "pullPolicy is the policy for pulling images. Valid options are `Always`, `Never`, and `IfNotPresent`. The default value is `IfNotPresent`.",
+              "enum": [
+                "Always",
+                "Never",
+                "IfNotPresent"
+              ],
+              "type": "string"
+            },
+            "pullSecretRef": {
+              "description": "pullSecretRef references the secrets in the same namespace to be used for pulling images. Image pull secrets are distinct from secrets because secrets can be mounted in the pod, but image pull secrets are only accessed by `kubelet`. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "application",
+            "init"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "injectAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectAnnotations are the annotations injected to the internal resources that CFK created. The internal annotations are preserved and cannot be overridden. For pod annotations, use `podTemplate.annotations`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "injectLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "injectLabels are the labels injected to the internal resources that CFK created. The internal labels are preserved and cannot be overridden. For pod labels, use `podTemplate.labels`.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "k8sClusterDomain": {
+          "description": "k8sClusterDomain specifies the configuration of the Kubernetes cluster domain. The default is the `cluster.local` domain.",
+          "type": "string"
+        },
+        "license": {
+          "description": "license specifies the license configuration for the Confluent Platform component.",
+          "properties": {
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where the license key is mounted. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "minLength": 1,
+              "type": "string"
+            },
+            "globalLicense": {
+              "description": "globalLicense specifies whether the Confluent Platform component shares the common global license.",
+              "type": "boolean"
+            },
+            "secretRef": {
+              "description": "secretRef references the secret that provides the license for the Confluent Platform component. More info: https://docs.confluent.io/operator/current/co-license.html#update-component-level-licenses",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logVolumeCapacity": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "logVolumeCapacity specifies the log volume size.",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
+        "metrics": {
+          "description": "metrics specify the security settings for the metric services.",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the authentication configuration for the metrics.",
+              "properties": {
+                "type": {
+                  "description": "type specifies the metrics authentication method. The valid option is `mtls`.",
+                  "enum": [
+                    "mtls"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "prometheus": {
+              "description": "prometheus specifies the configuration overrides for the JMX-Prometheus exporter.",
+              "properties": {
+                "blacklist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "rules": {
+                  "items": {
+                    "description": "Rule defines the Prometheus Exporter rule override.",
+                    "properties": {
+                      "attrNameSnakeCase": {
+                        "type": "boolean"
+                      },
+                      "cache": {
+                        "type": "boolean"
+                      },
+                      "help": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "granular"
+                      },
+                      "name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "type": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "value": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "valueFactor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": 1,
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "whitelist": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "tls specifies the TLS configuration for the metrics.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "ignoreTrustStoreConfig": {
+                  "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "jksPassword": {
+                  "description": "jksPassword references the secret containing the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mountedSecrets": {
+          "description": "mountedSecrets list the secrets injected to the underlying statefulset configuration. The secret reference is mounted in the default path `/mnt/secrets/<secret-name>`. The underlying resources will follow the secret as a file configuration. More info: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod. A change to this setting will roll the cluster.",
+          "items": {
+            "description": "MountedSecrets provides a way to inject a custom secret to the underlying statefulset.",
+            "properties": {
+              "keyItems": {
+                "description": "keyItems are key and path names.",
+                "items": {
+                  "description": "Maps a string key to a path within a volume.",
+                  "properties": {
+                    "key": {
+                      "description": "The key to project.",
+                      "type": "string"
+                    },
+                    "mode": {
+                      "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "path": {
+                      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "path"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "secretRef": {
+                "description": "secretRef references the name of the secret.",
+                "maxLength": 30,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "secretRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mountedVolumes": {
+          "description": "mountedVolumes list the custom volumes that need to be mounted into the underlying statefulset. A change to this setting will roll the cluster.",
+          "properties": {
+            "volumeMounts": {
+              "description": "volumeMounts specify the list of volume mounts for the pods in the statefulset.",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                    "type": "boolean"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "volumes": {
+              "description": "volumes specify the list of volumes that can be mounted into the pods of statefulset.",
+              "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureDisk": {
+                    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "cachingMode": {
+                        "description": "Host Caching mode: None, Read Only, Read Write.",
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "description": "The Name of the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "description": "The URI the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureFile": {
+                    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                    "properties": {
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "the name of secret that contains Azure Storage Account Name and Key",
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "description": "Share Name",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cephfs": {
+                    "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "monitors": {
+                        "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cinder": {
+                    "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: points to a secret object containing parameters used to connect to OpenStack.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeID": {
+                        "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "configMap": {
+                    "description": "ConfigMap represents a configMap that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its keys must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "csi": {
+                    "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "readOnly": {
+                        "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "downwardAPI": {
+                    "description": "DownwardAPI represents downward API about the pod that should populate this volume",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "Items is a list of downward API volume file",
+                        "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                          "properties": {
+                            "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "emptyDir": {
+                    "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "properties": {
+                      "medium": {
+                        "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ephemeral": {
+                    "description": "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                            "properties": {
+                              "accessModes": {
+                                "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dataSource": {
+                                "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "description": "Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "description": "Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "description": "A label query over volumes to consider for binding.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fc": {
+                    "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "Optional: FC target lun number",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "description": "Optional: FC target worldwide names (WWNs)",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "wwids": {
+                        "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flexVolume": {
+                    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                    "properties": {
+                      "driver": {
+                        "description": "Driver is the name of the driver to use for this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Optional: Extra command options if any.",
+                        "type": "object"
+                      },
+                      "readOnly": {
+                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flocker": {
+                    "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                    "properties": {
+                      "datasetName": {
+                        "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcePersistentDisk": {
+                    "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "pdName": {
+                        "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "pdName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitRepo": {
+                    "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                    "properties": {
+                      "directory": {
+                        "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "Repository URL",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "Commit hash for the specified revision.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repository"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "glusterfs": {
+                    "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                    "properties": {
+                      "endpoints": {
+                        "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostPath": {
+                    "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                    "properties": {
+                      "path": {
+                        "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "iscsi": {
+                    "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "description": "whether support iSCSI Discovery CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "description": "whether support iSCSI Session CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "description": "Target iSCSI Qualified Name.",
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "iSCSI Target Lun number.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "portals": {
+                        "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "CHAP Secret for iSCSI target and initiator authentication",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "targetPortal": {
+                        "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "properties": {
+                      "path": {
+                        "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "properties": {
+                      "claimName": {
+                        "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "claimName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "photonPersistentDisk": {
+                    "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "description": "ID that identifies Photon Controller persistent disk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pdID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "portworxVolume": {
+                    "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "VolumeID uniquely identifies a Portworx volume",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "projected": {
+                    "description": "Items for all in one resources secrets, configmaps, and downward API",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "sources": {
+                        "description": "list of volume projections",
+                        "items": {
+                          "description": "Projection that may be projected along with other supported volume types",
+                          "properties": {
+                            "configMap": {
+                              "description": "information about the configMap data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                              "description": "information about the downwardAPI data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secret": {
+                              "description": "information about the secret data to project",
+                              "properties": {
+                                "items": {
+                                  "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountToken": {
+                              "description": "information about the serviceAccountToken data to project",
+                              "properties": {
+                                "audience": {
+                                  "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "quobyte": {
+                    "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                    "properties": {
+                      "group": {
+                        "description": "Group to map volume access to Default is no group",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User to map volume access to Defaults to serivceaccount user",
+                        "type": "string"
+                      },
+                      "volume": {
+                        "description": "Volume is a string that references an already created Quobyte volume by name.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbd": {
+                    "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                        "type": "string"
+                      },
+                      "image": {
+                        "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "pool": {
+                        "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scaleIO": {
+                    "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "description": "The host address of the ScaleIO API Gateway.",
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "sslEnabled": {
+                        "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                        "type": "string"
+                      },
+                      "system": {
+                        "description": "The name of the storage system as configured in ScaleIO.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secret": {
+                    "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its keys must be defined",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageos": {
+                    "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeName": {
+                        "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "vsphereVolume": {
+                    "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                    "properties": {
+                      "fsType": {
+                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "description": "Storage Policy Based Management (SPBM) profile name.",
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "description": "Path that identifies vSphere volume vmdk",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumePath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "volumeMounts",
+            "volumes"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oneReplicaPerNode": {
+          "description": "oneReplicaPerNode controls whether to run 1 pod per node using the pod anti-affinity capability. Enabling this configuration in an existing cluster will roll the cluster.",
+          "type": "boolean"
+        },
+        "podTemplate": {
+          "description": "podTemplate specifies the statefulset pod template configuration.",
+          "properties": {
+            "affinity": {
+              "description": "affinity specifies a group of affinity scheduling rules. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.",
+              "properties": {
+                "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                        "properties": {
+                          "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations is a map of string key and value pairs stored with the resource and may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "envVars": {
+              "description": "envVars contain environment variables to be injected into containers. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container.",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "labels is a map of string key and value pairs that can be used to organize and categorize (scope and select) objects. More info: http://kubernetes.io/docs/user-guide/labels.",
+              "type": "object",
+              "x-kubernetes-map-type": "granular"
+            },
+            "podSecurityContext": {
+              "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+              "properties": {
+                "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
+                    "properties": {
+                      "name": {
+                        "description": "Name of a property to set",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of a property to set",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "priorityClassName": {
+              "description": "priorityClassName specifies the priority class for the pod (if any).",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            },
+            "probe": {
+              "description": "probe contains the fields for standard Kubernetes readiness/liveness probe configuration.",
+              "properties": {
+                "liveness": {
+                  "description": "liveness configures the Kubernetes probe settings. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "readiness": {
+                  "description": "readiness configures the Kubernetes probe setting. The changes will override the existing default configuration.",
+                  "properties": {
+                    "failureThreshold": {
+                      "description": "failureThreshold is the minimum consecutive failures for the probe to be considered failed. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "initialDelaySeconds": {
+                      "description": "initialDelaySeconds is the number of seconds after the container has started and before probes are initiated. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "periodSeconds specifies how often to perform the probe. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed. The default values is `1`. Must be `1` for liveness and startup. The minimum value is `1`.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "timeoutSeconds is the number of seconds after which the probe times out. Confluent Platform components come with the right configuration, and this setting is not required to change most of the time.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "resources": {
+              "description": "resources describe the compute resource requirements.",
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityContext": {
+              "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountName": {
+              "description": "ServiceAccountName is the name of the service account used to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account.",
+              "type": "string"
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "terminationGracePeriodSeconds is the grace period before the pod is deleted.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "tolerations": {
+              "description": "tolerations specify the pods to schedule onto the nodes with matching taints, using the triple `<key,value,effect>` and the matching operator `<operator>`.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "description": "topologySpreadConstraints describe how a group of pods ought to spread across topology domains. Scheduler will schedule pods based on the constraints. All topologySpreadConstraints are ANDed.",
+              "items": {
+                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                "properties": {
+                  "labelSelector": {
+                    "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "maxSkew": {
+                    "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "topologyKey": {
+                    "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "replicas is the desired number of replicas. A change to this setting will roll the cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "storageClass": {
+          "description": "storageClass specifies the user-provided storage class. If not configured, the default storage class is used.",
+          "properties": {
+            "name": {
+              "description": "name is the storage class name.",
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tls": {
+          "description": "tls specifies the TLS configuration.",
+          "properties": {
+            "autoGeneratedCerts": {
+              "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
+              "type": "boolean"
+            },
+            "directoryPathInContainer": {
+              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "ignoreTrustStoreConfig": {
+              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+              "type": "boolean"
+            },
+            "jksPassword": {
+              "description": "jksPassword references the secret containing the JKS password.",
+              "properties": {
+                "secretRef": {
+                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretRef"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+              "maxLength": 30,
+              "minLength": 1,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "dataVolumeCapacity",
+        "image",
+        "logVolumeCapacity",
+        "replicas"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status defines the observed state of the Zookeeper cluster.",
+      "properties": {
+        "arbitraryData": {
+          "description": "arbitraryData is the map for any arbitrary data associated with this Confluent component.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "authenticationType": {
+          "description": "authenticationType is the authentication method for the Zookeeper cluster.",
+          "type": "string"
+        },
+        "authorizationType": {
+          "description": "authorizationType is the authorization type for this Confluent component.",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "clusterName is the name of the Confluent Platform component cluster.",
+          "type": "string"
+        },
+        "clusterNamespace": {
+          "description": "clusterNamespace is the namespace where the Confluent Platform component cluster is running.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions specify the latest available observations of the current state.",
+          "items": {
+            "description": "Condition represent the latest available observations of the current state.",
+            "properties": {
+              "lastProbeTime": {
+                "description": "lastProbeTime shows the last time the condition was evaluated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastTransitionTime": {
+                "description": "lastTransitionTime shows the last time the condition was transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message shows a human-readable message with details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason shows the reason for the last transition of the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status shows the status of the condition, one of `True`, `False`, or `Unknown`.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type shows the condition type.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentReplicas": {
+          "description": "currentReplicas is the number of currently running replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "endpoint": {
+          "description": "endpoint is the Zookeeper cluster endpoint.",
+          "type": "string"
+        },
+        "internalSecrets": {
+          "description": "internalSecrets are internal secrets created by CFK for this Confluent component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "internalTopicNames": {
+          "description": "internalTopicNames are the topics used by the component for internal use.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "myIdOffset": {
+          "description": "myIdOffset shows the MyId offset configuration.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration is the most recent generation observed for this Confluent component.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "operatorVersion": {
+          "description": "operatorVersion is the internal version of CFK.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "phase describes the state of the Confluent Platform component. This can either be 'PROVISIONING' or 'RUNNING' 'PROVISIONING' means the Confluent Platform component is currently getting deployed and not ready yet. 'RUNNING' means the Confluent Platform component has been successfully deployed.",
+          "type": "string"
+        },
+        "readyReplicas": {
+          "description": "readyReplicas is the number of currently ready replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "replicas is the number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "selector gets the label selector of the child pod. The Horizontal Pod Autoscaler(HPA) will scale using the label selector of the child pod.",
+          "type": "string"
+        },
+        "tls": {
+          "description": "tls shows whether TLS is configured for the Zookeeper cluster.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
Schemas for [Confluent for Kubernetes](https://docs.confluent.io/operator/current). The CRDs were extracted from the [helm chart](https://packages.confluent.io/helm/confluent-for-kubernetes-0.581.55.tgz).