### PR TITLE
Add dapr schemas

### DIFF
--- a/dapr.io/component_v1alpha1.json
+++ b/dapr.io/component_v1alpha1.json
@@ -1,0 +1,96 @@
+{
+  "description": "Component describes an Dapr component type",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "auth": {
+      "description": "Auth represents authentication details for the component",
+      "properties": {
+        "secretStore": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "secretStore"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "scopes": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "spec": {
+      "description": "ComponentSpec is the spec for a component",
+      "properties": {
+        "ignoreErrors": {
+          "type": "boolean"
+        },
+        "initTimeout": {
+          "type": "string"
+        },
+        "metadata": {
+          "items": {
+            "description": "MetadataItem is a name/value pair for a metadata",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "secretKeyRef": {
+                "description": "SecretKeyRef is a reference to a secret holding the value for the metadata item. Name is the secret name, and key is the field in the secret.",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "value": {
+                "x-kubernetes-preserve-unknown-fields": true
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "metadata",
+        "type",
+        "version"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/dapr.io/configuration_v1alpha1.json
+++ b/dapr.io/configuration_v1alpha1.json
@@ -1,0 +1,421 @@
+{
+  "description": "Configuration describes an Dapr configuration setting.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ConfigurationSpec is the spec for an configuration.",
+      "properties": {
+        "accessControl": {
+          "description": "AccessControlSpec is the spec object in ConfigurationSpec.",
+          "properties": {
+            "defaultAction": {
+              "type": "string"
+            },
+            "policies": {
+              "items": {
+                "description": "AppPolicySpec defines the policy data structure for each app.",
+                "properties": {
+                  "appId": {
+                    "type": "string"
+                  },
+                  "defaultAction": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "operations": {
+                    "items": {
+                      "description": "AppOperationAction defines the data structure for each app operation.",
+                      "properties": {
+                        "action": {
+                          "type": "string"
+                        },
+                        "httpVerb": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "action",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "trustDomain": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "appId"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "trustDomain": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "api": {
+          "description": "APISpec describes the configuration for Dapr APIs.",
+          "properties": {
+            "allowed": {
+              "items": {
+                "description": "APIAccessRule describes an access rule for allowing a Dapr API to be enabled and accessible by an app.",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "protocol": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "version"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "appHttpPipeline": {
+          "description": "PipelineSpec defines the middleware pipeline.",
+          "properties": {
+            "handlers": {
+              "items": {
+                "description": "HandlerSpec defines a request handlers.",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "selector": {
+                    "description": "SelectorSpec selects target services to which the handler is to be applied.",
+                    "properties": {
+                      "fields": {
+                        "items": {
+                          "description": "SelectorField defines a selector fields.",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "fields"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "handlers"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "components": {
+          "description": "ComponentsSpec describes the configuration for Dapr components",
+          "properties": {
+            "deny": {
+              "description": "Denylist of component types that cannot be instantiated",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "features": {
+          "items": {
+            "description": "FeatureSpec defines the features that are enabled/disabled.",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "enabled",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "httpPipeline": {
+          "description": "PipelineSpec defines the middleware pipeline.",
+          "properties": {
+            "handlers": {
+              "items": {
+                "description": "HandlerSpec defines a request handlers.",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "selector": {
+                    "description": "SelectorSpec selects target services to which the handler is to be applied.",
+                    "properties": {
+                      "fields": {
+                        "items": {
+                          "description": "SelectorField defines a selector fields.",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "fields"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "handlers"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metric": {
+          "default": {
+            "enabled": true
+          },
+          "description": "MetricSpec defines metrics configuration.",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mtls": {
+          "description": "MTLSSpec defines mTLS configuration.",
+          "properties": {
+            "allowedClockSkew": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "workloadCertTTL": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nameResolution": {
+          "description": "NameResolutionSpec is the spec for name resolution configuration.",
+          "properties": {
+            "component": {
+              "type": "string"
+            },
+            "configuration": {
+              "description": "DynamicValue is a dynamic value struct for the component.metadata pair value.",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "component",
+            "configuration",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secrets": {
+          "description": "SecretsSpec is the spec for secrets configuration.",
+          "properties": {
+            "scopes": {
+              "items": {
+                "description": "SecretsScope defines the scope for secrets.",
+                "properties": {
+                  "allowedSecrets": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "defaultAccess": {
+                    "type": "string"
+                  },
+                  "deniedSecrets": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "storeName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "storeName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "scopes"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tracing": {
+          "description": "TracingSpec defines distributed tracing configuration.",
+          "properties": {
+            "otel": {
+              "description": "OtelSpec defines Otel exporter configurations.",
+              "properties": {
+                "endpointAddress": {
+                  "type": "string"
+                },
+                "isSecure": {
+                  "type": "boolean"
+                },
+                "protocol": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "endpointAddress",
+                "isSecure",
+                "protocol"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "samplingRate": {
+              "type": "string"
+            },
+            "stdout": {
+              "type": "boolean"
+            },
+            "zipkin": {
+              "description": "ZipkinSpec defines Zipkin trace configurations.",
+              "properties": {
+                "endpointAddress": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "endpointAddress"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "samplingRate"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/dapr.io/resiliency_v1alpha1.json
+++ b/dapr.io/resiliency_v1alpha1.json
@@ -1,0 +1,176 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "scopes": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "spec": {
+      "properties": {
+        "policies": {
+          "properties": {
+            "circuitBreakers": {
+              "additionalProperties": {
+                "properties": {
+                  "interval": {
+                    "type": "string"
+                  },
+                  "maxRequests": {
+                    "type": "integer"
+                  },
+                  "timeout": {
+                    "type": "string"
+                  },
+                  "trip": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "object"
+            },
+            "retries": {
+              "additionalProperties": {
+                "properties": {
+                  "duration": {
+                    "type": "string"
+                  },
+                  "maxInterval": {
+                    "type": "string"
+                  },
+                  "maxRetries": {
+                    "type": "integer"
+                  },
+                  "policy": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "object"
+            },
+            "timeouts": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targets": {
+          "properties": {
+            "actors": {
+              "additionalProperties": {
+                "properties": {
+                  "circuitBreaker": {
+                    "type": "string"
+                  },
+                  "circuitBreakerCacheSize": {
+                    "type": "integer"
+                  },
+                  "circuitBreakerScope": {
+                    "type": "string"
+                  },
+                  "retry": {
+                    "type": "string"
+                  },
+                  "timeout": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "object"
+            },
+            "apps": {
+              "additionalProperties": {
+                "properties": {
+                  "circuitBreaker": {
+                    "type": "string"
+                  },
+                  "circuitBreakerCacheSize": {
+                    "type": "integer"
+                  },
+                  "retry": {
+                    "type": "string"
+                  },
+                  "timeout": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "object"
+            },
+            "components": {
+              "additionalProperties": {
+                "properties": {
+                  "inbound": {
+                    "properties": {
+                      "circuitBreaker": {
+                        "type": "string"
+                      },
+                      "retry": {
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "outbound": {
+                    "properties": {
+                      "circuitBreaker": {
+                        "type": "string"
+                      },
+                      "retry": {
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "policies",
+        "targets"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/dapr.io/subscription_v1alpha1.json
+++ b/dapr.io/subscription_v1alpha1.json
@@ -1,0 +1,53 @@
+{
+  "description": "Subscription describes an pub/sub event subscription.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "scopes": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "spec": {
+      "description": "SubscriptionSpec is the spec for an event subscription.",
+      "properties": {
+        "deadLetterTopic": {
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "pubsubname": {
+          "type": "string"
+        },
+        "route": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "pubsubname",
+        "route",
+        "topic"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/dapr.io/subscription_v2alpha1.json
+++ b/dapr.io/subscription_v2alpha1.json
@@ -1,0 +1,87 @@
+{
+  "description": "Subscription describes an pub/sub event subscription.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "scopes": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "spec": {
+      "description": "SubscriptionSpec is the spec for an event subscription.",
+      "properties": {
+        "deadLetterTopic": {
+          "description": "The optional dead letter queue for this topic to send events to.",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The optional metadata to provide the subscription.",
+          "type": "object"
+        },
+        "pubsubname": {
+          "description": "The PubSub component name.",
+          "type": "string"
+        },
+        "routes": {
+          "description": "The Routes configuration for this topic.",
+          "properties": {
+            "default": {
+              "type": "string"
+            },
+            "rules": {
+              "description": "The list of rules for this topic.",
+              "items": {
+                "description": "Rule is used to specify the condition for sending a message to a specific path.",
+                "properties": {
+                  "match": {
+                    "description": "The optional CEL expression used to match the event. If the match is not specified, then the route is considered the default. The rules are tested in the order specified, so they should be define from most-to-least specific. The default route should appear last in the list.",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "The path for events that match this rule.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "match",
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "topic": {
+          "description": "The topic name to subscribe to.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pubsubname",
+        "routes",
+        "topic"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
When using Kubeconform the checks failed against dapr crd's. Using the CRD extractor from this repo I extracted them from my K8s cluster.

Upstream CRD's for reference: https://github.com/dapr/dapr/tree/master/charts/dapr/crds